### PR TITLE
Add order book wall detection

### DIFF
--- a/src/app/api/orderbook/route.ts
+++ b/src/app/api/orderbook/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+
+interface DepthCache {
+  data: any;
+  ts: number;
+}
+
+let cache: DepthCache | null = null;
+const CACHE_DURATION = 15 * 1000; // 15 seconds
+
+export async function GET() {
+  if (cache && Date.now() - cache.ts < CACHE_DURATION) {
+    return NextResponse.json({ ...cache.data, status: 'cached' });
+  }
+  try {
+    const res = await fetch(
+      'https://api.binance.com/api/v3/depth?symbol=BTCUSDT&limit=20',
+      { cache: 'no-store' },
+    );
+    if (!res.ok) throw new Error('Binance depth error');
+    const json = await res.json();
+    cache = { data: json, ts: Date.now() };
+    return NextResponse.json({ ...json, status: 'fresh' });
+  } catch (e) {
+    console.error('Orderbook fetch error', e);
+    if (cache) return NextResponse.json({ ...cache.data, status: 'cached_error' });
+    return NextResponse.json({ bids: [], asks: [], status: 'error' });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,6 +39,7 @@ import SignalCard from "@/components/SignalCard";
 import MarketChart from "@/components/MarketChart";
 import SignalHistory from "@/components/SignalHistory";
 import AtrWidget from "@/components/AtrWidget";
+import OrderBookWidget from "@/components/OrderBookWidget";
 import { Orchestrator } from "@/lib/agents/Orchestrator";
 import { DataCollector } from "@/lib/agents/DataCollector";
 import { IndicatorEngine } from "@/lib/agents/IndicatorEngine";
@@ -1751,14 +1752,15 @@ const CryptoDashboardPage: FC = () => {
             status="fresh"
             className="sm:col-span-2 lg:col-span-2"
           >
-            {correlationData.length > 0 ? (
-              <CorrelationPanel data={correlationData} />
-            ) : (
-              <p className="text-center p-4">Calculating correlations...</p>
-            )}
-          </DataCard>
-          <AtrWidget />
-          <SignalCard />
+          {correlationData.length > 0 ? (
+            <CorrelationPanel data={correlationData} />
+          ) : (
+            <p className="text-center p-4">Calculating correlations...</p>
+          )}
+        </DataCard>
+        <OrderBookWidget />
+        <AtrWidget />
+        <SignalCard />
           <DataCard
             title="Signal History"
             icon={Brain}

--- a/src/components/OrderBookWidget.tsx
+++ b/src/components/OrderBookWidget.tsx
@@ -1,0 +1,72 @@
+'use client';
+import { useEffect, useState } from 'react';
+import DataCard from '@/components/DataCard';
+import { detectWall } from '@/lib/data/orderBook';
+
+interface DepthData {
+  bids: [string, string][];
+  asks: [string, string][];
+  status: string;
+}
+
+export default function OrderBookWidget() {
+  const [data, setData] = useState<DepthData | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch('/api/orderbook');
+        if (!res.ok) throw new Error('API error');
+        setData(await res.json());
+      } catch (e) {
+        console.error('Orderbook fetch failed', e);
+      }
+    };
+    fetchData();
+    const id = setInterval(fetchData, 15000);
+    return () => clearInterval(id);
+  }, []);
+
+  const calcTotal = (arr: [string, string][]) =>
+    arr.reduce((sum, [price, qty]) => sum + parseFloat(qty), 0);
+  const bidTotal = data ? calcTotal(data.bids) : 0;
+  const askTotal = data ? calcTotal(data.asks) : 0;
+  const imbalance =
+    bidTotal && askTotal ? (bidTotal > askTotal ? 'Buy Wall' : 'Sell Wall') : '';
+  const bidWall = data ? detectWall(data.bids) : null;
+  const askWall = data ? detectWall(data.asks) : null;
+  const wallMsg = bidWall
+    ? `Large Bid Wall @ ${bidWall.price.toFixed(0)}`
+    : askWall
+    ? `Large Ask Wall @ ${askWall.price.toFixed(0)}`
+    : '';
+
+  return (
+    <DataCard title="Order Book Depth" className="sm:col-span-2 lg:col-span-2">
+      {data ? (
+        <div className="flex justify-around text-sm">
+          <div className="text-center">
+            <p className="font-medium text-green-600">Bids</p>
+            <p>{bidTotal.toFixed(2)}</p>
+          </div>
+          <div className="text-center">
+            <p className="font-medium text-red-600">Asks</p>
+            <p>{askTotal.toFixed(2)}</p>
+          </div>
+        </div>
+        {imbalance && (
+          <p className="text-center text-xs mt-2 font-medium">
+            {imbalance}
+          </p>
+        )}
+        {wallMsg && (
+          <p className="text-center text-yellow-600 text-xs mt-1">
+            {wallMsg}
+          </p>
+        )}
+      ) : (
+        <p className="text-center p-4">Loading depth...</p>
+      )}
+    </DataCard>
+  );
+}

--- a/src/lib/data/orderBook.ts
+++ b/src/lib/data/orderBook.ts
@@ -1,0 +1,18 @@
+export interface OrderBookWall {
+  price: number
+  qty: number
+}
+
+export function detectWall(levels: [string, string][]): OrderBookWall | null {
+  if (levels.length === 0) return null
+  const amounts = levels.map(l => parseFloat(l[1]))
+  const avg = amounts.reduce((a, b) => a + b, 0) / amounts.length
+  const threshold = avg * 3
+  for (const [priceStr, qtyStr] of levels) {
+    const qty = parseFloat(qtyStr)
+    if (qty >= threshold) {
+      return { price: parseFloat(priceStr), qty }
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## Summary
- detect large order book walls (>=3× average) via `detectWall`
- display warning message when walls appear in `OrderBookWidget`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c6f6e8ee883239f093f659ea60d30