### PR TITLE
Improve typing for agents and market chart

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -2,6 +2,17 @@
 
 > **Note:** Focused on essential trading features for Bitcoin and SPX/SPY
 
+## Top Priority Tasks
+- [ ] Integrate real-time DXY data from FRED API and cache for 15 minutes
+- [ ] Fetch 10-Year Treasury Yield (US10Y) from Treasury/FRED and update hourly
+- [ ] Display rolling 1-hour BTC vs SPX/SPY correlations, refresh every 5 minutes
+- [ ] Add 1-hour ATR widget with alert when ATR > 1.5× 20-day average
+- [ ] Create liquidity tab showing BTC funding rates and order book depth
+- [ ] Build signal matrix combining volatility, correlation and macro data
+- [ ] Backtest signal performance (win rate, profit factor) over 90 days
+- [ ] Forecast next 30-day BTC/SPX correlation trend with confidence interval
+- [ ] Implement EMA crossovers, Bollinger Bands, ATR and MACD indicators
+
 ## Core Trading Features
 
 ### 1. Price Data

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,6 +18,10 @@ import { DataCollector } from '@/lib/agents/DataCollector';
 import { IndicatorEngine } from '@/lib/agents/IndicatorEngine';
 import { SignalGenerator } from '@/lib/agents/SignalGenerator';
 import { AlertLogger } from '@/lib/agents/AlertLogger';
+import type { Candle } from '@/lib/data/binanceWs';
+import type { ComputedIndicators } from '@/lib/signals';
+import type { TradeSignal } from '@/types';
+import type { AgentMessage } from '@/types/agent';
 import {
   simpleMovingAverage,
   rsi,
@@ -111,9 +115,9 @@ const CryptoDashboardPage: FC = () => {
     const ie = new IndicatorEngine(bus);
     const sg = new SignalGenerator(bus);
     const al = new AlertLogger();
-    bus.register('IndicatorEngine', m => ie.handle(m as any));
-    bus.register('SignalGenerator', m => sg.handle(m as any));
-    bus.register('AlertLogger', m => al.handle(m as any));
+    bus.register('IndicatorEngine', m => ie.handle(m as AgentMessage<Candle>));
+    bus.register('SignalGenerator', m => sg.handle(m as AgentMessage<ComputedIndicators>));
+    bus.register('AlertLogger', m => al.handle(m as AgentMessage<TradeSignal>));
     bus.register('DataCollector', () => {});
     dc.start();
   }, []);

--- a/src/components/MarketChart.tsx
+++ b/src/components/MarketChart.tsx
@@ -9,7 +9,7 @@ interface Props {
 export default function MarketChart({ asset, interval }: Props) {
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    if (!(window as any).TradingView) {
+    if (!window.TradingView) {
       const script = document.createElement('script');
       script.src = 'https://s3.tradingview.com/tv.js';
       script.onload = () => init();
@@ -19,7 +19,6 @@ export default function MarketChart({ asset, interval }: Props) {
     }
 
     function init() {
-      // @ts-ignore
       new window.TradingView.widget({
         symbol: asset + 'USDT',
         interval: interval.replace('m', ''),

--- a/src/lib/agents/SignalGenerator.ts
+++ b/src/lib/agents/SignalGenerator.ts
@@ -1,15 +1,15 @@
 import { AgentMessage } from '@/types/agent';
 import type { TradeSignal } from '@/types';
-import { evaluateSignal } from '@/lib/signals';
+import { evaluateSignal, type ComputedIndicators } from '@/lib/signals';
 import { Orchestrator } from './Orchestrator';
 
 export class SignalGenerator {
-  private prev: any = null;
+  private prev: ComputedIndicators | null = null;
   private lastSignal = 0;
 
   constructor(private bus: Orchestrator) {}
 
-  handle(msg: AgentMessage<any>): void {
+  handle(msg: AgentMessage<ComputedIndicators>): void {
     if (msg.type !== 'INDICATORS_5M') return;
     const indicators = msg.payload;
     const signal = evaluateSignal(this.prev, indicators, indicators.close, indicators.volume, this.lastSignal);

--- a/src/scripts/backtest.ts
+++ b/src/scripts/backtest.ts
@@ -1,12 +1,12 @@
 import { fetchBackfill } from '@/lib/data/coingecko';
-import { computeIndicators, evaluateSignal } from '@/lib/signals';
+import { computeIndicators, evaluateSignal, type ComputedIndicators } from '@/lib/signals';
 import type { TradeSignal } from '@/types';
 
 async function run() {
   const candles = await fetchBackfill();
   const closes: number[] = [];
   const volumes: number[] = [];
-  let prev: any = null;
+  let prev: ComputedIndicators | null = null;
   let lastSignal = 0;
   const signals: TradeSignal[] = [];
   for (const c of candles) {

--- a/src/types/tradingview.d.ts
+++ b/src/types/tradingview.d.ts
@@ -1,0 +1,22 @@
+declare global {
+  interface TradingViewWidgetOptions {
+    symbol: string;
+    interval: string;
+    container_id: string;
+    width: string;
+    height: number;
+    studies: string[];
+    hide_top_toolbar: boolean;
+    hide_legend: boolean;
+  }
+
+  interface TradingView {
+    widget: new (options: TradingViewWidgetOptions) => void;
+  }
+
+  interface Window {
+    TradingView: TradingView;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- type `prev` and incoming messages in `SignalGenerator`
- enforce indicator typing in `backtest` script
- provide global `TradingView` typings
- drop `window as any` and ts-ignore in `MarketChart`
- register typed handlers in the main page without `as any`
- add top priority roadmap tasks

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find modules)*
- `npm run test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6839fbaadde4832398e46429572b3670