### PR TITLE
Add RSI indicator and trading signals

### DIFF
--- a/src/lib/indicators.ts
+++ b/src/lib/indicators.ts
@@ -9,3 +9,19 @@ export function simpleMovingAverage(data: number[], period: number): number {
   return sum / period
 }
 
+export function rsi(prices: number[], period = 14): number {
+  if (prices.length < period + 1) return 50
+  let gains = 0
+  let losses = 0
+
+  for (let i = prices.length - period; i < prices.length; i++) {
+    const diff = prices[i] - prices[i - 1]
+    if (diff > 0) gains += diff
+    else losses -= diff
+  }
+
+  if (losses === 0) return 100
+  const rs = gains / losses
+  return 100 - 100 / (1 + rs)
+}
+

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,6 +17,8 @@ export interface CoinData {
   ma50?: number;
   ma200?: number;
   maCrossover?: 'bullish' | 'bearish';
+  rsi14?: number;
+  signal?: 'buy' | 'sell' | 'hold';
 }
 
 export interface StockData {
@@ -29,6 +31,8 @@ export interface StockData {
   volume: number;
   lastUpdated?: string; // ISO string
   status: 'fresh' | 'cached_error' | 'error' | 'loading';
+  rsi14?: number;
+  signal?: 'buy' | 'sell' | 'hold';
 }
 
 export interface TrendingCoinItem {


### PR DESCRIPTION
## Summary
- implement `rsi` indicator function
- include RSI and simple buy/sell/hold signal in data types
- calculate RSI for BTC, SPY and SPX when fetching data
- display RSI and signal on dashboard cards

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing dependencies)*