### PR TITLE
Add market session timers

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -25,9 +25,9 @@
   - [x] Buy/Sell pressure meter
 
 ### 📅 Session & Time Awareness
-- [ ] **Market-Session Timers**
-  - [ ] NYSE/NASDAQ open/close countdown
-  - [ ] Asian / EU session highlights
+- [x] **Market-Session Timers**
+  - [x] NYSE/NASDAQ open/close countdown
+  - [x] Asian / EU session highlights
 
 ---
 

--- a/src/__tests__/sessions.test.ts
+++ b/src/__tests__/sessions.test.ts
@@ -1,0 +1,14 @@
+import { getSession, nyseCountdown } from '../lib/marketSessions'
+
+describe('market sessions utils', () => {
+  it('detects asia session', () => {
+    const date = new Date('2025-01-01T02:00:00Z')
+    expect(getSession(date)).toBe('Asia')
+  })
+  it('countdown before nyse open', () => {
+    const date = new Date('2025-01-01T13:00:00Z')
+    const result = nyseCountdown(date)
+    expect(result.label).toBe('Opens in')
+    expect(result.seconds).toBeGreaterThan(0)
+  })
+})

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -44,6 +44,7 @@ import StochRsiWidget from "@/components/StochRsiWidget";
 import OrderBookWidget from "@/components/OrderBookWidget";
 import VolumeSpikeChart from "@/components/VolumeSpikeChart";
 import OrderFlowWidget from "@/components/OrderFlowWidget";
+import SessionTimerWidget from "@/components/SessionTimerWidget";
 import { Orchestrator } from "@/lib/agents/Orchestrator";
 import { DataCollector } from "@/lib/agents/DataCollector";
 import { IndicatorEngine } from "@/lib/agents/IndicatorEngine";
@@ -1768,6 +1769,7 @@ const CryptoDashboardPage: FC = () => {
         <VwapWidget />
         <StochRsiWidget />
         <AtrWidget />
+        <SessionTimerWidget />
         <SignalCard />
           <DataCard
             title="Signal History"

--- a/src/components/SessionTimerWidget.tsx
+++ b/src/components/SessionTimerWidget.tsx
@@ -1,0 +1,41 @@
+'use client'
+import { useEffect, useState } from 'react'
+import DataCard from '@/components/DataCard'
+import { getSession, nyseCountdown, type Session } from '@/lib/marketSessions'
+
+function format(seconds: number) {
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  const s = seconds % 60
+  return `${h}h ${m}m ${s}s`
+}
+
+export default function SessionTimerWidget() {
+  const [now, setNow] = useState<Date>(new Date())
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 1000)
+    return () => clearInterval(id)
+  }, [])
+
+  const { label, seconds } = nyseCountdown(now)
+  const session: Session = getSession(now)
+  const sessionColors: Record<Session, string> = {
+    Asia: 'text-yellow-600',
+    EU: 'text-green-600',
+    US: 'text-blue-600',
+    Closed: 'text-gray-600',
+  }
+
+  return (
+    <DataCard title="Market Sessions">
+      <div className="text-center space-y-1">
+        <p className="text-sm font-medium">NYSE {label}</p>
+        <p className="text-2xl font-bold">{format(seconds)}</p>
+        <p className={`text-sm font-medium ${sessionColors[session]}`}>{
+          session === 'Closed' ? 'No major session' : `${session} session active`
+        }</p>
+      </div>
+    </DataCard>
+  )
+}

--- a/src/lib/marketSessions.ts
+++ b/src/lib/marketSessions.ts
@@ -1,0 +1,29 @@
+export type Session = 'Asia' | 'EU' | 'US' | 'Closed'
+
+export function getSession(now: Date = new Date()): Session {
+  const hour = now.getUTCHours()
+  if (hour >= 0 && hour < 8) return 'Asia'
+  if (hour >= 8 && hour < 16) return 'EU'
+  if (hour >= 13 && hour < 21) return 'US'
+  return 'Closed'
+}
+
+export function nyseCountdown(now: Date = new Date()): { label: string; seconds: number } {
+  const nyNow = new Date(
+    now.toLocaleString('en-US', { timeZone: 'America/New_York' })
+  )
+  const open = new Date(nyNow)
+  open.setHours(9, 30, 0, 0)
+  const close = new Date(nyNow)
+  close.setHours(16, 0, 0, 0)
+
+  if (nyNow < open) {
+    return { label: 'Opens in', seconds: Math.floor((open.getTime() - nyNow.getTime()) / 1000) }
+  }
+  if (nyNow < close) {
+    return { label: 'Closes in', seconds: Math.floor((close.getTime() - nyNow.getTime()) / 1000) }
+  }
+  const nextOpen = new Date(open)
+  nextOpen.setDate(open.getDate() + 1)
+  return { label: 'Opens in', seconds: Math.floor((nextOpen.getTime() - nyNow.getTime()) / 1000) }
+}


### PR DESCRIPTION
## Summary
- mark Market-Session Timers complete
- implement session time helpers
- add SessionTimerWidget and tests
- show session timers in dashboard

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: jest not found)*
- `npm run backtest` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_b_683da9955f088323859f426c47eeec37