### PR TITLE
fix: missing try block

### DIFF
--- a/src/app/api/us10y/route.ts
+++ b/src/app/api/us10y/route.ts
@@ -25,10 +25,12 @@ export async function GET() {
   const apiKey = process.env.FRED_API_KEY || process.env.NEXT_PUBLIC_FRED_API_KEY;
   if (!apiKey) {
     console.warn('FRED_API_KEY is not configured, using fallback data');
-    return NextResponse.json(FALLBACK_US10Y, { 
-      headers: corsHeaders 
+    return NextResponse.json(FALLBACK_US10Y, {
+      headers: corsHeaders
     });
   }
+
+  try {
 
     // Fetch current value
     const response = await fetch(


### PR DESCRIPTION
## Summary
- add missing try block to US10Y API route

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find module declarations)*
- `npm run build` *(fails: `next` not found)*