### PR TITLE
Implement FRED DXY fetch with caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ Personal dashboard for tracking Bitcoin and SPX/SPY price action and technical i
 ## Getting Started
 
 1. Clone the repository:
+
    ```bash
    git clone https://github.com/yourusername/bitdash-firestudio.git
    cd bitdash-firestudio
    ```
 
 2. Install dependencies:
+
    ```bash
    npm install
    ```
@@ -51,7 +53,8 @@ Personal dashboard for tracking Bitcoin and SPX/SPY price action and technical i
 For a simple example that fetches macro data only when you click refresh, visit
 `/refresh-demo` after starting the development server. This page displays the
 current US Dollar Index (DXY) and 10-Year Treasury Yield using the free FRED
-API through the project's API routes.
+API through the project's API routes. DXY data is cached for 15 minutes on the
+server to respect rate limits.
 
 ## Data Sources
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -3,7 +3,8 @@
 > **Note:** Focused on essential trading features for Bitcoin and SPX/SPY
 
 ## Top Priority Tasks
-- [ ] Integrate real-time DXY data from FRED API and cache for 15 minutes
+
+- [x] Integrate real-time DXY data from FRED API and cache for 15 minutes
 - [ ] Fetch 10-Year Treasury Yield (US10Y) from Treasury/FRED and update hourly
 - [ ] Display rolling 1-hour BTC vs SPX/SPY correlations, refresh every 5 minutes
 - [ ] Add 1-hour ATR widget with alert when ATR > 1.5× 20-day average
@@ -16,6 +17,7 @@
 ## Core Trading Features
 
 ### 1. Price Data
+
 - [x] BTC/USD price chart
 - [x] SPX/SPY price chart
 - [ ] Add 50/200 MA crossovers
@@ -24,36 +26,44 @@
 - [ ] Implement Ichimoku Cloud
 
 ### 2. Technical Indicators
+
 #### Trend Indicators
+
 - [ ] 20/50/200 EMA crossovers
 - [ ] Ichimoku Cloud components
 - [ ] Support/Resistance levels
 
 #### Momentum Indicators
+
 - [ ] RSI (14 period)
 - [ ] MACD (12,26,9)
 - [ ] Stochastic Oscillator
 
 #### Volatility Indicators
+
 - [ ] Bollinger Bands (20,2)
 - [ ] ATR (14) for position sizing
 
 ### 3. Volume & Liquidity
+
 - [ ] On-chain transaction count & volume (CoinGecko)
 - [ ] SPY average daily volume (Yahoo Finance)
 - [ ] Order book depth visualization (Binance/IEX)
 
 ### 4. Market Sentiment
+
 - [x] Crypto Fear & Greed Index
 - [ ] VIX index integration
 - [ ] Market breadth indicators
 
 ### 5. Correlation Analysis
+
 - [ ] BTC vs SPY/SPX correlation (1h, 1d)
 - [ ] Correlation heatmap
 - [ ] Decoupling alerts
 
 ### 6. Macro Indicators
+
 - [x] 10-Year Treasury Yield
 - [ ] Fed funds rate calendar
 - [ ] Economic calendar integration
@@ -61,6 +71,7 @@
 ## Development Tasks
 
 ### 1. Data Layer
+
 - [ ] Create data fetchers for each source:
   - [ ] CoinGecko (crypto data)
   - [ ] Yahoo Finance (stocks, VIX)
@@ -70,6 +81,7 @@
 - [ ] Add rate limiting (5 calls/min per endpoint)
 
 ### 2. Indicator Engine
+
 - [ ] Set up technical indicators library
 - [ ] Create indicator calculation utilities:
   - [ ] EMA/MA calculations
@@ -79,6 +91,7 @@
   - [ ] ATR calculation
 
 ### 3. Signal Generation
+
 - [ ] Define signal interface
 - [ ] Implement signal rules:
   - [ ] EMA crossovers
@@ -88,6 +101,7 @@
 - [ ] Create signal history logging
 
 ### 4. UI Components
+
 - [ ] Dashboard cards for:
   - [ ] Indicator status
   - [ ] Current signals
@@ -98,27 +112,32 @@
   - [ ] Timeframe selection
 
 ### 5. Alerting System
+
 - [ ] Toast notifications for signals
 - [ ] Signal history panel
 - [ ] Custom alert configuration
 
 ### 6. Configuration
+
 - [ ] Create config file for thresholds
 - [ ] Document all settings
 - [ ] Add UI for live adjustments
 
 ## Testing & Validation
+
 - [ ] Unit tests for indicators
 - [ ] Backtesting framework
 - [ ] Historical data validation
 - [ ] Performance testing
 
 ## Documentation
+
 - [ ] API documentation
 - [ ] User guide
 - [ ] Development setup guide
 
 ## Free APIs & Data Sources
+
 - **CoinGecko**: BTC metrics, on-chain data
 - **Binance**: Real-time BTC data
 - **Yahoo Finance**: SPY, ^GSPC, VIX, DXY
@@ -128,20 +147,24 @@
 - **TradingView**: Chart widgets
 
 ### 4. Data Management
+
 - [ ] Basic error handling
 - [ ] Simple caching (5 min)
 - [ ] Single data source per asset
 
 ## Current Focus
+
 - [ ] Implement RSI indicator
 - [ ] Add moving averages
 - [ ] Set up basic buy/sell signals
 
 ## Recent Updates
+
 - 2025-05-22: Initial dashboard with price charts
 - 2025-05-21: Set up basic project structure
 
 ### 3. End-to-End Testing
+
 - [ ] Complete trading signal workflow
 - [ ] Alert delivery and notifications
 - [ ] Data synchronization across components
@@ -150,6 +173,7 @@
 ## Deployment & Monitoring
 
 ### 1. Trading Infrastructure
+
 - [ ] Set up dedicated market data feeds
 - [ ] Implement rate limiting for API calls
 - [ ] Configure real-time data processing
@@ -157,6 +181,7 @@
 - [ ] Document trading hours and maintenance windows
 
 ### 2. Performance Monitoring
+
 - [ ] Monitor signal accuracy and performance
 - [ ] Track latency in data processing
 - [ ] Monitor alert delivery success rates
@@ -164,6 +189,7 @@
 - [ ] Monitor system resource usage during high volatility
 
 ## Commit Guidelines
+
 1. **Type**: Use conventional commit types (feat, fix, docs, etc.)
 2. **Scope**: Specify the area of changes (auth, ui, db, etc.)
 3. **Message**: Clear, concise description of changes
@@ -171,6 +197,7 @@
 5. **Footer**: Reference issues or breaking changes
 
 Example:
+
 ```
 feat(auth): add Google OAuth login
 

--- a/src/app/api/dxy/route.ts
+++ b/src/app/api/dxy/route.ts
@@ -1,90 +1,101 @@
-import { NextResponse } from 'next/server';
+import { NextResponse } from "next/server";
 
 // Fallback data in case API fails
 const FALLBACK_DXY = {
-  id: 'dxy',
-  name: 'US Dollar Index (DXY)',
-  symbol: 'DXY',
-  price: 104.50, // Example fallback value
-  change: 0.10,
-  changePercent: 0.10,
+  id: "dxy",
+  name: "US Dollar Index (DXY)",
+  symbol: "DXY",
+  price: 104.5, // Example fallback value
+  change: 0.1,
+  changePercent: 0.1,
   volume: 0,
   lastUpdated: new Date().toISOString(),
-  status: 'cached',
-  source: 'fallback'
+  status: "cached",
+  source: "fallback",
 };
 
 // CORS headers
 const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
 };
 
 // Helper function to fetch with retry
 async function fetchWithRetry(url: string, retries = 3, delay = 1000) {
   for (let i = 0; i < retries; i++) {
     try {
-      const response = await fetch(url, { next: { revalidate: 300 } });
+      const response = await fetch(url, { cache: "no-store" });
       if (response.ok) return response.json();
     } catch (error) {
       console.warn(`Attempt ${i + 1} failed:`, error);
     }
-    if (i < retries - 1) await new Promise(resolve => setTimeout(resolve, delay));
+    if (i < retries - 1)
+      await new Promise((resolve) => setTimeout(resolve, delay));
   }
   throw new Error(`Failed after ${retries} retries`);
 }
 
+interface CachedData {
+  payload: Record<string, any>;
+  timestamp: number;
+}
+
+const CACHE_DURATION = 15 * 60 * 1000; // 15 minutes
+let cache: CachedData | null = null;
+
 export async function GET() {
-  const apiKey = process.env.NEXT_PUBLIC_FMP_API_KEY;
-  
+  if (cache && Date.now() - cache.timestamp < CACHE_DURATION) {
+    return NextResponse.json(
+      { ...cache.payload, status: "cached" },
+      { headers: corsHeaders },
+    );
+  }
+
+  const apiKey = process.env.NEXT_PUBLIC_FRED_API_KEY;
+
   if (!apiKey) {
-    console.warn('FMP_API_KEY is not configured, using fallback data');
-    return NextResponse.json(FALLBACK_DXY, { 
-      headers: corsHeaders 
+    console.warn("FRED_API_KEY is not configured, using fallback data");
+    return NextResponse.json(FALLBACK_DXY, {
+      headers: corsHeaders,
     });
   }
 
   try {
-    // Fetch DXY data from Financial Modeling Prep
-    const response = await fetchWithRetry(
-      `https://financialmodelingprep.com/api/v3/quote/DX-Y.NYB?apikey=${apiKey}`
-    );
-    
-    if (!Array.isArray(response) || response.length === 0) {
-      console.warn('No DXY data returned from FMP API');
-      return NextResponse.json(FALLBACK_DXY, { headers: corsHeaders });
+    const url = `https://api.stlouisfed.org/fred/series/observations?series_id=DTWEXBGS&api_key=${apiKey}&file_type=json&limit=2&sort_order=desc`;
+    const data = await fetchWithRetry(url);
+    const obs = data?.observations;
+    const latest = parseFloat(obs?.[0]?.value);
+    const prev = obs?.[1] ? parseFloat(obs[1].value) : NaN;
+
+    if (isNaN(latest)) {
+      throw new Error("Invalid DXY data from FRED");
     }
-    
-    const dxyData = response[0];
-    const currentValue = dxyData.price;
-    const change = dxyData.change || 0;
-    const changePercent = dxyData.changesPercentage || 0;
-    
-    if (isNaN(currentValue)) {
-      console.warn('Invalid DXY data from FMP');
-      return NextResponse.json(FALLBACK_DXY, { headers: corsHeaders });
-    }
-    
-    return NextResponse.json({
-      id: 'dxy',
-      name: 'US Dollar Index (DXY)',
-      symbol: 'DXY',
-      price: parseFloat(currentValue.toFixed(4)),
+
+    const change = !isNaN(prev) ? latest - prev : 0;
+    const changePercent =
+      !isNaN(prev) && prev !== 0 ? (change / prev) * 100 : 0;
+
+    const result = {
+      id: "dxy",
+      name: "US Dollar Index (DXY)",
+      symbol: "DXY",
+      price: parseFloat(latest.toFixed(4)),
       change: parseFloat(change.toFixed(4)),
       changePercent: parseFloat(changePercent.toFixed(2)),
-      volume: dxyData.volume || 0,
-      lastUpdated: new Date().toISOString(),
-      status: 'fresh',
-      source: 'Financial Modeling Prep'
-    }, { 
-      headers: corsHeaders 
-    });
-    
+      volume: 0,
+      lastUpdated: obs?.[0]?.date || new Date().toISOString(),
+      status: "fresh",
+      source: "FRED",
+    };
+
+    cache = { payload: result, timestamp: Date.now() };
+
+    return NextResponse.json(result, { headers: corsHeaders });
   } catch (error) {
-    console.error('Error in DXY API route:', error);
-    return NextResponse.json(FALLBACK_DXY, { 
-      headers: corsHeaders 
+    console.error("Error in DXY API route:", error);
+    return NextResponse.json(FALLBACK_DXY, {
+      headers: corsHeaders,
     });
   }
 }
@@ -92,6 +103,6 @@ export async function GET() {
 // Handle OPTIONS request for CORS preflight
 export async function OPTIONS() {
   return new NextResponse(null, {
-    headers: corsHeaders
+    headers: corsHeaders,
   });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,36 +1,62 @@
+"use client";
 
-'use client';
-
-import { useState, useEffect, useCallback, useRef, type FC, type ElementType } from 'react';
-import Image from 'next/image';
-import DashboardHeader from '@/components/DashboardHeader';
-import DataCard from '@/components/DataCard';
-import ValueDisplay from '@/components/ValueDisplay';
-import type { AppData, CoinData, StockData, TrendingData, FearGreedData, MarketSentimentAnalysisOutput as AISentimentData, TrendingCoinItem } from '@/types';
-import { marketSentimentAnalysis } from '@/ai/flows/market-sentiment-analysis';
-import { Bitcoin, Brain, Briefcase, Gauge, Shapes, TrendingUp, BarChart3, DollarSign, Landmark, BarChart2 } from 'lucide-react';
-import { CorrelationPanel } from '@/components/CorrelationPanel';
-import SignalCard from '@/components/SignalCard';
-import MarketChart from '@/components/MarketChart';
-import SignalHistory from '@/components/SignalHistory';
-import { Orchestrator } from '@/lib/agents/Orchestrator';
-import { DataCollector } from '@/lib/agents/DataCollector';
-import { IndicatorEngine } from '@/lib/agents/IndicatorEngine';
-import { SignalGenerator } from '@/lib/agents/SignalGenerator';
-import { AlertLogger } from '@/lib/agents/AlertLogger';
-import type { Candle } from '@/lib/data/binanceWs';
-import type { ComputedIndicators } from '@/lib/signals';
-import type { TradeSignal } from '@/types';
-import type { AgentMessage } from '@/types/agent';
+import {
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  type FC,
+  type ElementType,
+} from "react";
+import Image from "next/image";
+import DashboardHeader from "@/components/DashboardHeader";
+import DataCard from "@/components/DataCard";
+import ValueDisplay from "@/components/ValueDisplay";
+import type {
+  AppData,
+  CoinData,
+  StockData,
+  TrendingData,
+  FearGreedData,
+  MarketSentimentAnalysisOutput as AISentimentData,
+  TrendingCoinItem,
+} from "@/types";
+import { marketSentimentAnalysis } from "@/ai/flows/market-sentiment-analysis";
+import {
+  Bitcoin,
+  Brain,
+  Briefcase,
+  Gauge,
+  Shapes,
+  TrendingUp,
+  BarChart3,
+  DollarSign,
+  Landmark,
+  BarChart2,
+} from "lucide-react";
+import { CorrelationPanel } from "@/components/CorrelationPanel";
+import SignalCard from "@/components/SignalCard";
+import MarketChart from "@/components/MarketChart";
+import SignalHistory from "@/components/SignalHistory";
+import { Orchestrator } from "@/lib/agents/Orchestrator";
+import { DataCollector } from "@/lib/agents/DataCollector";
+import { IndicatorEngine } from "@/lib/agents/IndicatorEngine";
+import { SignalGenerator } from "@/lib/agents/SignalGenerator";
+import { AlertLogger } from "@/lib/agents/AlertLogger";
+import type { Candle } from "@/lib/data/binanceWs";
+import type { ComputedIndicators } from "@/lib/signals";
+import type { TradeSignal } from "@/types";
+import type { AgentMessage } from "@/types/agent";
 import {
   simpleMovingAverage,
   rsi,
   exponentialMovingAverage,
   calculateVolumeProfile,
-} from '@/lib/indicators';
+} from "@/lib/indicators";
 
 const FMP_API_KEY = process.env.NEXT_PUBLIC_FMP_API_KEY;
-const ALPHA_VANTAGE_API_KEY = process.env.NEXT_PUBLIC_ALPHA_VANTAGE_API_KEY || 'demo'; // Get a free key from Alpha Vantage if needed
+const ALPHA_VANTAGE_API_KEY =
+  process.env.NEXT_PUBLIC_ALPHA_VANTAGE_API_KEY || "demo"; // Get a free key from Alpha Vantage if needed
 const CRYPTO_FETCH_INTERVAL_MS = 60 * 1000; // 1 minute
 const STOCK_FETCH_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
 const AI_ANALYSIS_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
@@ -38,28 +64,68 @@ const INITIAL_AI_ANALYSIS_DELAY_MS = 15 * 1000; // 15 seconds
 
 const getMockStockData = (symbol?: string): StockData => {
   const now = new Date().toISOString();
-  if (symbol === 'SPY') {
+  if (symbol === "SPY") {
     return {
-      id: 'spy', name: 'SPDR S&P 500 ETF (Mocked)', symbol: 'SPY', price: 450, change: 1.5, changePercent: 0.33, volume: 75000000, lastUpdated: now, status: 'cached_error'
+      id: "spy",
+      name: "SPDR S&P 500 ETF (Mocked)",
+      symbol: "SPY",
+      price: 450,
+      change: 1.5,
+      changePercent: 0.33,
+      volume: 75000000,
+      lastUpdated: now,
+      status: "cached_error",
     };
   }
-  if (symbol === '^GSPC') {
+  if (symbol === "^GSPC") {
     return {
-      id: 'spx', name: 'S&P 500 Index (Mocked)', symbol: '^GSPC', price: 4500, change: 10, changePercent: 0.22, volume: 2000000000, lastUpdated: now, status: 'cached_error'
+      id: "spx",
+      name: "S&P 500 Index (Mocked)",
+      symbol: "^GSPC",
+      price: 4500,
+      change: 10,
+      changePercent: 0.22,
+      volume: 2000000000,
+      lastUpdated: now,
+      status: "cached_error",
     };
   }
-  if (symbol === 'DX-Y.NYB' || symbol === 'DXY') { 
+  if (symbol === "DX-Y.NYB" || symbol === "DXY") {
     return {
-      id: 'dxy', name: 'US Dollar Index (Placeholder)', symbol: 'DXY', price: 104.50, change: 0.10, changePercent: 0.10, volume: 0, lastUpdated: now, status: 'cached_error'
+      id: "dxy",
+      name: "US Dollar Index (Placeholder)",
+      symbol: "DXY",
+      price: 104.5,
+      change: 0.1,
+      changePercent: 0.1,
+      volume: 0,
+      lastUpdated: now,
+      status: "cached_error",
     };
   }
-  if (symbol === '^TNX' || symbol === 'US10Y') { 
+  if (symbol === "^TNX" || symbol === "US10Y") {
     return {
-      id: 'us10y', name: 'US 10-Year Yield (Placeholder)', symbol: 'US10Y', price: 4.25, change: -0.02, changePercent: -0.47, volume: 0, lastUpdated: now, status: 'cached_error'
+      id: "us10y",
+      name: "US 10-Year Yield (Placeholder)",
+      symbol: "US10Y",
+      price: 4.25,
+      change: -0.02,
+      changePercent: -0.47,
+      volume: 0,
+      lastUpdated: now,
+      status: "cached_error",
     };
   }
   return {
-      id: 'mock', name: 'Mock Stock Data', symbol: 'MOCK', price: 100, change: 1, changePercent: 1, volume: 1000000, lastUpdated: now, status: 'cached_error'
+    id: "mock",
+    name: "Mock Stock Data",
+    symbol: "MOCK",
+    price: 100,
+    change: 1,
+    changePercent: 1,
+    volume: 1000000,
+    lastUpdated: now,
+    status: "cached_error",
   };
 };
 
@@ -74,18 +140,17 @@ const initialAppData: AppData = {
   fearGreed: null,
   aiSentiment: null,
   lastUpdated: null,
-  globalError: 'Click the refresh button to load the latest data',
+  globalError: "Click the refresh button to load the latest data",
   loading: false, // Start with loading false since we're not loading anything initially
-  loadingAi: false
+  loadingAi: false,
 };
-
 
 // Load data from localStorage on initial render
 const loadInitialData = (): AppData => {
-  if (typeof window === 'undefined') return initialAppData;
-  
+  if (typeof window === "undefined") return initialAppData;
+
   try {
-    const savedData = localStorage.getItem('cryptoDashboardData');
+    const savedData = localStorage.getItem("cryptoDashboardData");
     if (savedData) {
       const parsed = JSON.parse(savedData);
       // Ensure we have the latest structure with all required fields
@@ -94,11 +159,13 @@ const loadInitialData = (): AppData => {
         ...parsed,
         loading: false,
         loadingAi: false,
-        globalError: parsed.globalError || 'Click the refresh button to load the latest data'
+        globalError:
+          parsed.globalError ||
+          "Click the refresh button to load the latest data",
       };
     }
   } catch (e) {
-    console.error('Failed to load saved data:', e);
+    console.error("Failed to load saved data:", e);
   }
   return initialAppData;
 };
@@ -115,37 +182,48 @@ const CryptoDashboardPage: FC = () => {
     const ie = new IndicatorEngine(bus);
     const sg = new SignalGenerator(bus);
     const al = new AlertLogger();
-    bus.register('IndicatorEngine', m => ie.handle(m as AgentMessage<Candle>));
-    bus.register('SignalGenerator', m => sg.handle(m as AgentMessage<ComputedIndicators>));
-    bus.register('AlertLogger', m => al.handle(m as AgentMessage<TradeSignal>));
-    bus.register('DataCollector', () => {});
+    bus.register("IndicatorEngine", (m) =>
+      ie.handle(m as AgentMessage<Candle>),
+    );
+    bus.register("SignalGenerator", (m) =>
+      sg.handle(m as AgentMessage<ComputedIndicators>),
+    );
+    bus.register("AlertLogger", (m) =>
+      al.handle(m as AgentMessage<TradeSignal>),
+    );
+    bus.register("DataCollector", () => {});
     dc.start();
   }, []);
   const [appData, setAppData] = useState<AppData>(loadInitialData);
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const [correlationData, setCorrelationData] = useState<Array<{pair: string; value: number; timeFrame: string}>>([]);
+  const [correlationData, setCorrelationData] = useState<
+    Array<{ pair: string; value: number; timeFrame: string }>
+  >([]);
   const appDataRef = useRef(appData);
   const hasInitialized = useRef(false);
-  
+
   // Save to localStorage whenever appData changes
   useEffect(() => {
     if (hasInitialized.current) {
       try {
-        localStorage.setItem('cryptoDashboardData', JSON.stringify({
-          btc: appData.btc,
-          eth: appData.eth,
-          spy: appData.spy,
-          spx: appData.spx,
-          dxy: appData.dxy,
-          us10y: appData.us10y,
-          trending: appData.trending,
-          fearGreed: appData.fearGreed,
-          aiSentiment: appData.aiSentiment,
-          lastUpdated: appData.lastUpdated,
-          globalError: appData.globalError
-        }));
+        localStorage.setItem(
+          "cryptoDashboardData",
+          JSON.stringify({
+            btc: appData.btc,
+            eth: appData.eth,
+            spy: appData.spy,
+            spx: appData.spx,
+            dxy: appData.dxy,
+            us10y: appData.us10y,
+            trending: appData.trending,
+            fearGreed: appData.fearGreed,
+            aiSentiment: appData.aiSentiment,
+            lastUpdated: appData.lastUpdated,
+            globalError: appData.globalError,
+          }),
+        );
       } catch (e) {
-        console.error('Failed to save data to localStorage:', e);
+        console.error("Failed to save data to localStorage:", e);
       }
     } else {
       hasInitialized.current = true;
@@ -158,15 +236,17 @@ const CryptoDashboardPage: FC = () => {
 
   // Fetch DXY data from our API route
   const fetchDXYData = useCallback(async (forceRefresh = false) => {
-    const CACHE_KEY = 'dxy_data';
-    const CACHE_DURATION = 30 * 60 * 1000; // 30 minutes cache
-    
+    const CACHE_KEY = "dxy_data";
+    const CACHE_DURATION = 15 * 60 * 1000; // 15 minutes cache
+
     // Set loading state
-    setAppData(prev => ({
+    setAppData((prev) => ({
       ...prev,
-      dxy: prev.dxy ? { ...prev.dxy, status: 'loading' } : { ...getMockStockData('DXY'), status: 'loading' }
+      dxy: prev.dxy
+        ? { ...prev.dxy, status: "loading" }
+        : { ...getMockStockData("DXY"), status: "loading" },
     }));
-    
+
     // Try to get from cache first, unless force refresh
     if (!forceRefresh) {
       try {
@@ -175,76 +255,78 @@ const CryptoDashboardPage: FC = () => {
           const { data, timestamp } = JSON.parse(cached);
           // Only use cache if it's not expired
           if (Date.now() - timestamp < CACHE_DURATION) {
-            setAppData(prev => ({
+            setAppData((prev) => ({
               ...prev,
-              dxy: { ...data, status: 'cached' as const }
+              dxy: { ...data, status: "cached" as const },
             }));
             return;
           }
         }
       } catch (e) {
-        console.warn('Error reading DXY cache:', e);
+        console.warn("Error reading DXY cache:", e);
       }
     }
-    
+
     try {
-      const response = await fetch('/api/dxy', {
+      const response = await fetch("/api/dxy", {
         headers: {
-          'Cache-Control': 'no-cache',
-          'Pragma': 'no-cache'
+          "Cache-Control": "no-cache",
+          Pragma: "no-cache",
         },
-        next: { revalidate: 300 } // 5 minutes
+        next: { revalidate: 300 }, // 5 minutes
       });
-      
+
       if (!response.ok) {
         throw new Error(`API error: ${response.status} ${response.statusText}`);
       }
-      
+
       const data = await response.json();
-      
+
       // Cache the successful response
-      localStorage.setItem(CACHE_KEY, JSON.stringify({
-        data,
-        timestamp: Date.now()
-      }));
-      
-      setAppData(prev => ({
+      localStorage.setItem(
+        CACHE_KEY,
+        JSON.stringify({
+          data,
+          timestamp: Date.now(),
+        }),
+      );
+
+      setAppData((prev) => ({
         ...prev,
         dxy: {
           ...data,
-          status: 'fresh' as const
-        }
+          status: "fresh" as const,
+        },
       }));
-      
     } catch (error) {
-      console.error('Error fetching DXY data:', error);
+      console.error("Error fetching DXY data:", error);
       // Try to use cached data even if it's stale
       try {
         const cached = localStorage.getItem(CACHE_KEY);
         if (cached) {
           const { data } = JSON.parse(cached);
-          setAppData(prev => ({
+          setAppData((prev) => ({
             ...prev,
-            dxy: { ...data, status: 'stale' as const }
+            dxy: { ...data, status: "stale" as const },
           }));
           return;
         }
       } catch (e) {
-        console.warn('Failed to read from cache:', e);
+        console.warn("Failed to read from cache:", e);
       }
-      
+
       // Fall back to mock data if all else fails
-      setAppData(prev => ({
+      setAppData((prev) => ({
         ...prev,
-        dxy: getMockStockData('DXY')
+        dxy: getMockStockData("DXY"),
       }));
     }
   }, []);
 
   const fetchBtcMovingAverages = useCallback(async () => {
-    const CACHE_KEY = 'btc_ma_data';
+    const CACHE_KEY = "btc_ma_data";
     const CACHE_DURATION = 15 * 60 * 1000; // 15 minutes
-    
+
     try {
       // Try to get from cache first
       const cached = localStorage.getItem(CACHE_KEY);
@@ -255,25 +337,32 @@ const CryptoDashboardPage: FC = () => {
         }
       }
 
-      const res = await fetch('https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days=200&interval=daily')
+      const res = await fetch(
+        "https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days=200&interval=daily",
+      );
       if (!res.ok) {
         throw new Error(`CoinGecko API error: ${res.statusText}`);
       }
-      
-      const data = await res.json()
-      const prices: number[] = data.prices.map((p: [number, number]) => p[1])
-      const volumes: number[] = data.total_volumes.map((v: [number, number]) => v[1])
-      const ma50 = simpleMovingAverage(prices, 50)
-      const ma200 = simpleMovingAverage(prices, 200)
-      const maCrossover = ma50 > ma200 ? 'bullish' : 'bearish'
-      const ema20 = exponentialMovingAverage(prices, 20)
-      const ema50 = exponentialMovingAverage(prices, 50)
-      const ema200 = exponentialMovingAverage(prices, 200)
-      const volumeProfile = calculateVolumeProfile(prices, volumes)
-      const highestVolume = volumeProfile.reduce((a, b) => (b.volume > a.volume ? b : a), volumeProfile[0])
-      const volumeProfilePrice = highestVolume?.price
-      const rsi14 = rsi(prices, 14)
-      const signal = rsi14 <= 30 ? 'buy' : rsi14 >= 70 ? 'sell' : 'hold'
+
+      const data = await res.json();
+      const prices: number[] = data.prices.map((p: [number, number]) => p[1]);
+      const volumes: number[] = data.total_volumes.map(
+        (v: [number, number]) => v[1],
+      );
+      const ma50 = simpleMovingAverage(prices, 50);
+      const ma200 = simpleMovingAverage(prices, 200);
+      const maCrossover = ma50 > ma200 ? "bullish" : "bearish";
+      const ema20 = exponentialMovingAverage(prices, 20);
+      const ema50 = exponentialMovingAverage(prices, 50);
+      const ema200 = exponentialMovingAverage(prices, 200);
+      const volumeProfile = calculateVolumeProfile(prices, volumes);
+      const highestVolume = volumeProfile.reduce(
+        (a, b) => (b.volume > a.volume ? b : a),
+        volumeProfile[0],
+      );
+      const volumeProfilePrice = highestVolume?.price;
+      const rsi14 = rsi(prices, 14);
+      const signal = rsi14 <= 30 ? "buy" : rsi14 >= 70 ? "sell" : "hold";
       const result = {
         ma50,
         ma200,
@@ -285,17 +374,20 @@ const CryptoDashboardPage: FC = () => {
         rsi14,
         signal,
         lastUpdated: new Date().toISOString(),
-      }
-      
+      };
+
       // Cache the result
-      localStorage.setItem(CACHE_KEY, JSON.stringify({
-        data: result,
-        timestamp: Date.now()
-      }));
-      
+      localStorage.setItem(
+        CACHE_KEY,
+        JSON.stringify({
+          data: result,
+          timestamp: Date.now(),
+        }),
+      );
+
       return result;
     } catch (e) {
-      console.error('Error fetching BTC MA data:', e);
+      console.error("Error fetching BTC MA data:", e);
       // Return cached data even if stale
       try {
         const cached = localStorage.getItem(CACHE_KEY);
@@ -303,33 +395,38 @@ const CryptoDashboardPage: FC = () => {
           return JSON.parse(cached).data;
         }
       } catch (e) {
-        console.warn('Failed to read from cache:', e);
+        console.warn("Failed to read from cache:", e);
       }
       return null;
     }
-  }, [])
+  }, []);
 
   const fetchStockRsi = useCallback(async (symbol: string) => {
     try {
-      if (!FMP_API_KEY) return null
-      const res = await fetch(`https://financialmodelingprep.com/api/v3/historical-price-full/${encodeURIComponent(symbol)}?timeseries=20&apikey=${FMP_API_KEY}`)
-      if (!res.ok) return null
-      const data = await res.json()
+      if (!FMP_API_KEY) return null;
+      const res = await fetch(
+        `https://financialmodelingprep.com/api/v3/historical-price-full/${encodeURIComponent(symbol)}?timeseries=20&apikey=${FMP_API_KEY}`,
+      );
+      if (!res.ok) return null;
+      const data = await res.json();
       if (Array.isArray(data.historical)) {
-        const prices = data.historical.slice(0, 15).map((p: any) => p.close).reverse()
-        return rsi(prices, 14)
+        const prices = data.historical
+          .slice(0, 15)
+          .map((p: any) => p.close)
+          .reverse();
+        return rsi(prices, 14);
       }
     } catch (e) {
-      console.error('Error fetching RSI for', symbol, e)
+      console.error("Error fetching RSI for", symbol, e);
     }
-    return null
-  }, [])
+    return null;
+  }, []);
 
   // Fetch US10Y data from our API route
   const fetchUS10YData = useCallback(async (forceRefresh = false) => {
-    const CACHE_KEY = 'us10y_data';
+    const CACHE_KEY = "us10y_data";
     const CACHE_DURATION = 30 * 60 * 1000; // 30 minutes cache
-    
+
     // Always try to get from cache first, unless force refresh
     if (!forceRefresh) {
       const cached = localStorage.getItem(CACHE_KEY);
@@ -337,109 +434,115 @@ const CryptoDashboardPage: FC = () => {
         const { data, timestamp } = JSON.parse(cached);
         // Only use cache if it's not expired
         if (Date.now() - timestamp < CACHE_DURATION) {
-          setAppData(prev => ({
+          setAppData((prev) => ({
             ...prev,
-            us10y: { ...data, status: 'cached' as const }
+            us10y: { ...data, status: "cached" as const },
           }));
           return;
         }
       }
     }
-    
+
     // Use fallback data if API is not available
     const fallbackData = {
-      id: 'us10y',
-      name: '10-Year Treasury Yield',
-      symbol: 'US10Y',
+      id: "us10y",
+      name: "10-Year Treasury Yield",
+      symbol: "US10Y",
       price: 4.25,
       change: -0.02,
       changePercent: -0.47,
       volume: 0,
       lastUpdated: new Date().toISOString(),
-      status: 'cached',
-      source: 'fallback'
+      status: "cached",
+      source: "fallback",
     };
-    
-    setAppData(prev => ({
+
+    setAppData((prev) => ({
       ...prev,
-      us10y: { ...fallbackData, status: 'cached' as const }
+      us10y: { ...fallbackData, status: "cached" as const },
     }));
-    
+
     // Set loading state
-    setAppData(prev => ({
+    setAppData((prev) => ({
       ...prev,
-      us10y: prev.us10y ? { ...prev.us10y, status: 'loading' } : { ...getMockStockData('US10Y'), status: 'loading' }
+      us10y: prev.us10y
+        ? { ...prev.us10y, status: "loading" }
+        : { ...getMockStockData("US10Y"), status: "loading" },
     }));
-    
+
     try {
       // Use relative URL in production, absolute in development
-      const baseUrl = typeof window === 'undefined' ? 'http://localhost:3000' : '';
+      const baseUrl =
+        typeof window === "undefined" ? "http://localhost:3000" : "";
       const response = await fetch(`${baseUrl}/api/us10y`, {
         headers: {
-          'Cache-Control': 'no-cache',
-          'Pragma': 'no-cache'
+          "Cache-Control": "no-cache",
+          Pragma: "no-cache",
         },
-        cache: 'no-store', // Ensure we don't get cached responses
-        next: { revalidate: 0 } // Ensure we always get fresh data
+        cache: "no-store", // Ensure we don't get cached responses
+        next: { revalidate: 0 }, // Ensure we always get fresh data
       });
-      
+
       if (!response.ok) {
         throw new Error(`API error: ${response.statusText}`);
       }
-      
+
       const data = await response.json();
-      
+
       // Update cache
-      if (typeof window !== 'undefined') {
-        localStorage.setItem('us10y_data', JSON.stringify({
-          data,
-          timestamp: Date.now()
-        }));
+      if (typeof window !== "undefined") {
+        localStorage.setItem(
+          "us10y_data",
+          JSON.stringify({
+            data,
+            timestamp: Date.now(),
+          }),
+        );
       }
-      
-      setAppData(prev => ({
+
+      setAppData((prev) => ({
         ...prev,
         us10y: {
           ...data,
-          status: 'fresh' as const,
-          source: 'Alpha Vantage (via API)'
-        }
+          status: "fresh" as const,
+          source: "Alpha Vantage (via API)",
+        },
       }));
-      
     } catch (error) {
-      console.error('Error fetching US10Y data:', error);
+      console.error("Error fetching US10Y data:", error);
       // Fall back to mock data if all else fails
-      setAppData(prev => ({
+      setAppData((prev) => ({
         ...prev,
-        us10y: getMockStockData('US10Y')
+        us10y: getMockStockData("US10Y"),
       }));
     }
   }, []);
-
-
 
   // Calculate correlation between two data series
-  const calculateCorrelation = useCallback((x: number[], y: number[]): number => {
-    if (x.length !== y.length || x.length === 0) return 0;
-    
-    const n = x.length;
-    const xMean = x.reduce((a, b) => a + b, 0) / n;
-    const yMean = y.reduce((a, b) => a + b, 0) / n;
-    
-    let num = 0;
-    let denomX = 0;
-    let denomY = 0;
-    
-    for (let i = 0; i < n; i++) {
-      const xDiff = x[i] - xMean;
-      const yDiff = y[i] - yMean;
-      num += xDiff * yDiff;
-      denomX += xDiff * xDiff;
-      denomY += yDiff * yDiff;
-    }
-    
-    return num / Math.sqrt(denomX * denomY);
-  }, []);
+  const calculateCorrelation = useCallback(
+    (x: number[], y: number[]): number => {
+      if (x.length !== y.length || x.length === 0) return 0;
+
+      const n = x.length;
+      const xMean = x.reduce((a, b) => a + b, 0) / n;
+      const yMean = y.reduce((a, b) => a + b, 0) / n;
+
+      let num = 0;
+      let denomX = 0;
+      let denomY = 0;
+
+      for (let i = 0; i < n; i++) {
+        const xDiff = x[i] - xMean;
+        const yDiff = y[i] - yMean;
+        num += xDiff * yDiff;
+        denomX += xDiff * xDiff;
+        denomY += yDiff * yDiff;
+      }
+
+      return num / Math.sqrt(denomX * denomY);
+    },
+    [],
+  );
 
   // Update correlation data when prices change
   useEffect(() => {
@@ -448,28 +551,33 @@ const CryptoDashboardPage: FC = () => {
       const btcPrice = appData.btc.price;
       const spxPrice = appData.spx.price;
       const spyPrice = appData.spy.price;
-      
+
       // In a real app, you would use historical data points
       // This is a simplified example using just the current prices
       const btcSpxCorrelation = calculateCorrelation([btcPrice], [spxPrice]);
       const btcSpyCorrelation = calculateCorrelation([btcPrice], [spyPrice]);
       const spxSpyCorrelation = calculateCorrelation([spxPrice], [spyPrice]);
-      
+
       setCorrelationData([
-        { pair: 'BTC/SPX', value: btcSpxCorrelation, timeFrame: '1h' },
-        { pair: 'BTC/SPY', value: btcSpyCorrelation, timeFrame: '1h' },
-        { pair: 'SPX/SPY', value: spxSpyCorrelation, timeFrame: '1h' },
+        { pair: "BTC/SPX", value: btcSpxCorrelation, timeFrame: "1h" },
+        { pair: "BTC/SPY", value: btcSpyCorrelation, timeFrame: "1h" },
+        { pair: "SPX/SPY", value: spxSpyCorrelation, timeFrame: "1h" },
       ]);
     }
-  }, [appData.btc?.price, appData.spx?.price, appData.spy?.price, calculateCorrelation]);
+  }, [
+    appData.btc?.price,
+    appData.spx?.price,
+    appData.spy?.price,
+    calculateCorrelation,
+  ]);
 
   // Data fetching is now handled by the refresh button click
   // No automatic data fetching on component mount
 
   const fetchCryptoData = useCallback(async (forceRefresh = false) => {
-    const CRYPTO_CACHE_KEY = 'crypto_data';
+    const CRYPTO_CACHE_KEY = "crypto_data";
     const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes cache
-    
+
     // Try to get from cache first if not forcing refresh
     if (!forceRefresh) {
       const cached = localStorage.getItem(CRYPTO_CACHE_KEY);
@@ -477,23 +585,25 @@ const CryptoDashboardPage: FC = () => {
         const { data, timestamp } = JSON.parse(cached);
         // Only use cache if it's not expired
         if (Date.now() - timestamp < CACHE_DURATION) {
-          setAppData(prev => ({
+          setAppData((prev) => ({
             ...prev,
             ...data,
             loading: false,
-            loadingAi: false
+            loadingAi: false,
           }));
           return;
         }
       }
     }
-    
+
     // Set loading state
-    setAppData(prev => ({
+    setAppData((prev) => ({
       ...prev,
       loading: true,
       loadingAi: true,
-      globalError: prev.globalError?.includes('Refreshing data') ? prev.globalError : null
+      globalError: prev.globalError?.includes("Refreshing data")
+        ? prev.globalError
+        : null,
     }));
 
     const prevData = appDataRef.current;
@@ -502,21 +612,27 @@ const CryptoDashboardPage: FC = () => {
     let cryptoErrorMsg: string | null = null;
 
     try {
-      const [marketDataResponse, trendingResponse, fearGreedResponse] = await Promise.allSettled([
-        fetch('https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=bitcoin,ethereum&order=market_cap_desc&per_page=2&page=1&sparkline=false&price_change_percentage=24h'),
-        fetch('https://api.coingecko.com/api/v3/search/trending'),
-        fetch('https://api.alternative.me/fng/?limit=1')
-      ]);
+      const [marketDataResponse, trendingResponse, fearGreedResponse] =
+        await Promise.allSettled([
+          fetch(
+            "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=bitcoin,ethereum&order=market_cap_desc&per_page=2&page=1&sparkline=false&price_change_percentage=24h",
+          ),
+          fetch("https://api.coingecko.com/api/v3/search/trending"),
+          fetch("https://api.alternative.me/fng/?limit=1"),
+        ]);
 
       let newBtcData: CoinData | null = prevData.btc;
       let newEthData: CoinData | null = prevData.eth;
       let newTrendingData: TrendingData | null = prevData.trending;
       let newFearGreedData: FearGreedData | null = prevData.fearGreed;
 
-      if (marketDataResponse.status === 'fulfilled' && marketDataResponse.value.ok) {
+      if (
+        marketDataResponse.status === "fulfilled" &&
+        marketDataResponse.value.ok
+      ) {
         const markets = await marketDataResponse.value.json();
-        const btcApi = markets.find((c: any) => c.id === 'bitcoin');
-        const ethApi = markets.find((c: any) => c.id === 'ethereum');
+        const btcApi = markets.find((c: any) => c.id === "bitcoin");
+        const ethApi = markets.find((c: any) => c.id === "ethereum");
 
         if (btcApi) {
           anyDataFetched = true;
@@ -533,7 +649,7 @@ const CryptoDashboardPage: FC = () => {
             low24h: btcApi.low_24h,
             lastUpdated: btcApi.last_updated,
             image: btcApi.image,
-            status: 'fresh',
+            status: "fresh",
             ma50: maData?.ma50,
             ma200: maData?.ma200,
             maCrossover: maData?.maCrossover,
@@ -543,104 +659,183 @@ const CryptoDashboardPage: FC = () => {
             volumeProfilePrice: maData?.volumeProfilePrice,
             rsi14: maData?.rsi14,
             signal: maData?.signal,
-          }
-        } else { partialError = true; if (newBtcData) newBtcData.status = 'cached_error'; console.error("Bitcoin data not found."); }
+          };
+        } else {
+          partialError = true;
+          if (newBtcData) newBtcData.status = "cached_error";
+          console.error("Bitcoin data not found.");
+        }
 
         if (ethApi) {
           anyDataFetched = true;
           newEthData = {
-            id: ethApi.id, name: ethApi.name, symbol: ethApi.symbol.toUpperCase(), price: ethApi.current_price,
-            change24h: ethApi.price_change_percentage_24h || 0, volume24h: ethApi.total_volume, marketCap: ethApi.market_cap,
-            high24h: ethApi.high_24h, low24h: ethApi.low_24h, lastUpdated: ethApi.last_updated, image: ethApi.image, status: 'fresh',
+            id: ethApi.id,
+            name: ethApi.name,
+            symbol: ethApi.symbol.toUpperCase(),
+            price: ethApi.current_price,
+            change24h: ethApi.price_change_percentage_24h || 0,
+            volume24h: ethApi.total_volume,
+            marketCap: ethApi.market_cap,
+            high24h: ethApi.high_24h,
+            low24h: ethApi.low_24h,
+            lastUpdated: ethApi.last_updated,
+            image: ethApi.image,
+            status: "fresh",
           };
-        } else { partialError = true; if (newEthData) newEthData.status = 'cached_error'; console.error("Ethereum data not found."); }
+        } else {
+          partialError = true;
+          if (newEthData) newEthData.status = "cached_error";
+          console.error("Ethereum data not found.");
+        }
       } else {
         partialError = true;
-        if (newBtcData) newBtcData.status = 'cached_error'; if (newEthData) newEthData.status = 'cached_error';
-        const errorText = marketDataResponse.status === 'rejected' ? marketDataResponse.reason : (marketDataResponse.value?.statusText || "market data fetch error");
+        if (newBtcData) newBtcData.status = "cached_error";
+        if (newEthData) newEthData.status = "cached_error";
+        const errorText =
+          marketDataResponse.status === "rejected"
+            ? marketDataResponse.reason
+            : marketDataResponse.value?.statusText || "market data fetch error";
         cryptoErrorMsg = `Failed to fetch crypto market data: ${errorText}. `;
         console.error(cryptoErrorMsg);
       }
 
-      if (trendingResponse.status === 'fulfilled' && trendingResponse.value.ok) {
+      if (
+        trendingResponse.status === "fulfilled" &&
+        trendingResponse.value.ok
+      ) {
         const trendingApi = await trendingResponse.value.json();
         if (trendingApi.coins && trendingApi.coins.length > 0) {
           anyDataFetched = true;
           newTrendingData = {
-            coins: trendingApi.coins.slice(0, 7).map((coin: { item: any }): TrendingCoinItem => ({
-              id: coin.item.id, name: coin.item.name, symbol: coin.item.symbol.toUpperCase(),
-              market_cap_rank: coin.item.market_cap_rank, thumb: coin.item.thumb, price_btc: coin.item.price_btc,
-            })), status: 'fresh',
+            coins: trendingApi.coins.slice(0, 7).map(
+              (coin: { item: any }): TrendingCoinItem => ({
+                id: coin.item.id,
+                name: coin.item.name,
+                symbol: coin.item.symbol.toUpperCase(),
+                market_cap_rank: coin.item.market_cap_rank,
+                thumb: coin.item.thumb,
+                price_btc: coin.item.price_btc,
+              }),
+            ),
+            status: "fresh",
           };
-        } else { if (newTrendingData) newTrendingData.status = 'cached_error'; else partialError = true; }
+        } else {
+          if (newTrendingData) newTrendingData.status = "cached_error";
+          else partialError = true;
+        }
       } else {
-        partialError = true; if (newTrendingData) newTrendingData.status = 'cached_error';
-        const errorText = trendingResponse.status === 'rejected' ? trendingResponse.reason : (trendingResponse.value?.statusText || "trending coins fetch error");
+        partialError = true;
+        if (newTrendingData) newTrendingData.status = "cached_error";
+        const errorText =
+          trendingResponse.status === "rejected"
+            ? trendingResponse.reason
+            : trendingResponse.value?.statusText ||
+              "trending coins fetch error";
         cryptoErrorMsg = `${cryptoErrorMsg || ""}Failed to fetch trending coins: ${errorText}. `;
         console.error("Failed to fetch trending coins:", errorText);
       }
 
-      if (fearGreedResponse.status === 'fulfilled' && fearGreedResponse.value.ok) {
+      if (
+        fearGreedResponse.status === "fulfilled" &&
+        fearGreedResponse.value.ok
+      ) {
         const fearGreedApi = await fearGreedResponse.value.json();
         if (fearGreedApi.data && fearGreedApi.data.length > 0) {
-          anyDataFetched = true; const fgValue = fearGreedApi.data[0];
-          newFearGreedData = { value: fgValue.value, value_classification: fgValue.value_classification, timestamp: fgValue.timestamp, status: 'fresh' };
-        } else { if (newFearGreedData) newFearGreedData.status = 'cached_error'; else partialError = true; }
+          anyDataFetched = true;
+          const fgValue = fearGreedApi.data[0];
+          newFearGreedData = {
+            value: fgValue.value,
+            value_classification: fgValue.value_classification,
+            timestamp: fgValue.timestamp,
+            status: "fresh",
+          };
+        } else {
+          if (newFearGreedData) newFearGreedData.status = "cached_error";
+          else partialError = true;
+        }
       } else {
-        partialError = true; if (newFearGreedData) newFearGreedData.status = 'cached_error';
-        const errorText = fearGreedResponse.status === 'rejected' ? fearGreedResponse.reason : (fearGreedResponse.value?.statusText || "F&G index fetch error");
+        partialError = true;
+        if (newFearGreedData) newFearGreedData.status = "cached_error";
+        const errorText =
+          fearGreedResponse.status === "rejected"
+            ? fearGreedResponse.reason
+            : fearGreedResponse.value?.statusText || "F&G index fetch error";
         cryptoErrorMsg = `${cryptoErrorMsg || ""}Failed to fetch F&G Index: ${errorText}. `;
         console.error("Failed to fetch Fear & Greed Index:", errorText);
       }
-      
-      let currentGlobalError = appDataRef.current.globalError || "";
-      currentGlobalError = currentGlobalError.split(". ")
-        .filter(msg => 
-            !msg.toLowerCase().includes("crypto") && 
-            !msg.toLowerCase().includes("trending") && 
-            !msg.toLowerCase().includes("f&g") &&
-            !msg.toLowerCase().includes("ai sentiment"))
-        .join(". ");
-      if (currentGlobalError && !currentGlobalError.endsWith(".") && currentGlobalError.length > 0) currentGlobalError += ". ";
 
+      let currentGlobalError = appDataRef.current.globalError || "";
+      currentGlobalError = currentGlobalError
+        .split(". ")
+        .filter(
+          (msg) =>
+            !msg.toLowerCase().includes("crypto") &&
+            !msg.toLowerCase().includes("trending") &&
+            !msg.toLowerCase().includes("f&g") &&
+            !msg.toLowerCase().includes("ai sentiment"),
+        )
+        .join(". ");
+      if (
+        currentGlobalError &&
+        !currentGlobalError.endsWith(".") &&
+        currentGlobalError.length > 0
+      )
+        currentGlobalError += ". ";
 
       if (partialError && !anyDataFetched && !prevData.btc) {
-         cryptoErrorMsg = cryptoErrorMsg || "Failed to load critical market data.";
+        cryptoErrorMsg =
+          cryptoErrorMsg || "Failed to load critical market data.";
       } else if (partialError) {
-         cryptoErrorMsg = cryptoErrorMsg || "Some crypto data might be outdated.";
+        cryptoErrorMsg =
+          cryptoErrorMsg || "Some crypto data might be outdated.";
       } else {
-        cryptoErrorMsg = null; 
+        cryptoErrorMsg = null;
       }
-      
-      const finalGlobalError = cryptoErrorMsg ? (currentGlobalError + cryptoErrorMsg).trim() : currentGlobalError.trim();
 
-      setAppData(current => ({
-        ...current, btc: newBtcData, eth: newEthData, trending: newTrendingData, fearGreed: newFearGreedData,
-        lastUpdated: anyDataFetched || current.lastUpdated ? new Date().toISOString() : null,
+      const finalGlobalError = cryptoErrorMsg
+        ? (currentGlobalError + cryptoErrorMsg).trim()
+        : currentGlobalError.trim();
+
+      setAppData((current) => ({
+        ...current,
+        btc: newBtcData,
+        eth: newEthData,
+        trending: newTrendingData,
+        fearGreed: newFearGreedData,
+        lastUpdated:
+          anyDataFetched || current.lastUpdated
+            ? new Date().toISOString()
+            : null,
         globalError: finalGlobalError || null,
-        loading: false, 
+        loading: false,
       }));
-
     } catch (error) {
       console.error("Overall error fetching dashboard data:", error);
-      const errorMsg = error instanceof Error ? error.message : 'Unknown error fetching crypto data.';
-      setAppData(current => ({
+      const errorMsg =
+        error instanceof Error
+          ? error.message
+          : "Unknown error fetching crypto data.";
+      setAppData((current) => ({
         ...current,
-        btc: current.btc ? { ...current.btc, status: 'cached_error' } : null,
-        eth: current.eth ? { ...current.eth, status: 'cached_error' } : null,
-        trending: current.trending ? { ...current.trending, status: 'cached_error' } : null,
-        fearGreed: current.fearGreed ? { ...current.fearGreed, status: 'cached_error' } : null,
+        btc: current.btc ? { ...current.btc, status: "cached_error" } : null,
+        eth: current.eth ? { ...current.eth, status: "cached_error" } : null,
+        trending: current.trending
+          ? { ...current.trending, status: "cached_error" }
+          : null,
+        fearGreed: current.fearGreed
+          ? { ...current.fearGreed, status: "cached_error" }
+          : null,
         globalError: `${current.globalError ? current.globalError + " " : ""} ${errorMsg}`,
-        loading: false, 
+        loading: false,
         lastUpdated: current.lastUpdated || new Date().toISOString(),
       }));
     }
-  }, []); 
+  }, []);
 
   const fetchStockData = useCallback(async (forceRefresh = false) => {
-    const STOCK_CACHE_KEY = 'stock_data';
+    const STOCK_CACHE_KEY = "stock_data";
     const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes cache
-    
+
     // Try to get from cache first if not forcing refresh
     if (!forceRefresh) {
       const cached = localStorage.getItem(STOCK_CACHE_KEY);
@@ -648,10 +843,10 @@ const CryptoDashboardPage: FC = () => {
         const { data, timestamp } = JSON.parse(cached);
         // Only use cache if it's not expired
         if (Date.now() - timestamp < CACHE_DURATION) {
-          setAppData(prev => ({
+          setAppData((prev) => ({
             ...prev,
             ...data,
-            loading: false
+            loading: false,
           }));
           return;
         }
@@ -659,136 +854,201 @@ const CryptoDashboardPage: FC = () => {
     }
     // Only fetch fresh data if force refresh is true
     if (forceRefresh) {
-      await Promise.all([
-        fetchDXYData(true),
-        fetchUS10YData(true)
-      ]);
+      await Promise.all([fetchDXYData(true), fetchUS10YData(true)]);
     }
 
-    setAppData(prev => ({
+    setAppData((prev) => ({
       ...prev,
-      spy: prev.spy ? { ...prev.spy, status: 'loading' } : { ...getMockStockData('SPY'), status: 'loading' },
-      spx: prev.spx ? { ...prev.spx, status: 'loading' } : { ...getMockStockData('^GSPC'), status: 'loading' },
+      spy: prev.spy
+        ? { ...prev.spy, status: "loading" }
+        : { ...getMockStockData("SPY"), status: "loading" },
+      spx: prev.spx
+        ? { ...prev.spx, status: "loading" }
+        : { ...getMockStockData("^GSPC"), status: "loading" },
     }));
-  
+
     let newSpyData: StockData | null = appDataRef.current.spy;
     let newSpxData: StockData | null = appDataRef.current.spx;
     const localStockErrorParts: string[] = [];
-  
+
     if (!FMP_API_KEY) {
-      console.warn("FMP API key (NEXT_PUBLIC_FMP_API_KEY) is not set. Using mock stock data for SPY and SPX.");
-      localStockErrorParts.push("SPY and SPX data is mocked due to missing FMP API key");
-      newSpyData = getMockStockData('SPY');
-      newSpxData = getMockStockData('^GSPC');
+      console.warn(
+        "FMP API key (NEXT_PUBLIC_FMP_API_KEY) is not set. Using mock stock data for SPY and SPX.",
+      );
+      localStockErrorParts.push(
+        "SPY and SPX data is mocked due to missing FMP API key",
+      );
+      newSpyData = getMockStockData("SPY");
+      newSpxData = getMockStockData("^GSPC");
     } else {
       try {
-        const spyPromise = fetch(`https://financialmodelingprep.com/stable/quote?symbol=SPY&apikey=${FMP_API_KEY}`);
-        const spxPromise = fetch(`https://financialmodelingprep.com/stable/quote?symbol=${encodeURIComponent('^GSPC')}&apikey=${FMP_API_KEY}`);
-        
-        const [spyResponseSettled, spxResponseSettled] = await Promise.allSettled([spyPromise, spxPromise]);
+        const spyPromise = fetch(
+          `https://financialmodelingprep.com/stable/quote?symbol=SPY&apikey=${FMP_API_KEY}`,
+        );
+        const spxPromise = fetch(
+          `https://financialmodelingprep.com/stable/quote?symbol=${encodeURIComponent("^GSPC")}&apikey=${FMP_API_KEY}`,
+        );
 
-        if (spyResponseSettled.status === 'fulfilled') {
+        const [spyResponseSettled, spxResponseSettled] =
+          await Promise.allSettled([spyPromise, spxPromise]);
+
+        if (spyResponseSettled.status === "fulfilled") {
           const spyResponse = spyResponseSettled.value;
           if (spyResponse.ok) {
             const spyDataArray = await spyResponse.json();
             if (spyDataArray && spyDataArray.length > 0) {
               const spyApiData = spyDataArray[0];
-              const spyRsi = await fetchStockRsi('SPY')
+              const spyRsi = await fetchStockRsi("SPY");
               newSpyData = {
                 id: spyApiData.symbol,
-                name: spyApiData.name || 'SPDR S&P 500 ETF',
+                name: spyApiData.name || "SPDR S&P 500 ETF",
                 symbol: spyApiData.symbol,
                 price: spyApiData.price,
                 change: spyApiData.change,
                 changePercent: spyApiData.changesPercentage,
                 volume: spyApiData.volume,
-                lastUpdated: spyApiData.timestamp ? new Date(spyApiData.timestamp * 1000).toISOString() : new Date().toISOString(),
-                status: 'fresh',
+                lastUpdated: spyApiData.timestamp
+                  ? new Date(spyApiData.timestamp * 1000).toISOString()
+                  : new Date().toISOString(),
+                status: "fresh",
                 rsi14: spyRsi ?? undefined,
-                signal: spyRsi != null ? (spyRsi <= 30 ? 'buy' : spyRsi >= 70 ? 'sell' : 'hold') : undefined,
-              }
-            } else { 
-              if (newSpyData) newSpyData.status = 'cached_error'; else newSpyData = getMockStockData('SPY');
-              localStockErrorParts.push("SPY data not found in FMP response."); 
+                signal:
+                  spyRsi != null
+                    ? spyRsi <= 30
+                      ? "buy"
+                      : spyRsi >= 70
+                        ? "sell"
+                        : "hold"
+                    : undefined,
+              };
+            } else {
+              if (newSpyData) newSpyData.status = "cached_error";
+              else newSpyData = getMockStockData("SPY");
+              localStockErrorParts.push("SPY data not found in FMP response.");
             }
           } else {
-            if (newSpyData) newSpyData.status = 'cached_error'; else newSpyData = getMockStockData('SPY');
+            if (newSpyData) newSpyData.status = "cached_error";
+            else newSpyData = getMockStockData("SPY");
             let spyError = `Failed to fetch SPY data from FMP: (status ${spyResponse.status})`;
-            if (spyResponse.status === 401 || spyResponse.status === 403) spyError += ". Please check your FMP API key and ensure it has the correct permissions";
-            else if (spyResponse.status === 400) spyError += ". Bad request, check symbol or API endpoint";
+            if (spyResponse.status === 401 || spyResponse.status === 403)
+              spyError +=
+                ". Please check your FMP API key and ensure it has the correct permissions";
+            else if (spyResponse.status === 400)
+              spyError += ". Bad request, check symbol or API endpoint";
             localStockErrorParts.push(spyError);
           }
-        } else { 
-          if (newSpyData) newSpyData.status = 'cached_error'; else newSpyData = getMockStockData('SPY');
-          localStockErrorParts.push(`Failed to fetch SPY data: ${spyResponseSettled.reason?.message || 'Network error'}`); 
+        } else {
+          if (newSpyData) newSpyData.status = "cached_error";
+          else newSpyData = getMockStockData("SPY");
+          localStockErrorParts.push(
+            `Failed to fetch SPY data: ${spyResponseSettled.reason?.message || "Network error"}`,
+          );
         }
 
-        if (spxResponseSettled.status === 'fulfilled') {
+        if (spxResponseSettled.status === "fulfilled") {
           const spxResponse = spxResponseSettled.value;
           if (spxResponse.ok) {
             const spxDataArray = await spxResponse.json();
             if (spxDataArray && spxDataArray.length > 0) {
               const spxApiData = spxDataArray[0];
-              const spxRsi = await fetchStockRsi('^GSPC')
+              const spxRsi = await fetchStockRsi("^GSPC");
               newSpxData = {
                 id: spxApiData.symbol,
-                name: spxApiData.name || 'S&P 500 Index',
+                name: spxApiData.name || "S&P 500 Index",
                 symbol: spxApiData.symbol,
                 price: spxApiData.price,
                 change: spxApiData.change,
                 changePercent: spxApiData.changesPercentage,
                 volume: spxApiData.volume,
-                lastUpdated: spxApiData.timestamp ? new Date(spxApiData.timestamp * 1000).toISOString() : new Date().toISOString(),
-                status: 'fresh',
+                lastUpdated: spxApiData.timestamp
+                  ? new Date(spxApiData.timestamp * 1000).toISOString()
+                  : new Date().toISOString(),
+                status: "fresh",
                 rsi14: spxRsi ?? undefined,
-                signal: spxRsi != null ? (spxRsi <= 30 ? 'buy' : spxRsi >= 70 ? 'sell' : 'hold') : undefined,
-              }
-            } else { 
-              if (newSpxData) newSpxData.status = 'cached_error'; else newSpxData = getMockStockData('^GSPC');
-              localStockErrorParts.push("^GSPC data not found in FMP response."); 
+                signal:
+                  spxRsi != null
+                    ? spxRsi <= 30
+                      ? "buy"
+                      : spxRsi >= 70
+                        ? "sell"
+                        : "hold"
+                    : undefined,
+              };
+            } else {
+              if (newSpxData) newSpxData.status = "cached_error";
+              else newSpxData = getMockStockData("^GSPC");
+              localStockErrorParts.push(
+                "^GSPC data not found in FMP response.",
+              );
             }
           } else {
-            if (newSpxData) newSpxData.status = 'cached_error'; else newSpxData = getMockStockData('^GSPC');
+            if (newSpxData) newSpxData.status = "cached_error";
+            else newSpxData = getMockStockData("^GSPC");
             let spxError = `Failed to fetch ^GSPC data from FMP: (status ${spxResponse.status})`;
-            if (spxResponse.status === 401 || spxResponse.status === 403) spxError += ". Please check your FMP API key and ensure it has the correct permissions";
-            else if (spxResponse.status === 400) spxError += ". Bad request, check symbol or API endpoint";
+            if (spxResponse.status === 401 || spxResponse.status === 403)
+              spxError +=
+                ". Please check your FMP API key and ensure it has the correct permissions";
+            else if (spxResponse.status === 400)
+              spxError += ". Bad request, check symbol or API endpoint";
             localStockErrorParts.push(spxError);
           }
-        } else { 
-          if (newSpxData) newSpxData.status = 'cached_error'; else newSpxData = getMockStockData('^GSPC');
-          localStockErrorParts.push(`Failed to fetch ^GSPC data: ${spxResponseSettled.reason?.message || 'Network error'}`); 
+        } else {
+          if (newSpxData) newSpxData.status = "cached_error";
+          else newSpxData = getMockStockData("^GSPC");
+          localStockErrorParts.push(
+            `Failed to fetch ^GSPC data: ${spxResponseSettled.reason?.message || "Network error"}`,
+          );
         }
-
-      } catch (error) { 
+      } catch (error) {
         console.error("Unexpected error fetching SPY/SPX stock data:", error);
-        const errorText = error instanceof Error ? error.message : "Unknown error during SPY/SPX stock data fetch.";
+        const errorText =
+          error instanceof Error
+            ? error.message
+            : "Unknown error during SPY/SPX stock data fetch.";
         localStockErrorParts.push(`Unexpected error: ${errorText}`);
-        if (newSpyData) newSpyData.status = 'cached_error'; else newSpyData = getMockStockData('SPY');
-        if (newSpxData) newSpxData.status = 'cached_error'; else newSpxData = getMockStockData('^GSPC');
+        if (newSpyData) newSpyData.status = "cached_error";
+        else newSpyData = getMockStockData("SPY");
+        if (newSpxData) newSpxData.status = "cached_error";
+        else newSpxData = getMockStockData("^GSPC");
       }
     }
-    
-    const finalStockErrorMsg = localStockErrorParts.length > 0 ? localStockErrorParts.join(". ") + "." : null;
 
-    setAppData(prev => {
+    const finalStockErrorMsg =
+      localStockErrorParts.length > 0
+        ? localStockErrorParts.join(". ") + "."
+        : null;
+
+    setAppData((prev) => {
       let currentGlobalError = prev.globalError || "";
-      currentGlobalError = currentGlobalError.split(". ")
-        .filter(msg => 
-            !msg.toLowerCase().includes("stock") && 
+      currentGlobalError = currentGlobalError
+        .split(". ")
+        .filter(
+          (msg) =>
+            !msg.toLowerCase().includes("stock") &&
             !msg.toLowerCase().includes("fmp") &&
             !msg.toLowerCase().includes("ai sentiment") &&
-            !msg.toLowerCase().includes("dxy and us10y are using placeholder data"))
+            !msg
+              .toLowerCase()
+              .includes("dxy and us10y are using placeholder data"),
+        )
         .join(". ");
-      if (currentGlobalError && !currentGlobalError.endsWith(".") && currentGlobalError.length > 0) currentGlobalError += ". ";
+      if (
+        currentGlobalError &&
+        !currentGlobalError.endsWith(".") &&
+        currentGlobalError.length > 0
+      )
+        currentGlobalError += ". ";
 
-      const combinedError = currentGlobalError + (finalStockErrorMsg ? ` ${finalStockErrorMsg}` : '');
+      const combinedError =
+        currentGlobalError +
+        (finalStockErrorMsg ? ` ${finalStockErrorMsg}` : "");
 
       return {
         ...prev,
-        spy: newSpyData || prev.spy, 
-        spx: newSpxData || prev.spx, 
+        spy: newSpyData || prev.spy,
+        spx: newSpxData || prev.spx,
         globalError: combinedError.trim() || null,
-        lastUpdated: new Date().toISOString(), 
+        lastUpdated: new Date().toISOString(),
       };
     });
   }, []);
@@ -796,70 +1056,88 @@ const CryptoDashboardPage: FC = () => {
   // Data fetching is now handled by the refresh button click
   // No automatic data fetching on component mount
 
-
   const runAiAnalysis = useCallback(async () => {
     const currentData = appDataRef.current;
     if (currentData.loadingAi) return;
-    
-    const AI_CACHE_KEY = 'ai_analysis';
-    
+
+    const AI_CACHE_KEY = "ai_analysis";
+
     // Try to get from cache first
     const cached = localStorage.getItem(AI_CACHE_KEY);
     if (cached) {
       const { data, timestamp } = JSON.parse(cached);
-      if (Date.now() - timestamp < 15 * 60 * 1000) { // 15 minute cache
-        setAppData(prev => ({
+      if (Date.now() - timestamp < 15 * 60 * 1000) {
+        // 15 minute cache
+        setAppData((prev) => ({
           ...prev,
           aiSentiment: data,
-          loadingAi: false
+          loadingAi: false,
         }));
         return;
       }
     }
 
-    if (currentData.btc && currentData.eth && currentData.spy && currentData.spx && currentData.dxy && currentData.us10y) {
+    if (
+      currentData.btc &&
+      currentData.eth &&
+      currentData.spy &&
+      currentData.spx &&
+      currentData.dxy &&
+      currentData.us10y
+    ) {
       // Only run analysis if we don't have a recent result or data has changed significantly
-      const shouldRunAnalysis = !currentData.aiSentiment || 
-        (Date.now() - new Date(currentData.aiSentiment.timestamp || 0).getTime() > 15 * 60 * 1000);
+      const shouldRunAnalysis =
+        !currentData.aiSentiment ||
+        Date.now() -
+          new Date(currentData.aiSentiment.timestamp || 0).getTime() >
+          15 * 60 * 1000;
 
       if (!shouldRunAnalysis) return;
 
-      setAppData(prev => ({ ...prev, loadingAi: true }));
-      
+      setAppData((prev) => ({ ...prev, loadingAi: true }));
+
       try {
         const sentimentResult = await marketSentimentAnalysis({
-          btcPrice: currentData.btc.price, 
+          btcPrice: currentData.btc.price,
           ethPrice: currentData.eth.price,
-          spyPrice: currentData.spy.price, 
+          spyPrice: currentData.spy.price,
           spxPrice: currentData.spx.price,
-          dxyPrice: currentData.dxy.price, 
-          us10yPrice: currentData.us10y.price, 
+          dxyPrice: currentData.dxy.price,
+          us10yPrice: currentData.us10y.price,
         });
 
         // Only update if we got a fresh analysis or we don't have any analysis yet
         if (!sentimentResult.cached || !currentData.aiSentiment) {
-          setAppData(prev => {
+          setAppData((prev) => {
             let currentGlobalError = prev.globalError || "";
-            currentGlobalError = currentGlobalError.split(". ")
-              .filter(msg => !msg.toLowerCase().includes("ai sentiment analysis"))
-              .join(". ").trim();
-            
-            if (currentGlobalError && !currentGlobalError.endsWith(".") && currentGlobalError.length > 0) {
+            currentGlobalError = currentGlobalError
+              .split(". ")
+              .filter(
+                (msg) => !msg.toLowerCase().includes("ai sentiment analysis"),
+              )
+              .join(". ")
+              .trim();
+
+            if (
+              currentGlobalError &&
+              !currentGlobalError.endsWith(".") &&
+              currentGlobalError.length > 0
+            ) {
               currentGlobalError += ". ";
             }
 
             return {
-              ...prev, 
+              ...prev,
               aiSentiment: {
                 ...sentimentResult,
-                timestamp: new Date().toISOString()
-              }, 
-              loadingAi: false, 
-              globalError: currentGlobalError || null 
+                timestamp: new Date().toISOString(),
+              },
+              loadingAi: false,
+              globalError: currentGlobalError || null,
             };
           });
         } else {
-          setAppData(prev => ({ ...prev, loadingAi: false }));
+          setAppData((prev) => ({ ...prev, loadingAi: false }));
         }
       } catch (error) {
         console.error("Error in AI sentiment analysis:", error);
@@ -867,165 +1145,195 @@ const CryptoDashboardPage: FC = () => {
         if (error instanceof Error && error.message.includes("429")) {
           aiErrorMsg = "AI sentiment analysis rate limited. Will retry later.";
         }
-        
-        setAppData(prev => {
+
+        setAppData((prev) => {
           let currentGlobalError = prev.globalError || "";
-          currentGlobalError = currentGlobalError.split(". ")
-            .filter(msg => !msg.toLowerCase().includes("ai sentiment analysis failed due to rate limits"))
+          currentGlobalError = currentGlobalError
+            .split(". ")
+            .filter(
+              (msg) =>
+                !msg
+                  .toLowerCase()
+                  .includes("ai sentiment analysis failed due to rate limits"),
+            )
             .join(". ");
-          if (currentGlobalError && !currentGlobalError.endsWith(".") && currentGlobalError.length > 0) currentGlobalError += ". ";
-          
-          return { 
-            ...prev, 
-            aiSentiment: prev.aiSentiment || null, 
+          if (
+            currentGlobalError &&
+            !currentGlobalError.endsWith(".") &&
+            currentGlobalError.length > 0
+          )
+            currentGlobalError += ". ";
+
+          return {
+            ...prev,
+            aiSentiment: prev.aiSentiment || null,
             loadingAi: false,
-            globalError: (currentGlobalError + aiErrorMsg).trim() 
+            globalError: (currentGlobalError + aiErrorMsg).trim(),
           };
         });
       }
     } else {
-      if (!currentData.loading) { 
-         setAppData(prev => ({ ...prev, loadingAi: false, aiSentiment: null }));
+      if (!currentData.loading) {
+        setAppData((prev) => ({
+          ...prev,
+          loadingAi: false,
+          aiSentiment: null,
+        }));
       }
     }
   }, []);
 
-
   useEffect(() => {
-    const initialRunTimeout = setTimeout(() => { runAiAnalysis(); }, INITIAL_AI_ANALYSIS_DELAY_MS); 
+    const initialRunTimeout = setTimeout(() => {
+      runAiAnalysis();
+    }, INITIAL_AI_ANALYSIS_DELAY_MS);
     const aiInterval = setInterval(runAiAnalysis, AI_ANALYSIS_INTERVAL_MS);
-    return () => { clearTimeout(initialRunTimeout); clearInterval(aiInterval); };
+    return () => {
+      clearTimeout(initialRunTimeout);
+      clearInterval(aiInterval);
+    };
   }, [runAiAnalysis]);
 
-
   const navItems = [
-    { label: 'Metric' }, { label: 'Bitcoin (BTC)' }, { label: 'Ethereum (ETH)' },
-    { label: 'SPY' }, { label: 'S&P 500 (^GSPC)' }, { label: 'US Dollar (DXY)'}, {label: '10-Yr Yield (US10Y)'}
+    { label: "Metric" },
+    { label: "Bitcoin (BTC)" },
+    { label: "Ethereum (ETH)" },
+    { label: "SPY" },
+    { label: "S&P 500 (^GSPC)" },
+    { label: "US Dollar (DXY)" },
+    { label: "10-Yr Yield (US10Y)" },
   ];
 
-  const renderCoinData = (coin: CoinData | null, IconComponent: ElementType) => {
+  const renderCoinData = (
+    coin: CoinData | null,
+    IconComponent: ElementType,
+  ) => {
     const isBitcoin = IconComponent === Bitcoin;
-    const coinName = isBitcoin ? 'Bitcoin' : 'Ethereum';
-    
+    const coinName = isBitcoin ? "Bitcoin" : "Ethereum";
+
     // Handle server-side rendering and initial client render
-    if (typeof window === 'undefined' || !isClient) {
+    if (typeof window === "undefined" || !isClient) {
       return (
         <div className="space-y-3 p-1">
           <div className="p-4 text-center">Loading {coinName} data...</div>
         </div>
       );
     }
-    
+
     // Client-side rendering after initial hydration
     const isLoading = appData.loading && !coin;
-    
+
     return (
       <div className="space-y-3 p-1">
         {isLoading ? (
           <div className="p-4 text-center">Loading {coinName} data...</div>
         ) : !coin ? (
-          <div className="p-4 text-center">Data unavailable for {coinName}.</div>
+          <div className="p-4 text-center">
+            Data unavailable for {coinName}.
+          </div>
         ) : (
           <>
             <div className="flex items-center space-x-2 mb-2">
-              <Image 
-                data-ai-hint="coin logo" 
-                src={coin.image} 
-                alt={coin.name} 
-                width={32} 
-                height={32} 
-                className="rounded-full" 
+              <Image
+                data-ai-hint="coin logo"
+                src={coin.image}
+                alt={coin.name}
+                width={32}
+                height={32}
+                className="rounded-full"
               />
-              <ValueDisplay 
-                label="Price" 
-                value={coin.price} 
-                unit={coin.symbol.toUpperCase()} 
-                variant="highlight" 
-                isLoading={coin.status === 'loading'} 
-                valueClassName="text-accent" 
+              <ValueDisplay
+                label="Price"
+                value={coin.price}
+                unit={coin.symbol.toUpperCase()}
+                variant="highlight"
+                isLoading={coin.status === "loading"}
+                valueClassName="text-accent"
               />
             </div>
-            <ValueDisplay 
-              label="24h Change" 
-              value={`${coin.change24h?.toFixed(2) ?? 'N/A'}%`} 
-              valueClassName={coin.change24h >= 0 ? 'text-green-500' : 'text-red-500'} 
-              isLoading={coin.status === 'loading'} 
+            <ValueDisplay
+              label="24h Change"
+              value={`${coin.change24h?.toFixed(2) ?? "N/A"}%`}
+              valueClassName={
+                coin.change24h >= 0 ? "text-green-500" : "text-red-500"
+              }
+              isLoading={coin.status === "loading"}
             />
-            <ValueDisplay 
-              label="24h High" 
-              value={coin.high24h ?? 'N/A'} 
-              unit={coin.symbol.toUpperCase()} 
-              isLoading={coin.status === 'loading'} 
+            <ValueDisplay
+              label="24h High"
+              value={coin.high24h ?? "N/A"}
+              unit={coin.symbol.toUpperCase()}
+              isLoading={coin.status === "loading"}
             />
-            <ValueDisplay 
-              label="24h Low" 
-              value={coin.low24h ?? 'N/A'} 
-              unit={coin.symbol.toUpperCase()} 
-              isLoading={coin.status === 'loading'} 
+            <ValueDisplay
+              label="24h Low"
+              value={coin.low24h ?? "N/A"}
+              unit={coin.symbol.toUpperCase()}
+              isLoading={coin.status === "loading"}
             />
-            <ValueDisplay 
-              label="Volume" 
-              value={coin.volume24h ?? 'N/A'} 
-              unit={coin.symbol.toUpperCase()} 
-              isLoading={coin.status === 'loading'} 
+            <ValueDisplay
+              label="Volume"
+              value={coin.volume24h ?? "N/A"}
+              unit={coin.symbol.toUpperCase()}
+              isLoading={coin.status === "loading"}
             />
             <ValueDisplay
               label="Market Cap"
-              value={coin.marketCap ?? 'N/A'}
+              value={coin.marketCap ?? "N/A"}
               unit={coin.symbol.toUpperCase()}
-              isLoading={coin.status === 'loading'}
+              isLoading={coin.status === "loading"}
             />
             <ValueDisplay
               label="RSI (14)"
-              value={coin.rsi14?.toFixed(2) ?? 'N/A'}
+              value={coin.rsi14?.toFixed(2) ?? "N/A"}
               valueClassName={
                 coin.rsi14 !== undefined
                   ? coin.rsi14 >= 70
-                    ? 'text-red-500'
+                    ? "text-red-500"
                     : coin.rsi14 <= 30
-                      ? 'text-green-500'
-                      : ''
-                  : ''
+                      ? "text-green-500"
+                      : ""
+                  : ""
               }
-              isLoading={coin.status === 'loading'}
+              isLoading={coin.status === "loading"}
             />
             <ValueDisplay
               label="Signal"
-              value={coin.signal ? coin.signal.toUpperCase() : 'N/A'}
+              value={coin.signal ? coin.signal.toUpperCase() : "N/A"}
               valueClassName={
-                coin.signal === 'buy'
-                  ? 'text-green-500'
-                  : coin.signal === 'sell'
-                    ? 'text-red-500'
-                    : ''
+                coin.signal === "buy"
+                  ? "text-green-500"
+                  : coin.signal === "sell"
+                    ? "text-red-500"
+                    : ""
               }
-              isLoading={coin.status === 'loading'}
+              isLoading={coin.status === "loading"}
             />
             {/* Always render MA section but hide if no data */}
-            <div className={!coin.ma50 || !coin.ma200 ? 'hidden' : ''}>
+            <div className={!coin.ma50 || !coin.ma200 ? "hidden" : ""}>
               <ValueDisplay
                 label="MA 50"
-                value={coin.ma50?.toFixed(2) ?? 'N/A'}
+                value={coin.ma50?.toFixed(2) ?? "N/A"}
                 unit={coin.symbol.toUpperCase()}
-                isLoading={coin.status === 'loading'}
+                isLoading={coin.status === "loading"}
               />
               <ValueDisplay
                 label="MA 200"
-                value={coin.ma200?.toFixed(2) ?? 'N/A'}
+                value={coin.ma200?.toFixed(2) ?? "N/A"}
                 unit={coin.symbol.toUpperCase()}
-                isLoading={coin.status === 'loading'}
+                isLoading={coin.status === "loading"}
               />
               <ValueDisplay
                 label="MA Crossover"
-                value={coin.maCrossover === 'bullish' ? 'Bullish' : 'Bearish'}
-                isLoading={coin.status === 'loading'}
+                value={coin.maCrossover === "bullish" ? "Bullish" : "Bearish"}
+                isLoading={coin.status === "loading"}
               />
               {coin.ema20 !== undefined && (
                 <ValueDisplay
                   label="EMA 20"
                   value={coin.ema20.toFixed(2)}
                   unit={coin.symbol.toUpperCase()}
-                  isLoading={coin.status === 'loading'}
+                  isLoading={coin.status === "loading"}
                 />
               )}
               {coin.ema50 !== undefined && (
@@ -1033,7 +1341,7 @@ const CryptoDashboardPage: FC = () => {
                   label="EMA 50"
                   value={coin.ema50.toFixed(2)}
                   unit={coin.symbol.toUpperCase()}
-                  isLoading={coin.status === 'loading'}
+                  isLoading={coin.status === "loading"}
                 />
               )}
               {coin.ema200 !== undefined && (
@@ -1041,7 +1349,7 @@ const CryptoDashboardPage: FC = () => {
                   label="EMA 200"
                   value={coin.ema200.toFixed(2)}
                   unit={coin.symbol.toUpperCase()}
-                  isLoading={coin.status === 'loading'}
+                  isLoading={coin.status === "loading"}
                 />
               )}
               {coin.volumeProfilePrice !== undefined && (
@@ -1049,7 +1357,7 @@ const CryptoDashboardPage: FC = () => {
                   label="High Vol Price"
                   value={coin.volumeProfilePrice.toFixed(2)}
                   unit="USD"
-                  isLoading={coin.status === 'loading'}
+                  isLoading={coin.status === "loading"}
                 />
               )}
             </div>
@@ -1058,17 +1366,25 @@ const CryptoDashboardPage: FC = () => {
       </div>
     );
   };
-  
-  const renderStockData = (stock: StockData | null, IconComponent: ElementType) => {
+
+  const renderStockData = (
+    stock: StockData | null,
+    IconComponent: ElementType,
+  ) => {
     // Use a consistent title based on the stock symbol to prevent hydration mismatch
-    const title = stock?.symbol === 'SPY' ? 'SPDR S&P 500 ETF Trust' :
-                 stock?.symbol === '^GSPC' ? 'S&P 500 Index' :
-                 stock?.symbol === 'DXY' ? 'US Dollar Index' :
-                 stock?.symbol === 'US10Y' || stock?.symbol === '^TNX' ? 'US 10-Year Yield' :
-                 'Market Data';
+    const title =
+      stock?.symbol === "SPY"
+        ? "SPDR S&P 500 ETF Trust"
+        : stock?.symbol === "^GSPC"
+          ? "S&P 500 Index"
+          : stock?.symbol === "DXY"
+            ? "US Dollar Index"
+            : stock?.symbol === "US10Y" || stock?.symbol === "^TNX"
+              ? "US 10-Year Yield"
+              : "Market Data";
 
     // Handle server-side rendering and initial client render
-    if (typeof window === 'undefined' || !isClient) {
+    if (typeof window === "undefined" || !isClient) {
       return (
         <div className="space-y-3 p-1">
           <div className="p-4 text-center">Loading {title} data...</div>
@@ -1077,9 +1393,10 @@ const CryptoDashboardPage: FC = () => {
     }
 
     // Client-side rendering after initial hydration
-    const unit = (stock?.symbol === 'US10Y' || stock?.symbol === '^TNX') ? "%" : "USD";
-    const isPlaceholder = stock?.status === 'cached_error';
-    
+    const unit =
+      stock?.symbol === "US10Y" || stock?.symbol === "^TNX" ? "%" : "USD";
+    const isPlaceholder = stock?.status === "cached_error";
+
     return (
       <div className="space-y-3 p-1">
         {!stock ? (
@@ -1088,60 +1405,64 @@ const CryptoDashboardPage: FC = () => {
           <>
             <div className="flex items-center space-x-2 mb-2">
               <IconComponent className="h-6 w-6 text-muted-foreground" />
-              <ValueDisplay 
-                label="Price" 
-                value={stock.price} 
-                unit={unit} 
-                variant="highlight" 
-                isLoading={stock.status === 'loading'} 
-                valueClassName="text-accent" 
+              <ValueDisplay
+                label="Price"
+                value={stock.price}
+                unit={unit}
+                variant="highlight"
+                isLoading={stock.status === "loading"}
+                valueClassName="text-accent"
               />
             </div>
-            <ValueDisplay 
-              label="Change" 
-              value={stock.change?.toFixed(2) ?? 'N/A'} 
-              unit={unit} 
-              isLoading={stock.status === 'loading'} 
+            <ValueDisplay
+              label="Change"
+              value={stock.change?.toFixed(2) ?? "N/A"}
+              unit={unit}
+              isLoading={stock.status === "loading"}
             />
-            <ValueDisplay 
-              label="Change %" 
-              value={`${stock.changePercent?.toFixed(2) ?? '0.00'}%`} 
-              valueClassName={(stock.changePercent ?? 0) >= 0 ? 'text-green-500' : 'text-red-500'} 
-              isLoading={stock.status === 'loading'} 
+            <ValueDisplay
+              label="Change %"
+              value={`${stock.changePercent?.toFixed(2) ?? "0.00"}%`}
+              valueClassName={
+                (stock.changePercent ?? 0) >= 0
+                  ? "text-green-500"
+                  : "text-red-500"
+              }
+              isLoading={stock.status === "loading"}
             />
             {/* Always render volume but hide if 0 */}
-            <div className={!stock.volume ? 'hidden' : ''}>
+            <div className={!stock.volume ? "hidden" : ""}>
               <ValueDisplay
                 label="Volume"
                 value={stock.volume}
-                isLoading={stock.status === 'loading'}
+                isLoading={stock.status === "loading"}
               />
             </div>
             <ValueDisplay
               label="RSI (14)"
-              value={stock.rsi14?.toFixed(2) ?? 'N/A'}
+              value={stock.rsi14?.toFixed(2) ?? "N/A"}
               valueClassName={
                 stock.rsi14 !== undefined
                   ? stock.rsi14 >= 70
-                    ? 'text-red-500'
+                    ? "text-red-500"
                     : stock.rsi14 <= 30
-                      ? 'text-green-500'
-                      : ''
-                  : ''
+                      ? "text-green-500"
+                      : ""
+                  : ""
               }
-              isLoading={stock.status === 'loading'}
+              isLoading={stock.status === "loading"}
             />
             <ValueDisplay
               label="Signal"
-              value={stock.signal ? stock.signal.toUpperCase() : 'N/A'}
+              value={stock.signal ? stock.signal.toUpperCase() : "N/A"}
               valueClassName={
-                stock.signal === 'buy'
-                  ? 'text-green-500'
-                  : stock.signal === 'sell'
-                    ? 'text-red-500'
-                    : ''
+                stock.signal === "buy"
+                  ? "text-green-500"
+                  : stock.signal === "sell"
+                    ? "text-red-500"
+                    : ""
               }
-              isLoading={stock.status === 'loading'}
+              isLoading={stock.status === "loading"}
             />
             {isPlaceholder && (
               <p className="text-xs text-muted-foreground/80 text-center pt-1">
@@ -1157,80 +1478,85 @@ const CryptoDashboardPage: FC = () => {
   // Handle manual refresh
   const handleRefresh = useCallback(async () => {
     if (isRefreshing) return;
-    
+
     setIsRefreshing(true);
     const startTime = Date.now();
-    
+
     try {
       // Set loading state
-      setAppData(prev => ({
+      setAppData((prev) => ({
         ...prev,
-        globalError: 'Refreshing data...',
+        globalError: "Refreshing data...",
         loading: true,
-        loadingAi: true
+        loadingAi: true,
       }));
-      
+
       // Clear any existing errors
-      setAppData(prev => ({
+      setAppData((prev) => ({
         ...prev,
-        globalError: null
+        globalError: null,
       }));
-      
+
       // Fetch all data in parallel with force refresh
-      const [dxyResult, us10yResult, cryptoResult, stockResult] = await Promise.allSettled([
-        fetchDXYData(true).catch(e => {
-          console.error('Error in DXY fetch:', e);
-          return null;
-        }),
-        fetchUS10YData(true).catch(e => {
-          console.error('Error in US10Y fetch:', e);
-          return null;
-        }),
-        fetchCryptoData(true).catch(e => {
-          console.error('Error in crypto fetch:', e);
-          return null;
-        }),
-        fetchStockData(true).catch(e => {
-          console.error('Error in stock fetch:', e);
-          return null;
-        })
-      ]);
-      
+      const [dxyResult, us10yResult, cryptoResult, stockResult] =
+        await Promise.allSettled([
+          fetchDXYData(true).catch((e) => {
+            console.error("Error in DXY fetch:", e);
+            return null;
+          }),
+          fetchUS10YData(true).catch((e) => {
+            console.error("Error in US10Y fetch:", e);
+            return null;
+          }),
+          fetchCryptoData(true).catch((e) => {
+            console.error("Error in crypto fetch:", e);
+            return null;
+          }),
+          fetchStockData(true).catch((e) => {
+            console.error("Error in stock fetch:", e);
+            return null;
+          }),
+        ]);
+
       // Check if we have all required data for AI analysis
-      const hasAllData = [dxyResult, us10yResult, cryptoResult, stockResult].every(
-        result => result.status === 'fulfilled' && result.value !== null
+      const hasAllData = [
+        dxyResult,
+        us10yResult,
+        cryptoResult,
+        stockResult,
+      ].every(
+        (result) => result.status === "fulfilled" && result.value !== null,
       );
-      
+
       // Run AI analysis if we have all the required data
       if (hasAllData) {
         try {
           await runAiAnalysis();
         } catch (e) {
-          console.error('Error in AI analysis:', e);
+          console.error("Error in AI analysis:", e);
         }
       }
-      
+
       // Calculate refresh duration
       const refreshDuration = Date.now() - startTime;
-      
+
       // Clear loading state and update last updated time
-      setAppData(prev => ({
+      setAppData((prev) => ({
         ...prev,
         loading: false,
         loadingAi: false,
         lastUpdated: new Date().toISOString(),
-        globalError: null
+        globalError: null,
       }));
-      
+
       console.log(`Data refresh completed in ${refreshDuration}ms`);
-      
     } catch (error) {
-      console.error('Error during refresh:', error);
-      setAppData(prev => ({
+      console.error("Error during refresh:", error);
+      setAppData((prev) => ({
         ...prev,
-        globalError: `Error refreshing data: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        globalError: `Error refreshing data: ${error instanceof Error ? error.message : "Unknown error"}`,
         loading: false,
-        loadingAi: false
+        loadingAi: false,
       }));
     } finally {
       setIsRefreshing(false);
@@ -1238,34 +1564,51 @@ const CryptoDashboardPage: FC = () => {
   }, [isRefreshing]);
 
   // Helper function to get status that's consistent between server and client
-  const getStatus = (data: any): 'fresh' | 'cached_error' | 'error' | 'loading' | 'waiting' | null => {
+  const getStatus = (
+    data: any,
+  ): "fresh" | "cached_error" | "error" | "loading" | "waiting" | null => {
     // On server, always return 'loading' to match initial client render
-    if (typeof window === 'undefined') return 'loading';
-    
-    if (!data) return 'error';
-    if (data.status) return data.status as 'fresh' | 'cached_error' | 'error' | 'loading' | 'waiting';
-    if (data.isLoading) return 'loading';
-    if (data.error) return 'error';
-    if (data.lastFetched) return 'fresh';
-    return 'loading';
+    if (typeof window === "undefined") return "loading";
+
+    if (!data) return "error";
+    if (data.status)
+      return data.status as
+        | "fresh"
+        | "cached_error"
+        | "error"
+        | "loading"
+        | "waiting";
+    if (data.isLoading) return "loading";
+    if (data.error) return "error";
+    if (data.lastFetched) return "fresh";
+    return "loading";
   };
 
-  const hasLoadedData = isClient && (appData.btc || appData.eth || appData.spy || appData.spx || appData.dxy || appData.us10y);
+  const hasLoadedData =
+    isClient &&
+    (appData.btc ||
+      appData.eth ||
+      appData.spy ||
+      appData.spx ||
+      appData.dxy ||
+      appData.us10y);
 
   // Only render the welcome message on the client side
   const renderWelcomeMessage = () => {
     if (!isClient || hasLoadedData || isRefreshing) return null;
-    
+
     return (
       <div className="bg-primary/10 border border-primary text-primary p-6 rounded-lg mb-6 text-center">
         <p className="text-lg font-medium mb-2">Welcome to Crypto Pulse</p>
-        <p className="mb-4">Click the refresh button above to load the latest market data</p>
-        <button 
+        <p className="mb-4">
+          Click the refresh button above to load the latest market data
+        </p>
+        <button
           onClick={handleRefresh}
           disabled={isRefreshing}
           className="px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          {isRefreshing ? 'Loading...' : 'Load Data'}
+          {isRefreshing ? "Loading..." : "Load Data"}
         </button>
       </div>
     );
@@ -1274,7 +1617,7 @@ const CryptoDashboardPage: FC = () => {
   // Only render the error message on the client side
   const renderErrorMessage = () => {
     if (!isClient || !appData.globalError) return null;
-    
+
     return (
       <div className="bg-destructive/10 border border-destructive text-destructive p-3 rounded-md mb-4 text-sm">
         <strong>Notice:</strong> {appData.globalError}
@@ -1284,8 +1627,8 @@ const CryptoDashboardPage: FC = () => {
 
   return (
     <div className="flex flex-col min-h-screen bg-background text-foreground font-sans">
-      <DashboardHeader 
-        title="Crypto Pulse" 
+      <DashboardHeader
+        title="Crypto Pulse"
         navItems={navItems}
         onRefresh={handleRefresh}
         isLoading={isRefreshing}
@@ -1304,138 +1647,215 @@ const CryptoDashboardPage: FC = () => {
             {renderCoinData(appData.btc, Bitcoin)}
           </DataCard>
           <SignalCard />
-          <DataCard title="Signal History" icon={Brain} status="fresh" className="xl:col-span-1">
+          <DataCard
+            title="Signal History"
+            icon={Brain}
+            status="fresh"
+            className="xl:col-span-1"
+          >
             <SignalHistory />
           </DataCard>
 
-          <DataCard 
-            title="Ethereum (ETH)" 
-            icon={Shapes} 
-            status={getStatus(appData.eth)} 
+          <DataCard
+            title="Ethereum (ETH)"
+            icon={Shapes}
+            status={getStatus(appData.eth)}
             className="xl:col-span-1"
           >
             {renderCoinData(appData.eth, Shapes)}
           </DataCard>
-          
-          <DataCard 
-            title={appData.spy?.name || "SPDR S&P 500 ETF (SPY)"} 
-            icon={Briefcase} 
+
+          <DataCard
+            title={appData.spy?.name || "SPDR S&P 500 ETF (SPY)"}
+            icon={Briefcase}
             status={getStatus(appData.spy)}
           >
             {renderStockData(appData.spy, Briefcase)}
           </DataCard>
 
-          <DataCard 
-            title={appData.spx?.name || "S&P 500 Index (^GSPC)"} 
-            icon={BarChart3} 
+          <DataCard
+            title={appData.spx?.name || "S&P 500 Index (^GSPC)"}
+            icon={BarChart3}
             status={getStatus(appData.spx)}
           >
             {renderStockData(appData.spx, BarChart3)}
           </DataCard>
 
-          <DataCard 
-            title={appData.dxy?.name || "US Dollar Index (DXY)"} 
-            icon={DollarSign} 
+          <DataCard
+            title={appData.dxy?.name || "US Dollar Index (DXY)"}
+            icon={DollarSign}
             status={getStatus(appData.dxy)}
           >
             {renderStockData(appData.dxy, DollarSign)}
           </DataCard>
 
-          <DataCard 
-            title={appData.us10y?.name || "US 10-Year Yield (^TNX)"} 
-            icon={Landmark} 
+          <DataCard
+            title={appData.us10y?.name || "US 10-Year Yield (^TNX)"}
+            icon={Landmark}
             status={getStatus(appData.us10y)}
           >
             {renderStockData(appData.us10y, Landmark)}
           </DataCard>
 
-          <DataCard 
-            title="Fear & Greed Index" 
-            icon={Gauge} 
-            status={appData.fearGreed?.value_classification || ''} 
+          <DataCard
+            title="Fear & Greed Index"
+            icon={Gauge}
+            status={appData.fearGreed?.value_classification || ""}
             className="sm:col-span-1"
           >
             {!isClient ? (
-              <div className="p-4 text-center">Loading Fear & Greed data...</div>
+              <div className="p-4 text-center">
+                Loading Fear & Greed data...
+              </div>
             ) : appData.fearGreed ? (
               <div className="text-center py-4">
-                <p className="text-4xl font-bold text-primary">{appData.fearGreed.value}</p>
-                <p className="text-muted-foreground">{appData.fearGreed.value_classification}</p>
+                <p className="text-4xl font-bold text-primary">
+                  {appData.fearGreed.value}
+                </p>
+                <p className="text-muted-foreground">
+                  {appData.fearGreed.value_classification}
+                </p>
                 <div className="w-full bg-gray-200 rounded-full h-2.5 mt-2">
-                  <div 
+                  <div
                     className={`h-2.5 rounded-full ${
-                      appData.fearGreed.value < 20 ? 'bg-red-600' : 
-                      appData.fearGreed.value < 40 ? 'bg-orange-400' : 
-                      appData.fearGreed.value < 60 ? 'bg-yellow-400' : 
-                      appData.fearGreed.value < 80 ? 'bg-lime-400' : 'bg-green-600'
-                    }`} 
+                      appData.fearGreed.value < 20
+                        ? "bg-red-600"
+                        : appData.fearGreed.value < 40
+                          ? "bg-orange-400"
+                          : appData.fearGreed.value < 60
+                            ? "bg-yellow-400"
+                            : appData.fearGreed.value < 80
+                              ? "bg-lime-400"
+                              : "bg-green-600"
+                    }`}
                     style={{ width: `${appData.fearGreed.value}%` }}
                   ></div>
                 </div>
                 <p className="text-xs text-muted-foreground mt-2">
-                  {appData.fearGreed.value < 20 ? 'Extreme Fear' : 
-                   appData.fearGreed.value < 40 ? 'Fear' : 
-                   appData.fearGreed.value < 60 ? 'Neutral' : 
-                   appData.fearGreed.value < 80 ? 'Greed' : 'Extreme Greed'}
+                  {appData.fearGreed.value < 20
+                    ? "Extreme Fear"
+                    : appData.fearGreed.value < 40
+                      ? "Fear"
+                      : appData.fearGreed.value < 60
+                        ? "Neutral"
+                        : appData.fearGreed.value < 80
+                          ? "Greed"
+                          : "Extreme Greed"}
                 </p>
               </div>
             ) : appData.loading ? (
               <p className="text-center p-4">Loading F&G Index...</p>
             ) : (
-              <p className="text-center p-4">Fear & Greed Index data unavailable.</p>
+              <p className="text-center p-4">
+                Fear & Greed Index data unavailable.
+              </p>
             )}
           </DataCard>
 
           {/* Correlation Panel */}
-          <DataCard title="Market Correlations" icon={BarChart2} status="fresh" className="sm:col-span-2 lg:col-span-2">
+          <DataCard
+            title="Market Correlations"
+            icon={BarChart2}
+            status="fresh"
+            className="sm:col-span-2 lg:col-span-2"
+          >
             {correlationData.length > 0 ? (
               <CorrelationPanel data={correlationData} />
             ) : (
               <p className="text-center p-4">Calculating correlations...</p>
             )}
           </DataCard>
-          <DataCard title="BTC Chart" icon={BarChart3} status="fresh" className="sm:col-span-2 lg:col-span-2">
+          <DataCard
+            title="BTC Chart"
+            icon={BarChart3}
+            status="fresh"
+            className="sm:col-span-2 lg:col-span-2"
+          >
             <MarketChart asset="BTC" interval="5m" />
           </DataCard>
 
-          <DataCard title="AI Market Sentiment" icon={Brain} status={appData.aiSentiment?.status ?? (appData.loadingAi ? 'loading' : 'error')} className="sm:col-span-2 lg:col-span-2">
+          <DataCard
+            title="AI Market Sentiment"
+            icon={Brain}
+            status={
+              appData.aiSentiment?.status ??
+              (appData.loadingAi ? "loading" : "error")
+            }
+            className="sm:col-span-2 lg:col-span-2"
+          >
             {appData.loadingAi ? (
-              <p className="text-center p-4">Generating AI sentiment analysis...</p>
+              <p className="text-center p-4">
+                Generating AI sentiment analysis...
+              </p>
             ) : appData.aiSentiment ? (
               <div className="space-y-2 text-sm p-1">
-                <ValueDisplay label="Overall Sentiment" value={appData.aiSentiment.overallSentiment} />
-                <ValueDisplay label="Bitcoin (BTC) Sentiment" value={appData.aiSentiment.btcSentiment} />
-                <ValueDisplay label="Ethereum (ETH) Sentiment" value={appData.aiSentiment.ethSentiment} />
-                <ValueDisplay label="Stock Market Sentiment" value={appData.aiSentiment.stockMarketSentiment} />
+                <ValueDisplay
+                  label="Overall Sentiment"
+                  value={appData.aiSentiment.overallSentiment}
+                />
+                <ValueDisplay
+                  label="Bitcoin (BTC) Sentiment"
+                  value={appData.aiSentiment.btcSentiment}
+                />
+                <ValueDisplay
+                  label="Ethereum (ETH) Sentiment"
+                  value={appData.aiSentiment.ethSentiment}
+                />
+                <ValueDisplay
+                  label="Stock Market Sentiment"
+                  value={appData.aiSentiment.stockMarketSentiment}
+                />
               </div>
-            ) : (appData.btc && appData.eth && appData.spy && appData.spx && appData.dxy && appData.us10y) ? (
-              <p className="text-center p-4">AI sentiment analysis will be generated shortly. Waiting for next scheduled run.</p>
+            ) : appData.btc &&
+              appData.eth &&
+              appData.spy &&
+              appData.spx &&
+              appData.dxy &&
+              appData.us10y ? (
+              <p className="text-center p-4">
+                AI sentiment analysis will be generated shortly. Waiting for
+                next scheduled run.
+              </p>
             ) : (
               <p className="text-center p-4">AI sentiment data unavailable.</p>
             )}
           </DataCard>
 
-          <DataCard 
-            title="Top 7 Trending Coins" 
-            icon={TrendingUp} 
-            status={appData.trending?.length ? 'active' : ''} 
+          <DataCard
+            title="Top 7 Trending Coins"
+            icon={TrendingUp}
+            status={appData.trending?.length ? "active" : ""}
             className="sm:col-span-1"
           >
             {!isClient ? (
-              <div className="p-4 text-center">Loading trending coins data...</div>
+              <div className="p-4 text-center">
+                Loading trending coins data...
+              </div>
             ) : appData.trending && appData.trending.length > 0 ? (
               <div className="space-y-2">
                 {appData.trending.map((coin, index) => (
-                  <div key={index} className="flex items-center justify-between p-2 hover:bg-muted/50 rounded-lg transition-colors">
+                  <div
+                    key={index}
+                    className="flex items-center justify-between p-2 hover:bg-muted/50 rounded-lg transition-colors"
+                  >
                     <div className="flex items-center space-x-2">
-                      <span className="font-medium">{coin.symbol.toUpperCase()}</span>
-                      <span className="text-sm text-muted-foreground">{coin.name}</span>
+                      <span className="font-medium">
+                        {coin.symbol.toUpperCase()}
+                      </span>
+                      <span className="text-sm text-muted-foreground">
+                        {coin.name}
+                      </span>
                     </div>
                     <div className="flex items-center space-x-2">
-                      <span className={`text-sm font-medium ${coin.price_change_percentage_24h >= 0 ? 'text-green-500' : 'text-red-500'}`}>
-                        {coin.price_change_percentage_24h >= 0 ? '+' : ''}{coin.price_change_percentage_24h?.toFixed(2)}%
+                      <span
+                        className={`text-sm font-medium ${coin.price_change_percentage_24h >= 0 ? "text-green-500" : "text-red-500"}`}
+                      >
+                        {coin.price_change_percentage_24h >= 0 ? "+" : ""}
+                        {coin.price_change_percentage_24h?.toFixed(2)}%
                       </span>
-                      <span className="text-sm font-medium">${coin.current_price?.toLocaleString()}</span>
+                      <span className="text-sm font-medium">
+                        ${coin.current_price?.toLocaleString()}
+                      </span>
                     </div>
                   </div>
                 ))}
@@ -1443,19 +1863,45 @@ const CryptoDashboardPage: FC = () => {
             ) : appData.loading ? (
               <p className="text-center p-4">Loading trending coins...</p>
             ) : (
-              <p className="text-center p-4">Trending coins data unavailable.</p>
+              <p className="text-center p-4">
+                Trending coins data unavailable.
+              </p>
             )}
           </DataCard>
         </div>
 
         <footer className="text-center mt-8 py-4 border-t">
-          {appData.lastUpdated && <p className="text-xs text-muted-foreground">Last updated: {new Date(appData.lastUpdated).toLocaleString()}</p>}
+          {appData.lastUpdated && (
+            <p className="text-xs text-muted-foreground">
+              Last updated: {new Date(appData.lastUpdated).toLocaleString()}
+            </p>
+          )}
           <p className="text-xs text-muted-foreground mt-1">
-            Crypto Pulse - Financial data displayed is for informational purposes only.
-            {!FMP_API_KEY && " Live SPY/SPX data requires NEXT_PUBLIC_FMP_API_KEY."}
+            Crypto Pulse - Financial data displayed is for informational
+            purposes only.
+            {!FMP_API_KEY &&
+              " Live SPY/SPX data requires NEXT_PUBLIC_FMP_API_KEY."}
           </p>
-           <p className="text-xs text-muted-foreground mt-1">
-            Crypto data powered by <a href="https://www.coingecko.com" target="_blank" rel="noopener noreferrer" className="underline hover:text-primary">CoinGecko</a> and <a href="https://alternative.me/crypto/fear-and-greed-index/" target="_blank" rel="noopener noreferrer" className="underline hover:text-primary">alternative.me</a>.
+          <p className="text-xs text-muted-foreground mt-1">
+            Crypto data powered by{" "}
+            <a
+              href="https://www.coingecko.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-primary"
+            >
+              CoinGecko
+            </a>{" "}
+            and{" "}
+            <a
+              href="https://alternative.me/crypto/fear-and-greed-index/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-primary"
+            >
+              alternative.me
+            </a>
+            .
             {FMP_API_KEY && " SPY/SPX data powered by Financial Modeling Prep."}
           </p>
         </footer>
@@ -1465,5 +1911,3 @@ const CryptoDashboardPage: FC = () => {
 };
 
 export default CryptoDashboardPage;
-
-    

--- a/src/lib/marketData.ts
+++ b/src/lib/marketData.ts
@@ -1,27 +1,34 @@
-import axios from 'axios';
+import axios from "axios";
 
 // Cache for rate limiting
 let lastFetchTime = 0;
 const MIN_FETCH_INTERVAL = 1000; // 1 second between API calls
 
-async function fetchWithRetry(url: string, retries = 2, delay = 1000): Promise<any> {
+async function fetchWithRetry(
+  url: string,
+  retries = 2,
+  delay = 1000,
+): Promise<any> {
   try {
-    await new Promise(resolve => 
-      setTimeout(resolve, Math.max(0, MIN_FETCH_INTERVAL - (Date.now() - lastFetchTime)))
+    await new Promise((resolve) =>
+      setTimeout(
+        resolve,
+        Math.max(0, MIN_FETCH_INTERVAL - (Date.now() - lastFetchTime)),
+      ),
     );
-    
+
     const response = await axios.get(url, { timeout: 5000 });
     lastFetchTime = Date.now();
-    
+
     if (!response.data) {
-      throw new Error('Empty response data');
+      throw new Error("Empty response data");
     }
-    
+
     return response.data;
   } catch (error) {
     console.warn(`API call failed (${retries} retries left):`, error.message);
     if (retries <= 0) throw error;
-    await new Promise(resolve => setTimeout(resolve, delay));
+    await new Promise((resolve) => setTimeout(resolve, delay));
     return fetchWithRetry(url, retries - 1, delay * 2);
   }
 }
@@ -31,56 +38,64 @@ const DXY_RANGE = { min: 70, max: 120 };
 const US10Y_RANGE = { min: 0, max: 20 };
 
 export function validateTreasuryYield(yieldValue: number): boolean {
-  return !isNaN(yieldValue) && yieldValue >= US10Y_RANGE.min && yieldValue <= US10Y_RANGE.max;
+  return (
+    !isNaN(yieldValue) &&
+    yieldValue >= US10Y_RANGE.min &&
+    yieldValue <= US10Y_RANGE.max
+  );
 }
 
 export function validateDXY(dxyValue: number): boolean {
-  return !isNaN(dxyValue) && dxyValue >= DXY_RANGE.min && dxyValue <= DXY_RANGE.max;
+  return (
+    !isNaN(dxyValue) && dxyValue >= DXY_RANGE.min && dxyValue <= DXY_RANGE.max
+  );
 }
 
 // Fetch DXY from multiple sources
 // Cache for DXY data
-let cachedDXY: { value: number; source: string; timestamp: number } | null = null;
+let cachedDXY: { value: number; source: string; timestamp: number } | null =
+  null;
 
 export async function fetchDXY(): Promise<{ value: number; source: string }> {
-  // Return cached data if it's fresh (less than 1 hour old)
-  if (cachedDXY && (Date.now() - cachedDXY.timestamp < 3600000)) {
+  // Return cached data if it's fresh (less than 15 minutes old)
+  if (cachedDXY && Date.now() - cachedDXY.timestamp < 900000) {
     return { value: cachedDXY.value, source: `${cachedDXY.source} (cached)` };
   }
 
   const sources = [
     {
-      name: 'FRED',
+      name: "FRED",
       fetch: async () => {
         const url = `https://api.stlouisfed.org/fred/series/observations?series_id=DTWEXBGS&api_key=${process.env.NEXT_PUBLIC_FRED_API_KEY}&file_type=json&limit=1&sort_order=desc`;
         const data = await fetchWithRetry(url);
         const value = parseFloat(data?.observations?.[0]?.value);
         return { value, valid: validateDXY(value) };
-      }
+      },
     },
     {
-      name: 'Financial Modeling Prep',
+      name: "Financial Modeling Prep",
       fetch: async () => {
         const url = `https://financialmodelingprep.com/api/v3/quote/DXY?apikey=${process.env.NEXT_PUBLIC_FMP_API_KEY}`;
         const data = await fetchWithRetry(url);
         const value = data?.[0]?.price;
         return { value, valid: validateDXY(value) };
-      }
-    }
+      },
+    },
   ];
 
   // Try to get from localStorage if no fresh cache
-  if (typeof window !== 'undefined') {
+  if (typeof window !== "undefined") {
     try {
-      const cached = localStorage.getItem('dxy_cache');
+      const cached = localStorage.getItem("dxy_cache");
       if (cached) {
         const { value, source, timestamp } = JSON.parse(cached);
-        if (Date.now() - timestamp < 86400000) { // 24 hours
+        if (Date.now() - timestamp < 86400000) {
+          // 24 hours
           return { value, source: `${source} (cached)` };
         }
       }
     } catch (e) {
-      console.warn('Error reading DXY from cache:', e);
+      console.warn("Error reading DXY from cache:", e);
     }
   }
 
@@ -91,8 +106,8 @@ export async function fetchDXY(): Promise<{ value: number; source: string }> {
       if (valid) {
         // Update cache
         cachedDXY = { value, source: source.name, timestamp: Date.now() };
-        if (typeof window !== 'undefined') {
-          localStorage.setItem('dxy_cache', JSON.stringify(cachedDXY));
+        if (typeof window !== "undefined") {
+          localStorage.setItem("dxy_cache", JSON.stringify(cachedDXY));
         }
         return { value, source: source.name };
       }
@@ -100,62 +115,69 @@ export async function fetchDXY(): Promise<{ value: number; source: string }> {
       console.warn(`Failed to fetch DXY from ${source.name}:`, error);
     }
   }
-  
+
   // If all sources fail, try to return the last known good value if available
   if (cachedDXY) {
-    return { 
-      value: cachedDXY.value, 
-      source: `${cachedDXY.source} (last known value)` 
+    return {
+      value: cachedDXY.value,
+      source: `${cachedDXY.source} (last known value)`,
     };
   }
 
-  throw new Error('Failed to fetch DXY from all sources and no cache available');
+  throw new Error(
+    "Failed to fetch DXY from all sources and no cache available",
+  );
 }
 
 // Fetch 10-Year Treasury Yield from multiple sources
 // Cache for US10Y data
-let cachedUS10Y: { value: number; source: string; timestamp: number } | null = null;
+let cachedUS10Y: { value: number; source: string; timestamp: number } | null =
+  null;
 
 export async function fetchUS10Y(): Promise<{ value: number; source: string }> {
   // Return cached data if it's fresh (less than 1 hour old)
-  if (cachedUS10Y && (Date.now() - cachedUS10Y.timestamp < 3600000)) {
-    return { value: cachedUS10Y.value, source: `${cachedUS10Y.source} (cached)` };
+  if (cachedUS10Y && Date.now() - cachedUS10Y.timestamp < 3600000) {
+    return {
+      value: cachedUS10Y.value,
+      source: `${cachedUS10Y.source} (cached)`,
+    };
   }
 
-  const today = new Date().toISOString().split('T')[0];
+  const today = new Date().toISOString().split("T")[0];
   const sources = [
     {
-      name: 'FRED',
+      name: "FRED",
       fetch: async () => {
         const url = `https://api.stlouisfed.org/fred/series/observations?series_id=DGS10&api_key=${process.env.NEXT_PUBLIC_FRED_API_KEY}&file_type=json&limit=1&sort_order=desc`;
         const data = await fetchWithRetry(url);
         const value = parseFloat(data?.observations?.[0]?.value);
         return { value, valid: validateTreasuryYield(value) };
-      }
+      },
     },
     {
-      name: 'Financial Modeling Prep',
+      name: "Financial Modeling Prep",
       fetch: async () => {
         const url = `https://financialmodelingprep.com/api/v4/treasury?from=${today}&to=${today}&apikey=${process.env.NEXT_PUBLIC_FMP_API_KEY}`;
         const data = await fetchWithRetry(url);
-        const value = parseFloat(data?.[0]?.['10Y']);
+        const value = parseFloat(data?.[0]?.["10Y"]);
         return { value, valid: validateTreasuryYield(value) };
-      }
-    }
+      },
+    },
   ];
 
   // Try to get from localStorage if no fresh cache
-  if (typeof window !== 'undefined') {
+  if (typeof window !== "undefined") {
     try {
-      const cached = localStorage.getItem('us10y_cache');
+      const cached = localStorage.getItem("us10y_cache");
       if (cached) {
         const { value, source, timestamp } = JSON.parse(cached);
-        if (Date.now() - timestamp < 86400000) { // 24 hours
+        if (Date.now() - timestamp < 86400000) {
+          // 24 hours
           return { value, source: `${source} (cached)` };
         }
       }
     } catch (e) {
-      console.warn('Error reading US10Y from cache:', e);
+      console.warn("Error reading US10Y from cache:", e);
     }
   }
 
@@ -166,8 +188,8 @@ export async function fetchUS10Y(): Promise<{ value: number; source: string }> {
       if (valid) {
         // Update cache
         cachedUS10Y = { value, source: source.name, timestamp: Date.now() };
-        if (typeof window !== 'undefined') {
-          localStorage.setItem('us10y_cache', JSON.stringify(cachedUS10Y));
+        if (typeof window !== "undefined") {
+          localStorage.setItem("us10y_cache", JSON.stringify(cachedUS10Y));
         }
         return { value, source: source.name };
       }
@@ -175,14 +197,16 @@ export async function fetchUS10Y(): Promise<{ value: number; source: string }> {
       console.warn(`Failed to fetch US10Y from ${source.name}:`, error);
     }
   }
-  
+
   // If all sources fail, try to return the last known good value if available
   if (cachedUS10Y) {
-    return { 
-      value: cachedUS10Y.value, 
-      source: `${cachedUS10Y.source} (last known value)` 
+    return {
+      value: cachedUS10Y.value,
+      source: `${cachedUS10Y.source} (last known value)`,
     };
   }
 
-  throw new Error('Failed to fetch US10Y from all sources and no cache available');
+  throw new Error(
+    "Failed to fetch US10Y from all sources and no cache available",
+  );
 }


### PR DESCRIPTION
## Summary
- fetch DXY from FRED in API route with a 15m cache
- update client cache duration
- shorten server cache in marketData helper
- mention FRED caching in README
- mark DXY task done in TASKS

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b36a468a08323a3de53988b3dfc3b