### PR TITLE
Fix OrderBookWidget parse error

### DIFF
--- a/src/components/DataCard.tsx
+++ b/src/components/DataCard.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { type FC, ReactNode } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 

--- a/src/components/OrderBookWidget.tsx
+++ b/src/components/OrderBookWidget.tsx
@@ -36,21 +36,21 @@ export default function OrderBookWidget() {
   return (
     <DataCard title="Order Book Depth" className="sm:col-span-2 lg:col-span-2">
       {data ? (
-        <div className="flex justify-around text-sm">
-          <div className="text-center">
-            <p className="font-medium text-green-600">Bids</p>
-            <p>{bidTotal.toFixed(2)}</p>
+        <>
+          <div className="flex justify-around text-sm">
+            <div className="text-center">
+              <p className="font-medium text-green-600">Bids</p>
+              <p>{bidTotal.toFixed(2)}</p>
+            </div>
+            <div className="text-center">
+              <p className="font-medium text-red-600">Asks</p>
+              <p>{askTotal.toFixed(2)}</p>
+            </div>
           </div>
-          <div className="text-center">
-            <p className="font-medium text-red-600">Asks</p>
-            <p>{askTotal.toFixed(2)}</p>
-          </div>
-        </div>
-        {imbalance && (
-          <p className="text-center text-xs mt-2 font-medium">
-            {imbalance}
-          </p>
-        )}
+          {imbalance && (
+            <p className="text-center text-xs mt-2 font-medium">{imbalance}</p>
+          )}
+        </>
       ) : (
         <p className="text-center p-4">Loading depth...</p>
       )}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,3 +1,4 @@
+"use client"
 import * as React from "react"
 
 import { cn } from "@/lib/utils"


### PR DESCRIPTION
## Summary
- mark DataCard and UI Card component as client components
- simplify OrderBookWidget JSX to avoid parse error

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test` *(fails: `jest` not found)*
- `npm run backtest` *(fails: `ts-node` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c843d01c083238a70e27cd5df76fb