### PR TITLE
Add volume profile chart

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -38,7 +38,7 @@
 - [x] SPX/SPY price chart
 - [x] EMA crossovers (10/20/50/200)
 - [x] Bollinger Bands (20, 2)
-- [ ] Volume-profile visualization
+- [x] Volume-profile visualization
 - [ ] Ichimoku Cloud overlay
 
 ### 🛠 Technical Indicators

--- a/src/app/api/volume-profile/route.ts
+++ b/src/app/api/volume-profile/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server'
+import { fetchBackfill } from '@/lib/data/coingecko'
+import { calculateVolumeProfile } from '@/lib/indicators'
+
+interface VolumePoint {
+  price: number
+  volume: number
+}
+
+interface CacheEntry {
+  data: VolumePoint[]
+  ts: number
+}
+
+let cache: CacheEntry | null = null
+const CACHE_DURATION = 15 * 1000
+
+export async function GET() {
+  if (cache && Date.now() - cache.ts < CACHE_DURATION) {
+    return NextResponse.json({ profile: cache.data, status: 'cached' })
+  }
+  try {
+    const candles = await fetchBackfill()
+    const prices = candles.map(c => c.c)
+    const volumes = candles.map(c => c.v)
+    const profile = calculateVolumeProfile(prices, volumes, 20)
+    cache = { data: profile, ts: Date.now() }
+    return NextResponse.json({ profile, status: 'fresh' })
+  } catch (e) {
+    console.error('Volume profile route error', e)
+    if (cache) {
+      return NextResponse.json({ profile: cache.data, status: 'cached_error' })
+    }
+    return NextResponse.json({ profile: [], status: 'error' })
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -44,6 +44,7 @@ import StochRsiWidget from "@/components/StochRsiWidget";
 import BollingerWidget from "@/components/BollingerWidget";
 import OrderBookWidget from "@/components/OrderBookWidget";
 import VolumeSpikeChart from "@/components/VolumeSpikeChart";
+import VolumeProfileChart from "@/components/VolumeProfileChart";
 import OrderFlowWidget from "@/components/OrderFlowWidget";
 import SessionTimerWidget from "@/components/SessionTimerWidget";
 import EmaCrossoverWidget from "@/components/EmaCrossoverWidget";
@@ -1789,6 +1790,7 @@ const CryptoDashboardPage: FC = () => {
         </DataCard>
         <OrderBookWidget />
         <VolumeSpikeChart />
+        <VolumeProfileChart />
         <OrderFlowWidget />
         <VwapWidget />
         <BollingerWidget />

--- a/src/components/VolumeProfileChart.tsx
+++ b/src/components/VolumeProfileChart.tsx
@@ -1,0 +1,59 @@
+'use client'
+import { useEffect, useState } from 'react'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts'
+import DataCard from '@/components/DataCard'
+
+interface VolumePoint {
+  price: number
+  volume: number
+}
+
+export default function VolumeProfileChart() {
+  const [data, setData] = useState<VolumePoint[]>([])
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch('/api/volume-profile')
+        if (!res.ok) throw new Error('API error')
+        const json = await res.json()
+        setData(json.profile)
+      } catch (e) {
+        console.error('Volume profile fetch failed', e)
+      }
+    }
+    fetchData()
+    const id = setInterval(fetchData, 60 * 1000)
+    return () => clearInterval(id)
+  }, [])
+
+  return (
+    <DataCard title="Volume Profile" className="sm:col-span-2 lg:col-span-2">
+      {data.length ? (
+        <ResponsiveContainer width="100%" height={200}>
+          <BarChart
+            data={data}
+            margin={{ top: 10, right: 10, left: 0, bottom: 0 }}
+          >
+            <XAxis dataKey="price" tickFormatter={(v) => v.toFixed(0)} />
+            <YAxis />
+            <Tooltip
+              formatter={(v: unknown) => Number(v as number).toFixed(2)}
+              labelFormatter={(v: unknown) => Number(v as number).toFixed(2)}
+            />
+            <Bar dataKey="volume" fill="#60a5fa" />
+          </BarChart>
+        </ResponsiveContainer>
+      ) : (
+        <p className="text-center p-4">Loading volume profile...</p>
+      )}
+    </DataCard>
+  )
+}


### PR DESCRIPTION
## Summary
- visualize volume profile using recharts
- expose `/api/volume-profile` for volume profile data
- display new widget on dashboard
- mark the related TODO in `TASKS.md`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test` *(fails: `jest` not found)*
- `npm run backtest` *(fails: `ts-node` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683daeca9adc83239d66798125dd083f