### PR TITLE
Implement FRED DXY cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Personal dashboard for tracking Bitcoin and SPX/SPY price action and technical i
 For a simple example that fetches macro data only when you click refresh, visit
 `/refresh-demo` after starting the development server. This page displays the
 current US Dollar Index (DXY) and 10-Year Treasury Yield using the free FRED
-API through the project's API routes.
+API through the project's API routes. DXY data is cached for 15 minutes on the
+server to stay within FRED rate limits.
 
 ## Data Sources
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -3,7 +3,7 @@
 > **Note:** Focused on essential trading features for Bitcoin and SPX/SPY
 
 ## Top Priority Tasks
-- [ ] Integrate real-time DXY data from FRED API and cache for 15 minutes
+- [x] Integrate real-time DXY data from FRED API and cache for 15 minutes
 - [ ] Fetch 10-Year Treasury Yield (US10Y) from Treasury/FRED and update hourly
 - [ ] Display rolling 1-hour BTC vs SPX/SPY correlations, refresh every 5 minutes
 - [ ] Add 1-hour ATR widget with alert when ATR > 1.5× 20-day average

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -159,7 +159,7 @@ const CryptoDashboardPage: FC = () => {
   // Fetch DXY data from our API route
   const fetchDXYData = useCallback(async (forceRefresh = false) => {
     const CACHE_KEY = 'dxy_data';
-    const CACHE_DURATION = 30 * 60 * 1000; // 30 minutes cache
+    const CACHE_DURATION = 15 * 60 * 1000; // 15 minutes cache
     
     // Set loading state
     setAppData(prev => ({

--- a/src/lib/marketData.ts
+++ b/src/lib/marketData.ts
@@ -43,8 +43,8 @@ export function validateDXY(dxyValue: number): boolean {
 let cachedDXY: { value: number; source: string; timestamp: number } | null = null;
 
 export async function fetchDXY(): Promise<{ value: number; source: string }> {
-  // Return cached data if it's fresh (less than 1 hour old)
-  if (cachedDXY && (Date.now() - cachedDXY.timestamp < 3600000)) {
+  // Return cached data if it's fresh (less than 15 minutes old)
+  if (cachedDXY && (Date.now() - cachedDXY.timestamp < 900000)) {
     return { value: cachedDXY.value, source: `${cachedDXY.source} (cached)` };
   }
 


### PR DESCRIPTION
## Summary
- fetch DXY from FRED with 15 minute cache
- trim server cache interval in `marketData`
- shorten client cache duration
- mark DXY task complete and mention cache in docs

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b36a468a08323a3de53988b3dfc3b