### PR TITLE
Add toggleable arbitrage alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ Personal dashboard for tracking Bitcoin and SPX/SPY price action and technical i
 3. Monitor technical indicators
 4. Use signals to inform trading decisions
 
+### Arbitrage Alerts
+
+1. Start the arbitrage polling service:
+   ```bash
+   npm run arbitrage-server
+   ```
+   The server listens on port 3001 by default.
+2. Set `NEXT_PUBLIC_ARBITRAGE_API` in your environment if the endpoint differs.
+   The dashboard defaults to `http://localhost:3001/api/arbitrage`.
+3. Toggle the "Arbitrage Opportunity" card to begin polling every 10 seconds.
+
 ### Macro Data Refresh Demo
 
 For a simple example that fetches macro data only when you click refresh, visit

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,8 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.54.2",
         "recharts": "^2.15.1",
+        "express": "^4.21.0",
+        "ccxt": "^4.1.89",
         "tailwind-merge": "^3.0.1",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.24.2"
@@ -55,6 +57,7 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "@types/express": "^4",
         "genkit-cli": "^1.8.0",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
@@ -3951,6 +3954,18 @@
       "devOptional": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-LBI5fnfK8BPVKx/aRXefxWWEXUvhYaL6VLdystD5nq2WEYLRh1SeDsICoZ6RiMIXja+6JGZveHFkNjEcNWefjQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/@types/request": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "arbitrage-server": "node server.js"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.8.0",
@@ -55,6 +56,8 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",
     "recharts": "^2.15.1",
+    "express": "^4.21.0",
+    "ccxt": "^4.1.89",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.24.2"
@@ -63,6 +66,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/express": "^4",
     "genkit-cli": "^1.8.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,72 @@
+const express = require('express');
+const ccxt = require('ccxt');
+const cors = require('cors');
+
+const app = express();
+const port = process.env.PORT || 3001;
+
+app.use(cors());
+
+const exchanges = {
+  binance: new ccxt.binance(),
+  coinbasepro: new ccxt.coinbasepro(),
+  kraken: new ccxt.kraken()
+};
+
+let bestArbitrage = null;
+const FEE = 50; // flat taker fee in USD per round trip
+const MIN_PROFIT = 50; // minimum net profit to report
+
+async function fetchPrices() {
+  const tickers = {};
+  for (const [name, ex] of Object.entries(exchanges)) {
+    try {
+      const ticker = await ex.fetchTicker('BTC/USDT');
+      tickers[name] = { bid: ticker.bid, ask: ticker.ask };
+    } catch (err) {
+      console.error(`Error fetching ${name}:`, err.message);
+    }
+  }
+  return tickers;
+}
+
+function computeArbitrage(tickers) {
+  const names = Object.keys(tickers);
+  let best = null;
+  for (const buy of names) {
+    for (const sell of names) {
+      if (buy === sell) continue;
+      const buyPrice = tickers[buy].ask;
+      const sellPrice = tickers[sell].bid;
+      const spread = sellPrice - buyPrice;
+      const netProfit = spread - FEE;
+      if (netProfit >= MIN_PROFIT && (!best || netProfit > best.netProfit)) {
+        best = { buy, sell, buyPrice, sellPrice, spread, netProfit };
+      }
+    }
+  }
+  bestArbitrage = best;
+}
+
+async function poll() {
+  const tickers = await fetchPrices();
+  if (Object.keys(tickers).length >= 2) {
+    computeArbitrage(tickers);
+  }
+}
+
+setInterval(poll, 10000);
+// initial call
+poll().catch(console.error);
+
+app.get('/api/arbitrage', (req, res) => {
+  if (bestArbitrage) {
+    res.json(bestArbitrage);
+  } else {
+    res.json({});
+  }
+});
+
+app.listen(port, () => {
+  console.log(`Arbitrage server listening on ${port}`);
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import type { AppData, CoinData, StockData, TrendingData, FearGreedData, MarketS
 import { marketSentimentAnalysis } from '@/ai/flows/market-sentiment-analysis';
 import { Bitcoin, Brain, Briefcase, Gauge, Shapes, TrendingUp, BarChart3, DollarSign, Landmark, BarChart2 } from 'lucide-react';
 import { CorrelationPanel } from '@/components/CorrelationPanel';
+import ArbAlertCard from '@/components/ArbAlertCard';
 import {
   simpleMovingAverage,
   rsi,
@@ -1384,10 +1385,10 @@ const CryptoDashboardPage: FC = () => {
             )}
           </DataCard>
 
-          <DataCard 
-            title="Top 7 Trending Coins" 
-            icon={TrendingUp} 
-            status={appData.trending?.length ? 'active' : ''} 
+          <DataCard
+            title="Top 7 Trending Coins"
+            icon={TrendingUp}
+            status={appData.trending?.length ? 'active' : ''}
             className="sm:col-span-1"
           >
             {!isClient ? (
@@ -1415,6 +1416,9 @@ const CryptoDashboardPage: FC = () => {
               <p className="text-center p-4">Trending coins data unavailable.</p>
             )}
           </DataCard>
+          <div className="sm:col-span-1">
+            <ArbAlertCard />
+          </div>
         </div>
 
         <footer className="text-center mt-8 py-4 border-t">

--- a/src/components/ArbAlertCard.tsx
+++ b/src/components/ArbAlertCard.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+
+interface Arbitrage {
+  buy: string;
+  sell: string;
+  buyPrice: number;
+  sellPrice: number;
+  spread: number;
+  netProfit: number;
+}
+
+export default function ArbAlertCard() {
+  const [arb, setArb] = useState<Arbitrage | null>(null);
+  const [enabled, setEnabled] = useState(false);
+  const API_URL = process.env.NEXT_PUBLIC_ARBITRAGE_API || 'http://localhost:3001/api/arbitrage';
+
+  useEffect(() => {
+    if (!enabled) return;
+    const fetchArb = async () => {
+      try {
+        const res = await fetch(API_URL);
+        if (!res.ok) return;
+        const data = await res.json();
+        if (data && data.buy) {
+          setArb(data);
+        } else {
+          setArb(null);
+        }
+      } catch (err) {
+        console.error('Failed to fetch arbitrage', err);
+      }
+    };
+    fetchArb();
+    const interval = setInterval(fetchArb, 10000);
+    return () => clearInterval(interval);
+  }, [enabled, API_URL]);
+
+  return (
+    <Card className="max-w-sm">
+      <CardHeader className="flex items-start justify-between">
+        <div>
+          <CardTitle>Arbitrage Opportunity</CardTitle>
+          {arb && (
+            <CardDescription>
+              Buy on {arb.buy}, sell on {arb.sell}
+            </CardDescription>
+          )}
+        </div>
+        <Switch
+          checked={enabled}
+          onCheckedChange={setEnabled}
+          className="data-[state=checked]:bg-green-600 data-[state=unchecked]:bg-red-600"
+        />
+      </CardHeader>
+      <CardContent className="space-y-1 text-sm">
+        {arb ? (
+          <>
+            <div className="flex justify-between">
+              <span>Buy Price</span>
+              <span>${arb.buyPrice.toFixed(2)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span>Sell Price</span>
+              <span>${arb.sellPrice.toFixed(2)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span>Spread</span>
+              <span>${arb.spread.toFixed(2)}</span>
+            </div>
+            <div className="flex justify-between font-semibold">
+              <span>Net Profit</span>
+              <span>${arb.netProfit.toFixed(2)}</span>
+            </div>
+          </>
+        ) : (
+          <p>No opportunity found.</p>
+        )}
+      </CardContent>
+      {arb && (
+        <CardFooter>
+          <Button asChild>
+            <a href="#">Go to Trade</a>
+          </Button>
+        </CardFooter>
+      )}
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- add npm script for arbitrage server
- document how to run arbitrage alerts
- poll exchanges every 10s in `server.js`
- enable polling toggle and env variable in `ArbAlertCard`
- mount the card in the dashboard
- include `@types/express` dev dependency

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails due to missing modules)*
