### PR TITLE
Add Stochastic RSI widget

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -18,8 +18,8 @@
   - [x] Price-to-VWAP deviation indicator (%)
 
 ### 📊 Advanced Technical Indicators
-- [ ] **Stochastic RSI**
-  - [ ] Overbought/oversold alerts (20 / 80)
+- [x] **Stochastic RSI**
+  - [x] Overbought/oversold alerts (20 / 80)
 - [ ] **Order-Flow Analysis (Cumulative Delta)**
   - [ ] Real-time delta visual
   - [ ] Buy/Sell pressure meter

--- a/src/__tests__/indicators.test.ts
+++ b/src/__tests__/indicators.test.ts
@@ -5,6 +5,7 @@ import {
   volumeSMA,
   averageTrueRange,
   volumeWeightedAveragePrice,
+  stochasticRsi,
   OHLC,
 } from '../lib/indicators';
 
@@ -39,5 +40,11 @@ describe('indicator calculations', () => {
     const volume = [10, 10, 10];
     const val = volumeWeightedAveragePrice(price, volume, 3);
     expect(val).toBeCloseTo(2);
+  });
+  it('stochastic RSI', () => {
+    const prices = Array.from({ length: 30 }, (_, i) => i + 1);
+    const val = stochasticRsi(prices, 14);
+    expect(val).toBeGreaterThanOrEqual(0);
+    expect(val).toBeLessThanOrEqual(100);
   });
 });

--- a/src/app/api/stoch-rsi/route.ts
+++ b/src/app/api/stoch-rsi/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { fetchBackfill } from '@/lib/data/coingecko';
+import { stochasticRsi } from '@/lib/indicators';
+
+interface CacheEntry {
+  data: { stoch: number };
+  ts: number;
+}
+
+let cache: CacheEntry | null = null;
+const CACHE_DURATION = 15 * 1000; // 15 seconds
+
+export async function GET() {
+  if (cache && Date.now() - cache.ts < CACHE_DURATION) {
+    return NextResponse.json({ ...cache.data, status: 'cached' });
+  }
+  try {
+    const candles = await fetchBackfill();
+    const closes = candles.map(c => c.c);
+    const stoch = stochasticRsi(closes, 14);
+    cache = { data: { stoch }, ts: Date.now() };
+    return NextResponse.json({ stoch, status: 'fresh' });
+  } catch (e) {
+    console.error('Stoch RSI route error', e);
+    if (cache) return NextResponse.json({ ...cache.data, status: 'cached_error' });
+    return NextResponse.json({ stoch: 50, status: 'error' });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,6 +40,7 @@ import MarketChart from "@/components/MarketChart";
 import SignalHistory from "@/components/SignalHistory";
 import AtrWidget from "@/components/AtrWidget";
 import VwapWidget from "@/components/VwapWidget";
+import StochRsiWidget from "@/components/StochRsiWidget";
 import OrderBookWidget from "@/components/OrderBookWidget";
 import VolumeSpikeChart from "@/components/VolumeSpikeChart";
 import { Orchestrator } from "@/lib/agents/Orchestrator";
@@ -1763,6 +1764,7 @@ const CryptoDashboardPage: FC = () => {
         <OrderBookWidget />
         <VolumeSpikeChart />
         <VwapWidget />
+        <StochRsiWidget />
         <AtrWidget />
         <SignalCard />
           <DataCard

--- a/src/components/StochRsiWidget.tsx
+++ b/src/components/StochRsiWidget.tsx
@@ -1,0 +1,47 @@
+'use client';
+import { useEffect, useState } from 'react';
+import DataCard from '@/components/DataCard';
+
+interface StochResp {
+  stoch: number;
+  status: string;
+}
+
+export default function StochRsiWidget() {
+  const [data, setData] = useState<StochResp | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch('/api/stoch-rsi');
+        if (!res.ok) throw new Error('API error');
+        setData(await res.json());
+      } catch (e) {
+        console.error('Stoch RSI fetch failed', e);
+      }
+    };
+    fetchData();
+    const id = setInterval(fetchData, 60 * 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const value = data ? data.stoch : 50;
+  let label: string | null = null;
+  if (value >= 80) label = 'Overbought';
+  else if (value <= 20) label = 'Oversold';
+
+  return (
+    <DataCard title="Stoch RSI">
+      {data ? (
+        <div className="text-center space-y-1">
+          <p className="text-2xl font-bold">{value.toFixed(2)}</p>
+          {label && (
+            <p className="text-sm font-medium text-red-600">{label}</p>
+          )}
+        </div>
+      ) : (
+        <p className="text-center p-4">Loading Stoch RSI...</p>
+      )}
+    </DataCard>
+  );
+}

--- a/src/lib/indicators.ts
+++ b/src/lib/indicators.ts
@@ -122,3 +122,17 @@ export function volumeWeightedAveragePrice(
   }
   return volSum ? pvSum / volSum : 0;
 }
+
+export function stochasticRsi(prices: number[], period = 14): number {
+  if (prices.length < period + 1) return 50;
+  const rsiSeries: number[] = [];
+  for (let i = period; i < prices.length; i++) {
+    const slice = prices.slice(i - period, i + 1);
+    rsiSeries.push(rsi(slice, period));
+  }
+  const lastRsi = rsiSeries[rsiSeries.length - 1];
+  const minRsi = Math.min(...rsiSeries);
+  const maxRsi = Math.max(...rsiSeries);
+  if (maxRsi === minRsi) return 50;
+  return ((lastRsi - minRsi) / (maxRsi - minRsi)) * 100;
+}


### PR DESCRIPTION
## Summary
- complete Stochastic RSI task
- implement `stochasticRsi` indicator
- expose `/api/stoch-rsi` endpoint
- create `StochRsiWidget`
- mount widget in dashboard
- test indicator logic

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: jest not found)*
- `npm run backtest` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_b_683da5d18b288323b0cf4b13503eba98