### PR TITLE
Implement EMA crossover widget

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -36,7 +36,7 @@
 ### 📈 Price Data & Chart Enhancements
 - [x] BTC/USD 5-minute price chart
 - [x] SPX/SPY price chart
-- [ ] EMA crossovers (10/20/50/200)
+- [x] EMA crossovers (10/20/50/200)
 - [ ] Bollinger Bands (20, 2)
 - [ ] Volume-profile visualization
 - [ ] Ichimoku Cloud overlay

--- a/logs/backtest.log
+++ b/logs/backtest.log
@@ -1,4 +1,6 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
 
 > bitdash-firestudio@1.0.0 backtest
 > ts-node src/scripts/backtest.ts
 
+sh: 1: ts-node: not found

--- a/logs/lint.log
+++ b/logs/lint.log
@@ -1,4 +1,6 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
 
 > bitdash-firestudio@1.0.0 lint
 > next lint
 
+sh: 1: next: not found

--- a/logs/test.log
+++ b/logs/test.log
@@ -1,4 +1,6 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
 
 > bitdash-firestudio@1.0.0 test
 > jest
 
+sh: 1: jest: not found

--- a/src/__tests__/indicators.test.ts
+++ b/src/__tests__/indicators.test.ts
@@ -8,6 +8,7 @@ import {
   stochasticRsi,
   cumulativeDelta,
   buyPressurePercent,
+  emaCrossoverState,
   OHLC,
 } from '../lib/indicators';
 
@@ -60,5 +61,10 @@ describe('indicator calculations', () => {
     const pressure = buyPressurePercent(trades);
     expect(pressure).toBeGreaterThan(0);
     expect(pressure).toBeLessThanOrEqual(100);
+  });
+  it('ema crossover state', () => {
+    expect(emaCrossoverState([10, 9, 8, 7])).toBe('bullish');
+    expect(emaCrossoverState([7, 8, 9, 10])).toBe('bearish');
+    expect(emaCrossoverState([10, 8, 9, 7])).toBe('mixed');
   });
 });

--- a/src/app/api/ema-crossovers/route.ts
+++ b/src/app/api/ema-crossovers/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server'
+import { fetchBackfill } from '@/lib/data/coingecko'
+import { exponentialMovingAverage, emaCrossoverState } from '@/lib/indicators'
+
+interface CacheEntry {
+  data: {
+    ema10: number
+    ema20: number
+    ema50: number
+    ema200: number
+    crossover: 'bullish' | 'bearish' | 'mixed'
+  }
+  ts: number
+}
+
+let cache: CacheEntry | null = null
+const CACHE_DURATION = 15 * 1000
+
+export async function GET() {
+  if (cache && Date.now() - cache.ts < CACHE_DURATION) {
+    return NextResponse.json({ ...cache.data, status: 'cached' })
+  }
+  try {
+    const candles = await fetchBackfill()
+    const closes = candles.map(c => c.c)
+    const ema10 = exponentialMovingAverage(closes, 10)
+    const ema20 = exponentialMovingAverage(closes, 20)
+    const ema50 = exponentialMovingAverage(closes, 50)
+    const ema200 = exponentialMovingAverage(closes, 200)
+    const crossover = emaCrossoverState([ema10, ema20, ema50, ema200])
+    const data = { ema10, ema20, ema50, ema200, crossover }
+    cache = { data, ts: Date.now() }
+    return NextResponse.json({ ...data, status: 'fresh' })
+  } catch (e) {
+    console.error('EMA crossovers error', e)
+    if (cache) return NextResponse.json({ ...cache.data, status: 'cached_error' })
+    return NextResponse.json({ ema10: 0, ema20: 0, ema50: 0, ema200: 0, crossover: 'mixed', status: 'error' })
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,6 +45,7 @@ import OrderBookWidget from "@/components/OrderBookWidget";
 import VolumeSpikeChart from "@/components/VolumeSpikeChart";
 import OrderFlowWidget from "@/components/OrderFlowWidget";
 import SessionTimerWidget from "@/components/SessionTimerWidget";
+import EmaCrossoverWidget from "@/components/EmaCrossoverWidget";
 import { Orchestrator } from "@/lib/agents/Orchestrator";
 import { DataCollector } from "@/lib/agents/DataCollector";
 import { IndicatorEngine } from "@/lib/agents/IndicatorEngine";
@@ -59,6 +60,7 @@ import {
   rsi,
   exponentialMovingAverage,
   calculateVolumeProfile,
+  emaCrossoverState,
 } from "@/lib/indicators";
 
 const FMP_API_KEY = process.env.NEXT_PUBLIC_FMP_API_KEY;
@@ -364,9 +366,11 @@ const CryptoDashboardPage: FC = () => {
       const ma50 = simpleMovingAverage(prices, 50);
       const ma200 = simpleMovingAverage(prices, 200);
       const maCrossover = ma50 > ma200 ? "bullish" : "bearish";
+      const ema10 = exponentialMovingAverage(prices, 10);
       const ema20 = exponentialMovingAverage(prices, 20);
       const ema50 = exponentialMovingAverage(prices, 50);
       const ema200 = exponentialMovingAverage(prices, 200);
+      const emaCrossover = emaCrossoverState([ema10, ema20, ema50, ema200]);
       const volumeProfile = calculateVolumeProfile(prices, volumes);
       const highestVolume = volumeProfile.reduce(
         (a, b) => (b.volume > a.volume ? b : a),
@@ -379,9 +383,11 @@ const CryptoDashboardPage: FC = () => {
         ma50,
         ma200,
         maCrossover,
+        ema10,
         ema20,
         ema50,
         ema200,
+        emaCrossover,
         volumeProfilePrice,
         rsi14,
         signal,
@@ -651,9 +657,11 @@ const CryptoDashboardPage: FC = () => {
             ma50: maData?.ma50,
             ma200: maData?.ma200,
             maCrossover: maData?.maCrossover,
+            ema10: maData?.ema10,
             ema20: maData?.ema20,
             ema50: maData?.ema50,
             ema200: maData?.ema200,
+            emaCrossover: maData?.emaCrossover,
             volumeProfilePrice: maData?.volumeProfilePrice,
             rsi14: maData?.rsi14,
             signal: maData?.signal,
@@ -1326,6 +1334,21 @@ const CryptoDashboardPage: FC = () => {
                 value={coin.maCrossover === "bullish" ? "Bullish" : "Bearish"}
                 isLoading={coin.status === "loading"}
               />
+              {coin.ema10 !== undefined && (
+                <ValueDisplay
+                  label="EMA 10"
+                  value={coin.ema10.toFixed(2)}
+                  unit={coin.symbol.toUpperCase()}
+                  isLoading={coin.status === "loading"}
+                />
+              )}
+              {coin.emaCrossover && (
+                <ValueDisplay
+                  label="EMA Crossover"
+                  value={coin.emaCrossover}
+                  isLoading={coin.status === "loading"}
+                />
+              )}
               {coin.ema20 !== undefined && (
                 <ValueDisplay
                   label="EMA 20"
@@ -1767,6 +1790,7 @@ const CryptoDashboardPage: FC = () => {
         <VolumeSpikeChart />
         <OrderFlowWidget />
         <VwapWidget />
+        <EmaCrossoverWidget />
         <StochRsiWidget />
         <AtrWidget />
         <SessionTimerWidget />

--- a/src/components/EmaCrossoverWidget.tsx
+++ b/src/components/EmaCrossoverWidget.tsx
@@ -1,0 +1,46 @@
+'use client'
+import { useEffect, useState } from 'react'
+import DataCard from '@/components/DataCard'
+
+interface EmaResp {
+  ema10: number
+  ema20: number
+  ema50: number
+  ema200: number
+  crossover: 'bullish' | 'bearish' | 'mixed'
+  status: string
+}
+
+export default function EmaCrossoverWidget() {
+  const [data, setData] = useState<EmaResp | null>(null)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch('/api/ema-crossovers')
+        if (!res.ok) throw new Error('API error')
+        setData(await res.json())
+      } catch (e) {
+        console.error('EMA crossover fetch failed', e)
+      }
+    }
+    fetchData()
+    const id = setInterval(fetchData, 60 * 1000)
+    return () => clearInterval(id)
+  }, [])
+
+  return (
+    <DataCard title="EMA Crossovers">
+      {data ? (
+        <div className="text-center space-y-1">
+          <p className="text-2xl font-bold">{data.crossover}</p>
+          <p className="text-sm">
+            10:{data.ema10.toFixed(2)} 20:{data.ema20.toFixed(2)} 50:{data.ema50.toFixed(2)} 200:{data.ema200.toFixed(2)}
+          </p>
+        </div>
+      ) : (
+        <p className="text-center p-4">Loading EMAs...</p>
+      )}
+    </DataCard>
+  )
+}

--- a/src/lib/indicators.ts
+++ b/src/lib/indicators.ts
@@ -161,3 +161,13 @@ export function buyPressurePercent(trades: AggTrade[]): number {
   const total = buyVol + sellVol;
   return total ? (buyVol / total) * 100 : 0;
 }
+
+export type EmaTrend = 'bullish' | 'bearish' | 'mixed';
+
+export function emaCrossoverState(emas: number[]): EmaTrend {
+  if (emas.length < 4) return 'mixed';
+  const [e10, e20, e50, e200] = emas;
+  if (e10 > e20 && e20 > e50 && e50 > e200) return 'bullish';
+  if (e10 < e20 && e20 < e50 && e50 < e200) return 'bearish';
+  return 'mixed';
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,9 +17,11 @@ export interface CoinData {
   ma50?: number;
   ma200?: number;
   maCrossover?: 'bullish' | 'bearish';
+  ema10?: number;
   ema20?: number;
   ema50?: number;
   ema200?: number;
+  emaCrossover?: 'bullish' | 'bearish' | 'mixed';
   volumeProfilePrice?: number;
   rsi14?: number;
   signal?: 'buy' | 'sell' | 'hold';


### PR DESCRIPTION
## Summary
- mark EMA crossover task complete
- expose `emaCrossoverState` helper in indicators
- add API route for EMA crossovers
- add React widget to display EMA crossover trend
- compute EMA10 and crossover data in dashboard
- display EMA10 and crossover in UI
- expand types and tests

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: jest not found)*
- `npm run backtest` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_b_683dab27e55483238bd43409ad2a0bf2