### PR TITLE
Add VWAP indicator and widget

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -13,9 +13,9 @@
 - [x] **Volume-Spike Detection**
   - [x] Color-coded spike overlay on chart
   - [x] Threshold alerts for abnormal volume
-- [ ] **VWAP (Volume-Weighted Avg Price)**
-  - [ ] Real-time VWAP calculation
-  - [ ] Price-to-VWAP deviation indicator (%)
+- [x] **VWAP (Volume-Weighted Avg Price)**
+  - [x] Real-time VWAP calculation
+  - [x] Price-to-VWAP deviation indicator (%)
 
 ### 📊 Advanced Technical Indicators
 - [ ] **Stochastic RSI**

--- a/src/__tests__/indicators.test.ts
+++ b/src/__tests__/indicators.test.ts
@@ -1,4 +1,12 @@
-import { exponentialMovingAverage, rsi, bollingerBands, volumeSMA, averageTrueRange, OHLC } from '../lib/indicators';
+import {
+  exponentialMovingAverage,
+  rsi,
+  bollingerBands,
+  volumeSMA,
+  averageTrueRange,
+  volumeWeightedAveragePrice,
+  OHLC,
+} from '../lib/indicators';
 
 describe('indicator calculations', () => {
   it('ema', () => {
@@ -25,5 +33,11 @@ describe('indicator calculations', () => {
     ];
     const val = averageTrueRange(data, 2);
     expect(val).toBeGreaterThan(0);
+  });
+  it('VWAP', () => {
+    const price = [1, 2, 3];
+    const volume = [10, 10, 10];
+    const val = volumeWeightedAveragePrice(price, volume, 3);
+    expect(val).toBeCloseTo(2);
   });
 });

--- a/src/app/api/vwap/route.ts
+++ b/src/app/api/vwap/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { fetchBackfill } from '@/lib/data/coingecko';
+import { volumeWeightedAveragePrice } from '@/lib/indicators';
+
+interface CacheEntry {
+  data: { vwap: number; deviationPct: number };
+  ts: number;
+}
+
+let cache: CacheEntry | null = null;
+const CACHE_DURATION = 15 * 1000; // 15 seconds
+
+export async function GET() {
+  if (cache && Date.now() - cache.ts < CACHE_DURATION) {
+    return NextResponse.json({ ...cache.data, status: 'cached' });
+  }
+  try {
+    const candles = await fetchBackfill();
+    const closes = candles.map(c => c.c);
+    const volumes = candles.map(c => c.v);
+    const vwap = volumeWeightedAveragePrice(closes, volumes, 12);
+    const current = closes[closes.length - 1];
+    const deviationPct = vwap ? ((current - vwap) / vwap) * 100 : 0;
+    cache = { data: { vwap, deviationPct }, ts: Date.now() };
+    return NextResponse.json({ vwap, deviationPct, status: 'fresh' });
+  } catch (e) {
+    console.error('VWAP route error', e);
+    if (cache) return NextResponse.json({ ...cache.data, status: 'cached_error' });
+    return NextResponse.json({ vwap: 0, deviationPct: 0, status: 'error' });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,6 +39,7 @@ import SignalCard from "@/components/SignalCard";
 import MarketChart from "@/components/MarketChart";
 import SignalHistory from "@/components/SignalHistory";
 import AtrWidget from "@/components/AtrWidget";
+import VwapWidget from "@/components/VwapWidget";
 import OrderBookWidget from "@/components/OrderBookWidget";
 import VolumeSpikeChart from "@/components/VolumeSpikeChart";
 import { Orchestrator } from "@/lib/agents/Orchestrator";
@@ -1761,6 +1762,7 @@ const CryptoDashboardPage: FC = () => {
         </DataCard>
         <OrderBookWidget />
         <VolumeSpikeChart />
+        <VwapWidget />
         <AtrWidget />
         <SignalCard />
           <DataCard

--- a/src/components/VwapWidget.tsx
+++ b/src/components/VwapWidget.tsx
@@ -1,0 +1,44 @@
+'use client';
+import { useEffect, useState } from 'react';
+import DataCard from '@/components/DataCard';
+
+interface VwapResp {
+  vwap: number;
+  deviationPct: number;
+  status: string;
+}
+
+export default function VwapWidget() {
+  const [data, setData] = useState<VwapResp | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch('/api/vwap');
+        if (!res.ok) throw new Error('API error');
+        setData(await res.json());
+      } catch (e) {
+        console.error('VWAP fetch failed', e);
+      }
+    };
+    fetchData();
+    const id = setInterval(fetchData, 60 * 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const deviation = data ? data.deviationPct : 0;
+  const deviationColor = deviation > 0 ? 'text-green-600' : 'text-red-600';
+
+  return (
+    <DataCard title="BTC VWAP">
+      {data ? (
+        <div className="text-center space-y-1">
+          <p className="text-2xl font-bold">{data.vwap.toFixed(2)}</p>
+          <p className={`text-sm font-medium ${deviationColor}`}>{deviation.toFixed(2)}%</p>
+        </div>
+      ) : (
+        <p className="text-center p-4">Loading VWAP...</p>
+      )}
+    </DataCard>
+  );
+}

--- a/src/lib/indicators.ts
+++ b/src/lib/indicators.ts
@@ -104,3 +104,21 @@ export function averageTrueRange(data: OHLC[], period: number): number {
   const sum = trs.reduce((a, b) => a + b, 0);
   return sum / period;
 }
+
+export function volumeWeightedAveragePrice(
+  closes: number[],
+  volumes: number[],
+  period: number,
+): number {
+  if (closes.length === 0 || volumes.length === 0) return 0;
+  const len = Math.min(period, closes.length, volumes.length);
+  const c = closes.slice(-len);
+  const v = volumes.slice(-len);
+  let pvSum = 0;
+  let volSum = 0;
+  for (let i = 0; i < len; i++) {
+    pvSum += c[i] * v[i];
+    volSum += v[i];
+  }
+  return volSum ? pvSum / volSum : 0;
+}


### PR DESCRIPTION
## Summary
- compute volume-weighted average price in indicators lib
- expose `/api/vwap` route with cached VWAP data
- add VWAP widget to dashboard page
- test VWAP helper
- mark VWAP task complete

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683da4c1b0fc8323851d9621b07bf218