### PR TITLE
Add new agent roles

### DIFF
--- a/src/lib/agents/Backtester.ts
+++ b/src/lib/agents/Backtester.ts
@@ -1,0 +1,7 @@
+import { AgentMessage } from '@/types/agent';
+
+export class Backtester {
+  handle(_msg: AgentMessage): void {
+    // Backtesting logic would go here
+  }
+}

--- a/src/lib/agents/Orchestrator.ts
+++ b/src/lib/agents/Orchestrator.ts
@@ -8,7 +8,10 @@ export class Orchestrator {
     DataCollector: () => {},
     IndicatorEngine: () => {},
     SignalGenerator: () => {},
+    UIRenderer: () => {},
     AlertLogger: () => {},
+    Backtester: () => {},
+    QATester: () => {},
   };
 
   register(role: AgentRole, handler: Handler): void {

--- a/src/lib/agents/QATester.ts
+++ b/src/lib/agents/QATester.ts
@@ -1,0 +1,7 @@
+import { AgentMessage } from '@/types/agent';
+
+export class QATester {
+  handle(_msg: AgentMessage): void {
+    // QA testing logic would go here
+  }
+}

--- a/src/lib/agents/UIRenderer.ts
+++ b/src/lib/agents/UIRenderer.ts
@@ -1,0 +1,7 @@
+import { AgentMessage } from '@/types/agent';
+
+export class UIRenderer {
+  handle(_msg: AgentMessage): void {
+    // UI update logic would go here
+  }
+}

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -11,4 +11,7 @@ export type AgentRole =
   | 'DataCollector'
   | 'IndicatorEngine'
   | 'SignalGenerator'
-  | 'AlertLogger';
+  | 'UIRenderer'
+  | 'AlertLogger'
+  | 'Backtester'
+  | 'QATester';


### PR DESCRIPTION
## Summary
- expand `AgentRole` to include `UIRenderer`, `Backtester`, and `QATester`
- support new roles in `Orchestrator`
- add stubs for new agent classes

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test` *(fails: `jest` not found)*
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_b_6839f9ccc3748323aa78ef469716f6e5