### PR TITLE
Add EMA and volume profile metrics

### DIFF
--- a/src/lib/indicators.ts
+++ b/src/lib/indicators.ts
@@ -25,3 +25,39 @@ export function rsi(prices: number[], period = 14): number {
   return 100 - 100 / (1 + rs)
 }
 
+export function exponentialMovingAverage(data: number[], period: number): number {
+  if (data.length === 0) return 0
+  const slice = data.slice(-period)
+  const k = 2 / (period + 1)
+  let ema = slice[0]
+  for (let i = 1; i < slice.length; i++) {
+    ema = slice[i] * k + ema * (1 - k)
+  }
+  return ema
+}
+
+export function calculateVolumeProfile(
+  prices: number[],
+  volumes: number[],
+  bins = 10
+): Array<{ price: number; volume: number }> {
+  if (prices.length !== volumes.length) {
+    throw new Error('Price and volume arrays must be the same length')
+  }
+  if (prices.length === 0) return []
+  const minPrice = Math.min(...prices)
+  const maxPrice = Math.max(...prices)
+  const binSize = (maxPrice - minPrice) / bins
+  const buckets = Array.from({ length: bins }, () => 0)
+  for (let i = 0; i < prices.length; i++) {
+    const idx = Math.min(
+      bins - 1,
+      Math.floor((prices[i] - minPrice) / binSize)
+    )
+    buckets[idx] += volumes[i]
+  }
+  return buckets.map((volume, idx) => ({
+    price: minPrice + binSize * idx + binSize / 2,
+    volume,
+  }))
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,6 +17,10 @@ export interface CoinData {
   ma50?: number;
   ma200?: number;
   maCrossover?: 'bullish' | 'bearish';
+  ema20?: number;
+  ema50?: number;
+  ema200?: number;
+  volumeProfilePrice?: number;
   rsi14?: number;
   signal?: 'buy' | 'sell' | 'hold';
 }


### PR DESCRIPTION
## Summary
- extend indicator utilities with EMA and volume profile
- compute EMA and volume profile when fetching BTC market data
- expose new metrics in `CoinData` type and show them on the dashboard

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing dependencies)*