### PR TITLE
Add ATR widget and API

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -44,7 +44,7 @@
 ### 🛠 Technical Indicators
 - [ ] RSI (14)
 - [ ] MACD (12, 26, 9)
-- [ ] ATR (14) for position sizing
+- [x] ATR (14) for position sizing
 
 ### 💧 Volume & Liquidity
 - [ ] BTC funding-rates widget

--- a/src/__tests__/indicators.test.ts
+++ b/src/__tests__/indicators.test.ts
@@ -1,4 +1,4 @@
-import { exponentialMovingAverage, rsi, bollingerBands, volumeSMA } from '../lib/indicators';
+import { exponentialMovingAverage, rsi, bollingerBands, volumeSMA, averageTrueRange, OHLC } from '../lib/indicators';
 
 describe('indicator calculations', () => {
   it('ema', () => {
@@ -15,6 +15,15 @@ describe('indicator calculations', () => {
   });
   it('volumeSMA', () => {
     const val = volumeSMA([1,2,3,4,5], 3);
+    expect(val).toBeGreaterThan(0);
+  });
+  it('ATR', () => {
+    const data: OHLC[] = [
+      { high: 2, low: 1, close: 1.5 },
+      { high: 3, low: 1.5, close: 2 },
+      { high: 4, low: 2, close: 3 },
+    ];
+    const val = averageTrueRange(data, 2);
     expect(val).toBeGreaterThan(0);
   });
 });

--- a/src/app/api/atr/route.ts
+++ b/src/app/api/atr/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { fetchIntradayCandles, fetchDailyCandles } from '@/lib/data/fmp';
+import { averageTrueRange } from '@/lib/indicators';
+
+interface Cached {
+  data: { atr1h: number; atr20d: number };
+  ts: number;
+}
+
+let cache: Cached | null = null;
+const CACHE_DURATION = 15 * 60 * 1000; // 15 minutes
+
+export async function GET() {
+  if (cache && Date.now() - cache.ts < CACHE_DURATION) {
+    return NextResponse.json({ ...cache.data, status: 'cached' });
+  }
+  try {
+    const intraday = await fetchIntradayCandles('BTCUSD', 13); // ~1h
+    const daily = await fetchDailyCandles('BTCUSD', 21); // 20 day ATR
+    const atr1h = averageTrueRange(intraday, 12);
+    const atr20d = averageTrueRange(daily, 20);
+    cache = { data: { atr1h, atr20d }, ts: Date.now() };
+    return NextResponse.json({ atr1h, atr20d, status: 'fresh' });
+  } catch (e) {
+    console.error('ATR route error', e);
+    if (cache) return NextResponse.json({ ...cache.data, status: 'cached_error' });
+    return NextResponse.json({ atr1h: 0, atr20d: 0, status: 'error' });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,6 +38,7 @@ import { CorrelationPanel } from "@/components/CorrelationPanel";
 import SignalCard from "@/components/SignalCard";
 import MarketChart from "@/components/MarketChart";
 import SignalHistory from "@/components/SignalHistory";
+import AtrWidget from "@/components/AtrWidget";
 import { Orchestrator } from "@/lib/agents/Orchestrator";
 import { DataCollector } from "@/lib/agents/DataCollector";
 import { IndicatorEngine } from "@/lib/agents/IndicatorEngine";
@@ -1751,6 +1752,7 @@ const CryptoDashboardPage: FC = () => {
               <p className="text-center p-4">Calculating correlations...</p>
             )}
           </DataCard>
+          <AtrWidget />
           <SignalCard />
           <DataCard
             title="Signal History"

--- a/src/components/AtrWidget.tsx
+++ b/src/components/AtrWidget.tsx
@@ -1,0 +1,48 @@
+'use client';
+import { useEffect, useState } from 'react';
+import DataCard from '@/components/DataCard';
+
+interface AtrResp {
+  atr1h: number;
+  atr20d: number;
+  status: string;
+}
+
+export default function AtrWidget() {
+  const [data, setData] = useState<AtrResp | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch('/api/atr');
+        if (!res.ok) throw new Error('API error');
+        const json = await res.json();
+        setData(json);
+      } catch (e) {
+        console.error('Failed to fetch ATR', e);
+      }
+    };
+    fetchData();
+    const id = setInterval(fetchData, 15 * 60 * 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const ratio = data && data.atr20d ? data.atr1h / data.atr20d : 0;
+  const alert = ratio > 1.5;
+
+  return (
+    <DataCard title="BTC 1h ATR">
+      {data ? (
+        <div className="text-center space-y-1">
+          <p className="text-2xl font-bold">{data.atr1h.toFixed(2)}</p>
+          <p className="text-sm text-muted-foreground">20d Avg {data.atr20d.toFixed(2)}</p>
+          {alert && (
+            <p className="text-sm text-red-600 font-medium">High volatility</p>
+          )}
+        </div>
+      ) : (
+        <p className="text-center p-4">Loading ATR...</p>
+      )}
+    </DataCard>
+  );
+}

--- a/src/lib/indicators.ts
+++ b/src/lib/indicators.ts
@@ -79,3 +79,28 @@ export function bollingerBands(
 export function volumeSMA(volumes: number[], period: number): number {
   return simpleMovingAverage(volumes, period);
 }
+
+export interface OHLC {
+  high: number;
+  low: number;
+  close: number;
+}
+
+export function trueRange(curr: OHLC, prevClose: number): number {
+  const highLow = curr.high - curr.low;
+  const highClose = Math.abs(curr.high - prevClose);
+  const lowClose = Math.abs(curr.low - prevClose);
+  return Math.max(highLow, highClose, lowClose);
+}
+
+export function averageTrueRange(data: OHLC[], period: number): number {
+  if (data.length < period + 1) return 0;
+  const trs: number[] = [];
+  for (let i = data.length - period; i < data.length; i++) {
+    const prev = data[i - 1];
+    const curr = data[i];
+    trs.push(trueRange(curr, prev.close));
+  }
+  const sum = trs.reduce((a, b) => a + b, 0);
+  return sum / period;
+}


### PR DESCRIPTION
## Summary
- add ATR calculation utilities
- expose /api/atr endpoint
- create `AtrWidget` component and show on dashboard
- implement ATR test case
- mark ATR task complete in TASKS.md

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c6c1efe2c8323b6dcd199ea64bcea