### PR TITLE
Implement Bollinger Bands widget

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -37,7 +37,7 @@
 - [x] BTC/USD 5-minute price chart
 - [x] SPX/SPY price chart
 - [x] EMA crossovers (10/20/50/200)
-- [ ] Bollinger Bands (20, 2)
+- [x] Bollinger Bands (20, 2)
 - [ ] Volume-profile visualization
 - [ ] Ichimoku Cloud overlay
 

--- a/src/app/api/bollinger/route.ts
+++ b/src/app/api/bollinger/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server'
+import { fetchBackfill } from '@/lib/data/coingecko'
+import { bollingerBands } from '@/lib/indicators'
+
+interface CacheEntry {
+  data: { upper: number; middle: number; lower: number; price: number }
+  ts: number
+}
+
+let cache: CacheEntry | null = null
+const CACHE_DURATION = 15 * 1000
+
+export async function GET() {
+  if (cache && Date.now() - cache.ts < CACHE_DURATION) {
+    return NextResponse.json({ ...cache.data, status: 'cached' })
+  }
+  try {
+    const candles = await fetchBackfill()
+    const closes = candles.map(c => c.c)
+    const price = closes[closes.length - 1]
+    const bands = bollingerBands(closes, 20, 2)
+    const data = { ...bands, price }
+    cache = { data, ts: Date.now() }
+    return NextResponse.json({ ...data, status: 'fresh' })
+  } catch (e) {
+    console.error('Bollinger route error', e)
+    if (cache) return NextResponse.json({ ...cache.data, status: 'cached_error' })
+    return NextResponse.json({ upper: 0, middle: 0, lower: 0, price: 0, status: 'error' })
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -41,6 +41,7 @@ import SignalHistory from "@/components/SignalHistory";
 import AtrWidget from "@/components/AtrWidget";
 import VwapWidget from "@/components/VwapWidget";
 import StochRsiWidget from "@/components/StochRsiWidget";
+import BollingerWidget from "@/components/BollingerWidget";
 import OrderBookWidget from "@/components/OrderBookWidget";
 import VolumeSpikeChart from "@/components/VolumeSpikeChart";
 import OrderFlowWidget from "@/components/OrderFlowWidget";
@@ -1790,6 +1791,7 @@ const CryptoDashboardPage: FC = () => {
         <VolumeSpikeChart />
         <OrderFlowWidget />
         <VwapWidget />
+        <BollingerWidget />
         <EmaCrossoverWidget />
         <StochRsiWidget />
         <AtrWidget />

--- a/src/components/BollingerWidget.tsx
+++ b/src/components/BollingerWidget.tsx
@@ -1,0 +1,44 @@
+'use client'
+import { useEffect, useState } from 'react'
+import DataCard from '@/components/DataCard'
+
+interface BbResp {
+  upper: number
+  middle: number
+  lower: number
+  price: number
+  status: string
+}
+
+export default function BollingerWidget() {
+  const [data, setData] = useState<BbResp | null>(null)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch('/api/bollinger')
+        if (!res.ok) throw new Error('API error')
+        setData(await res.json())
+      } catch (e) {
+        console.error('Bollinger fetch failed', e)
+      }
+    }
+    fetchData()
+    const id = setInterval(fetchData, 60 * 1000)
+    return () => clearInterval(id)
+  }, [])
+
+  return (
+    <DataCard title="Bollinger Bands">
+      {data ? (
+        <div className="text-center space-y-1">
+          <p className="text-sm">Upper {data.upper.toFixed(2)}</p>
+          <p className="text-2xl font-bold">{data.price.toFixed(2)}</p>
+          <p className="text-sm">Lower {data.lower.toFixed(2)}</p>
+        </div>
+      ) : (
+        <p className="text-center p-4">Loading Bollinger...</p>
+      )}
+    </DataCard>
+  )
+}


### PR DESCRIPTION
## Summary
- mark Bollinger Bands task as done
- expose `/api/bollinger` endpoint returning latest band values
- add `BollingerWidget` component
- display widget on the dashboard

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test` *(fails: `jest` not found)*
- `npm run backtest` *(fails: `ts-node` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683dacd8f7fc8323b1444851d9549815