### PR TITLE
Implement order book wall highlighting

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -7,9 +7,9 @@
 ## 🚀 Top-Priority Enhancements
 
 ### ✅ Immediate Scalping Data
-- [ ] **Binance Order-Book Depth**
-  - [ ] Real-time depth widget (bid/ask imbalance)
-  - [ ] Highlight significant buy/sell walls
+- [x] **Binance Order-Book Depth**
+  - [x] Real-time depth widget (bid/ask imbalance)
+  - [x] Highlight significant buy/sell walls
 - [ ] **Volume-Spike Detection**
   - [ ] Color-coded spike overlay on chart
   - [ ] Threshold alerts for abnormal volume

--- a/logs/backtest.log
+++ b/logs/backtest.log
@@ -1,0 +1,4 @@
+
+> bitdash-firestudio@1.0.0 backtest
+> ts-node src/scripts/backtest.ts
+

--- a/logs/lint.log
+++ b/logs/lint.log
@@ -1,0 +1,4 @@
+
+> bitdash-firestudio@1.0.0 lint
+> next lint
+

--- a/logs/test.log
+++ b/logs/test.log
@@ -1,0 +1,4 @@
+
+> bitdash-firestudio@1.0.0 test
+> jest
+

--- a/src/components/OrderBookWidget.tsx
+++ b/src/components/OrderBookWidget.tsx
@@ -33,6 +33,13 @@ export default function OrderBookWidget() {
   const imbalance =
     bidTotal && askTotal ? (bidTotal > askTotal ? 'Buy Wall' : 'Sell Wall') : '';
 
+  const normalizeDepth = (orders: [string, string][]) =>
+    orders.map(([p, q]) => ({ price: parseFloat(p), qty: parseFloat(q) }));
+  const bids = data ? normalizeDepth(data.bids).slice(0, 5) : [];
+  const asks = data ? normalizeDepth(data.asks).slice(0, 5) : [];
+  const maxBid = Math.max(...bids.map(b => b.qty), 0);
+  const maxAsk = Math.max(...asks.map(a => a.qty), 0);
+
   return (
     <DataCard title="Order Book Depth" className="sm:col-span-2 lg:col-span-2">
       {data ? (
@@ -50,6 +57,34 @@ export default function OrderBookWidget() {
           {imbalance && (
             <p className="text-center text-xs mt-2 font-medium">{imbalance}</p>
           )}
+          <div className="flex justify-around mt-2 text-xs">
+            <table className="w-1/2">
+              <tbody>
+                {bids.map(b => (
+                  <tr
+                    key={`bid-${b.price}`}
+                    className={b.qty === maxBid ? 'bg-green-100' : ''}
+                  >
+                    <td className="px-1 text-right">{b.price.toFixed(2)}</td>
+                    <td className="px-1 text-right">{b.qty.toFixed(2)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <table className="w-1/2">
+              <tbody>
+                {asks.map(a => (
+                  <tr
+                    key={`ask-${a.price}`}
+                    className={a.qty === maxAsk ? 'bg-red-100' : ''}
+                  >
+                    <td className="px-1 text-right">{a.price.toFixed(2)}</td>
+                    <td className="px-1 text-right">{a.qty.toFixed(2)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </>
       ) : (
         <p className="text-center p-4">Loading depth...</p>


### PR DESCRIPTION
## Summary
- highlight large bid/ask levels in `OrderBookWidget`
- mark Order-Book Depth task complete
- include logs for lint, test and backtest

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_683d9ad68d588323956c060c9bc6bb2b