### PR TITLE
Add Ichimoku cloud overlay widget

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -7,6 +7,7 @@
 ## 🚀 Top-Priority Enhancements
 
 ### ✅ Immediate Scalping Data
+
 - [x] **Binance Order-Book Depth**
   - [x] Real-time depth widget (bid/ask imbalance)
   - [x] Highlight significant buy/sell walls
@@ -18,6 +19,7 @@
   - [x] Price-to-VWAP deviation indicator (%)
 
 ### 📊 Advanced Technical Indicators
+
 - [x] **Stochastic RSI**
   - [x] Overbought/oversold alerts (20 / 80)
 - [x] **Order-Flow Analysis (Cumulative Delta)**
@@ -25,6 +27,7 @@
   - [x] Buy/Sell pressure meter
 
 ### 📅 Session & Time Awareness
+
 - [x] **Market-Session Timers**
   - [x] NYSE/NASDAQ open/close countdown
   - [x] Asian / EU session highlights
@@ -34,30 +37,35 @@
 ## 🔥 Core Trading Features
 
 ### 📈 Price Data & Chart Enhancements
+
 - [x] BTC/USD 5-minute price chart
 - [x] SPX/SPY price chart
 - [x] EMA crossovers (10/20/50/200)
 - [x] Bollinger Bands (20, 2)
 - [x] Volume-profile visualization
-- [ ] Ichimoku Cloud overlay
+- [x] Ichimoku Cloud overlay
 
 ### 🛠 Technical Indicators
+
 - [ ] RSI (14)
 - [ ] MACD (12, 26, 9)
 - [x] ATR (14) for position sizing
 
 ### 💧 Volume & Liquidity
+
 - [ ] BTC funding-rates widget
 - [ ] On-chain BTC txn count (CoinGecko)
 - [ ] SPY volume (Yahoo Finance)
 
 ### 🎯 Sentiment & Correlation
+
 - [x] Crypto Fear-&-Greed Index
 - [ ] Short-term Crypto-Twitter sentiment
 - [ ] Real-time liquidations & open interest
 - [ ] Rolling BTC / SPX correlation (1 h)
 
 ### 📊 Macro Indicators
+
 - [x] 10-Year Treasury Yield
 - [ ] Fed-funds-rate schedule
 - [ ] Economic-event calendar
@@ -67,18 +75,21 @@
 ## 📚 Data-Management Layer
 
 ### ⚙️ Data Fetchers
+
 - [ ] Binance WS (order-book & OHLCV)
 - [ ] CoinGecko (historical BTC)
 - [ ] Yahoo Finance (SPX/SPY/VIX/DXY)
 - [ ] FRED (macro series)
 
 ### 🔄 Caching & Rate-Limiting
+
 - [ ] Cache REST calls 15-30 s
 - [ ] Enforce ≤ 5 calls/min/endpoint
 
 ---
 
 ## 🚨 Alerts & Notifications
+
 - [ ] Toast notifications on signals
 - [ ] Custom alert-config panel
 - [ ] Integrated quick-entry trade journal
@@ -89,16 +100,19 @@
 ## 🧪 Testing & Validation
 
 ### 🔍 Indicator Tests
+
 - [ ] Unit tests for each indicator
 - [ ] Validate results on historical data
 
 ### 📈 Backtesting & Analytics
+
 - [ ] Real-time strategy backtester (90 days)
   - [ ] Win-rate, profit-factor, drawdown
 
 ---
 
 ## 📖 Documentation & Configuration
+
 - [ ] API docs
 - [ ] User guide
 - [ ] Dev setup guide
@@ -108,6 +122,7 @@
 ---
 
 ## 🖥 UI Enhancements
+
 - [ ] Proximity indicators (key levels, pivots, VWAP)
 - [ ] Customisable TradingView widget
 - [ ] One-click indicator toggles
@@ -115,12 +130,14 @@
 ---
 
 ## ⚡ Performance & Monitoring
+
 - [ ] Real-time strategy-performance tracker
 - [ ] Monitor data latency & system load
 
 ---
 
 ## 🎯 Definition of Done
+
 - All priority widgets & indicators visible and functional.
 - BUY/SELL signals render in UI ≤ 2 s after candle close.
 - Backtest & test logs saved under `/logs`.

--- a/logs/backtest.log
+++ b/logs/backtest.log
@@ -1,6 +1,4 @@
-npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
 
 > bitdash-firestudio@1.0.0 backtest
 > ts-node src/scripts/backtest.ts
 
-sh: 1: ts-node: not found

--- a/logs/lint.log
+++ b/logs/lint.log
@@ -1,6 +1,4 @@
-npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
 
 > bitdash-firestudio@1.0.0 lint
 > next lint
 
-sh: 1: next: not found

--- a/logs/test.log
+++ b/logs/test.log
@@ -1,6 +1,4 @@
-npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
 
 > bitdash-firestudio@1.0.0 test
 > jest
 
-sh: 1: jest: not found

--- a/src/__tests__/indicators.test.ts
+++ b/src/__tests__/indicators.test.ts
@@ -9,27 +9,32 @@ import {
   cumulativeDelta,
   buyPressurePercent,
   emaCrossoverState,
+  ichimokuCloud,
   OHLC,
-} from '../lib/indicators';
+} from "../lib/indicators";
 
-describe('indicator calculations', () => {
-  it('ema', () => {
-    const ema = exponentialMovingAverage([1,2,3,4,5], 3);
+describe("indicator calculations", () => {
+  it("ema", () => {
+    const ema = exponentialMovingAverage([1, 2, 3, 4, 5], 3);
     expect(ema).toBeGreaterThan(0);
   });
-  it('rsi', () => {
-    const val = rsi([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15], 14);
+  it("rsi", () => {
+    const val = rsi([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], 14);
     expect(val).toBeGreaterThanOrEqual(0);
   });
-  it('bollinger', () => {
-    const bb = bollingerBands([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20], 20, 2);
+  it("bollinger", () => {
+    const bb = bollingerBands(
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+      20,
+      2,
+    );
     expect(bb.upper).toBeGreaterThan(bb.lower);
   });
-  it('volumeSMA', () => {
-    const val = volumeSMA([1,2,3,4,5], 3);
+  it("volumeSMA", () => {
+    const val = volumeSMA([1, 2, 3, 4, 5], 3);
     expect(val).toBeGreaterThan(0);
   });
-  it('ATR', () => {
+  it("ATR", () => {
     const data: OHLC[] = [
       { high: 2, low: 1, close: 1.5 },
       { high: 3, low: 1.5, close: 2 },
@@ -38,19 +43,19 @@ describe('indicator calculations', () => {
     const val = averageTrueRange(data, 2);
     expect(val).toBeGreaterThan(0);
   });
-  it('VWAP', () => {
+  it("VWAP", () => {
     const price = [1, 2, 3];
     const volume = [10, 10, 10];
     const val = volumeWeightedAveragePrice(price, volume, 3);
     expect(val).toBeCloseTo(2);
   });
-  it('stochastic RSI', () => {
+  it("stochastic RSI", () => {
     const prices = Array.from({ length: 30 }, (_, i) => i + 1);
     const val = stochasticRsi(prices, 14);
     expect(val).toBeGreaterThanOrEqual(0);
     expect(val).toBeLessThanOrEqual(100);
   });
-  it('cumulative delta', () => {
+  it("cumulative delta", () => {
     const trades = [
       { quantity: 1, isBuyerMaker: false },
       { quantity: 2, isBuyerMaker: true },
@@ -62,9 +67,19 @@ describe('indicator calculations', () => {
     expect(pressure).toBeGreaterThan(0);
     expect(pressure).toBeLessThanOrEqual(100);
   });
-  it('ema crossover state', () => {
-    expect(emaCrossoverState([10, 9, 8, 7])).toBe('bullish');
-    expect(emaCrossoverState([7, 8, 9, 10])).toBe('bearish');
-    expect(emaCrossoverState([10, 8, 9, 7])).toBe('mixed');
+  it("ema crossover state", () => {
+    expect(emaCrossoverState([10, 9, 8, 7])).toBe("bullish");
+    expect(emaCrossoverState([7, 8, 9, 10])).toBe("bearish");
+    expect(emaCrossoverState([10, 8, 9, 7])).toBe("mixed");
+  });
+  it("ichimoku cloud", () => {
+    const data: OHLC[] = Array.from({ length: 60 }, (_, i) => ({
+      high: i + 2,
+      low: i,
+      close: i + 1,
+    }));
+    const res = ichimokuCloud(data);
+    expect(res.tenkan).toBeGreaterThan(0);
+    expect(res.spanA).toBeGreaterThan(0);
   });
 });

--- a/src/app/api/ichimoku/route.ts
+++ b/src/app/api/ichimoku/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { fetchIntradayCandles } from "@/lib/data/fmp";
+import { ichimokuCloud } from "@/lib/indicators";
+
+interface CacheEntry {
+  data: {
+    tenkan: number;
+    kijun: number;
+    spanA: number;
+    spanB: number;
+    price: number;
+  };
+  ts: number;
+}
+
+let cache: CacheEntry | null = null;
+const CACHE_DURATION = 15 * 1000;
+
+export async function GET() {
+  if (cache && Date.now() - cache.ts < CACHE_DURATION) {
+    return NextResponse.json({ ...cache.data, status: "cached" });
+  }
+  try {
+    const candles = await fetchIntradayCandles("BTCUSD", 60);
+    const ichimoku = ichimokuCloud(candles);
+    const price = candles[candles.length - 1]?.close || 0;
+    const data = { ...ichimoku, price };
+    cache = { data, ts: Date.now() };
+    return NextResponse.json({ ...data, status: "fresh" });
+  } catch (e) {
+    console.error("Ichimoku route error", e);
+    if (cache)
+      return NextResponse.json({ ...cache.data, status: "cached_error" });
+    return NextResponse.json({
+      tenkan: 0,
+      kijun: 0,
+      spanA: 0,
+      spanB: 0,
+      price: 0,
+      status: "error",
+    });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,6 +45,7 @@ import BollingerWidget from "@/components/BollingerWidget";
 import OrderBookWidget from "@/components/OrderBookWidget";
 import VolumeSpikeChart from "@/components/VolumeSpikeChart";
 import VolumeProfileChart from "@/components/VolumeProfileChart";
+import IchimokuWidget from "@/components/IchimokuWidget";
 import OrderFlowWidget from "@/components/OrderFlowWidget";
 import SessionTimerWidget from "@/components/SessionTimerWidget";
 import EmaCrossoverWidget from "@/components/EmaCrossoverWidget";
@@ -571,9 +572,12 @@ const CryptoDashboardPage: FC = () => {
 
   useEffect(() => {
     fetchCorrelationData().catch(console.error);
-    const id = setInterval(() => {
-      fetchCorrelationData().catch(console.error);
-    }, 5 * 60 * 1000);
+    const id = setInterval(
+      () => {
+        fetchCorrelationData().catch(console.error);
+      },
+      5 * 60 * 1000,
+    );
     return () => clearInterval(id);
   }, [fetchCorrelationData]);
 
@@ -1669,7 +1673,7 @@ const CryptoDashboardPage: FC = () => {
           >
             {renderCoinData(appData.btc, Bitcoin)}
           </DataCard>
-          
+
           <DataCard
             title="BTC Chart"
             icon={BarChart3}
@@ -1782,23 +1786,24 @@ const CryptoDashboardPage: FC = () => {
             status="fresh"
             className="sm:col-span-2 lg:col-span-2"
           >
-          {correlationData.length > 0 ? (
-            <CorrelationPanel data={correlationData} />
-          ) : (
-            <p className="text-center p-4">Calculating correlations...</p>
-          )}
-        </DataCard>
-        <OrderBookWidget />
-        <VolumeSpikeChart />
-        <VolumeProfileChart />
-        <OrderFlowWidget />
-        <VwapWidget />
-        <BollingerWidget />
-        <EmaCrossoverWidget />
-        <StochRsiWidget />
-        <AtrWidget />
-        <SessionTimerWidget />
-        <SignalCard />
+            {correlationData.length > 0 ? (
+              <CorrelationPanel data={correlationData} />
+            ) : (
+              <p className="text-center p-4">Calculating correlations...</p>
+            )}
+          </DataCard>
+          <OrderBookWidget />
+          <VolumeSpikeChart />
+          <VolumeProfileChart />
+          <IchimokuWidget />
+          <OrderFlowWidget />
+          <VwapWidget />
+          <BollingerWidget />
+          <EmaCrossoverWidget />
+          <StochRsiWidget />
+          <AtrWidget />
+          <SessionTimerWidget />
+          <SignalCard />
           <DataCard
             title="Signal History"
             icon={Brain}

--- a/src/components/IchimokuWidget.tsx
+++ b/src/components/IchimokuWidget.tsx
@@ -1,0 +1,46 @@
+"use client";
+import { useEffect, useState } from "react";
+import DataCard from "@/components/DataCard";
+
+interface IchiResp {
+  tenkan: number;
+  kijun: number;
+  spanA: number;
+  spanB: number;
+  price: number;
+  status: string;
+}
+
+export default function IchimokuWidget() {
+  const [data, setData] = useState<IchiResp | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch("/api/ichimoku");
+        if (!res.ok) throw new Error("API error");
+        setData(await res.json());
+      } catch (e) {
+        console.error("Ichimoku fetch failed", e);
+      }
+    };
+    fetchData();
+    const id = setInterval(fetchData, 60 * 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <DataCard title="Ichimoku Cloud">
+      {data ? (
+        <div className="text-center space-y-1">
+          <p className="text-sm">Tenkan {data.tenkan.toFixed(2)}</p>
+          <p className="text-sm">Kijun {data.kijun.toFixed(2)}</p>
+          <p className="text-sm">SpanA {data.spanA.toFixed(2)}</p>
+          <p className="text-sm">SpanB {data.spanB.toFixed(2)}</p>
+        </div>
+      ) : (
+        <p className="text-center p-4">Loading Ichimoku...</p>
+      )}
+    </DataCard>
+  );
+}

--- a/src/lib/indicators.ts
+++ b/src/lib/indicators.ts
@@ -1,75 +1,79 @@
 export function simpleMovingAverage(data: number[], period: number): number {
   if (data.length < period) {
-    const slice = data.slice()
-    const sum = slice.reduce((a, b) => a + b, 0)
-    return sum / slice.length
+    const slice = data.slice();
+    const sum = slice.reduce((a, b) => a + b, 0);
+    return sum / slice.length;
   }
-  const recent = data.slice(data.length - period)
-  const sum = recent.reduce((a, b) => a + b, 0)
-  return sum / period
+  const recent = data.slice(data.length - period);
+  const sum = recent.reduce((a, b) => a + b, 0);
+  return sum / period;
 }
 
 export function rsi(prices: number[], period = 14): number {
-  if (prices.length < period + 1) return 50
-  let gains = 0
-  let losses = 0
+  if (prices.length < period + 1) return 50;
+  let gains = 0;
+  let losses = 0;
 
   for (let i = prices.length - period; i < prices.length; i++) {
-    const diff = prices[i] - prices[i - 1]
-    if (diff > 0) gains += diff
-    else losses -= diff
+    const diff = prices[i] - prices[i - 1];
+    if (diff > 0) gains += diff;
+    else losses -= diff;
   }
 
-  if (losses === 0) return 100
-  const rs = gains / losses
-  return 100 - 100 / (1 + rs)
+  if (losses === 0) return 100;
+  const rs = gains / losses;
+  return 100 - 100 / (1 + rs);
 }
 
-export function exponentialMovingAverage(data: number[], period: number): number {
-  if (data.length === 0) return 0
-  const slice = data.slice(-period)
-  const k = 2 / (period + 1)
-  let ema = slice[0]
+export function exponentialMovingAverage(
+  data: number[],
+  period: number,
+): number {
+  if (data.length === 0) return 0;
+  const slice = data.slice(-period);
+  const k = 2 / (period + 1);
+  let ema = slice[0];
   for (let i = 1; i < slice.length; i++) {
-    ema = slice[i] * k + ema * (1 - k)
+    ema = slice[i] * k + ema * (1 - k);
   }
-  return ema
+  return ema;
 }
 
 export function calculateVolumeProfile(
   prices: number[],
   volumes: number[],
-  bins = 10
+  bins = 10,
 ): Array<{ price: number; volume: number }> {
   if (prices.length !== volumes.length) {
-    throw new Error('Price and volume arrays must be the same length')
+    throw new Error("Price and volume arrays must be the same length");
   }
-  if (prices.length === 0) return []
-  const minPrice = Math.min(...prices)
-  const maxPrice = Math.max(...prices)
-  const binSize = (maxPrice - minPrice) / bins
-  const buckets = Array.from({ length: bins }, () => 0)
+  if (prices.length === 0) return [];
+  const minPrice = Math.min(...prices);
+  const maxPrice = Math.max(...prices);
+  const binSize = (maxPrice - minPrice) / bins;
+  const buckets = Array.from({ length: bins }, () => 0);
   for (let i = 0; i < prices.length; i++) {
     const idx = Math.min(
       bins - 1,
-      Math.floor((prices[i] - minPrice) / binSize)
-    )
-    buckets[idx] += volumes[i]
+      Math.floor((prices[i] - minPrice) / binSize),
+    );
+    buckets[idx] += volumes[i];
   }
   return buckets.map((volume, idx) => ({
     price: minPrice + binSize * idx + binSize / 2,
     volume,
-  }))
+  }));
 }
 
 export function bollingerBands(
   closes: number[],
   period: number,
-  stdDev: number
+  stdDev: number,
 ): { upper: number; middle: number; lower: number } {
   const middle = simpleMovingAverage(closes, period);
   const slice = closes.slice(-period);
-  const variance = slice.reduce((a, c) => a + Math.pow(c - middle, 2), 0) / slice.length;
+  const variance =
+    slice.reduce((a, c) => a + Math.pow(c - middle, 2), 0) / slice.length;
   const sd = Math.sqrt(variance);
   const upper = middle + sd * stdDev;
   const lower = middle - sd * stdDev;
@@ -162,12 +166,44 @@ export function buyPressurePercent(trades: AggTrade[]): number {
   return total ? (buyVol / total) * 100 : 0;
 }
 
-export type EmaTrend = 'bullish' | 'bearish' | 'mixed';
+export type EmaTrend = "bullish" | "bearish" | "mixed";
 
 export function emaCrossoverState(emas: number[]): EmaTrend {
-  if (emas.length < 4) return 'mixed';
+  if (emas.length < 4) return "mixed";
   const [e10, e20, e50, e200] = emas;
-  if (e10 > e20 && e20 > e50 && e50 > e200) return 'bullish';
-  if (e10 < e20 && e20 < e50 && e50 < e200) return 'bearish';
-  return 'mixed';
+  if (e10 > e20 && e20 > e50 && e50 > e200) return "bullish";
+  if (e10 < e20 && e20 < e50 && e50 < e200) return "bearish";
+  return "mixed";
+}
+export interface IchimokuLines {
+  tenkan: number;
+  kijun: number;
+  spanA: number;
+  spanB: number;
+  chikou: number;
+}
+
+export function ichimokuCloud(data: OHLC[]): IchimokuLines {
+  if (data.length === 0) {
+    return { tenkan: 0, kijun: 0, spanA: 0, spanB: 0, chikou: 0 };
+  }
+
+  const high = (period: number) => {
+    const slice = data.slice(-period);
+    return Math.max(...slice.map((c) => c.high));
+  };
+  const low = (period: number) => {
+    const slice = data.slice(-period);
+    return Math.min(...slice.map((c) => c.low));
+  };
+  const sliceLen = (p: number) => Math.min(p, data.length);
+
+  const tenkan = (high(sliceLen(9)) + low(sliceLen(9))) / 2;
+  const kijun = (high(sliceLen(26)) + low(sliceLen(26))) / 2;
+  const spanA = (tenkan + kijun) / 2;
+  const spanB = (high(sliceLen(52)) + low(sliceLen(52))) / 2;
+  const chikouIndex = data.length - 26;
+  const chikou = chikouIndex >= 0 ? data[chikouIndex].close : data[0].close;
+
+  return { tenkan, kijun, spanA, spanB, chikou };
 }


### PR DESCRIPTION
## Summary
- compute Ichimoku Cloud lines in `indicators.ts`
- expose new `/api/ichimoku` endpoint
- display cloud data with `IchimokuWidget`
- include widget in dashboard
- check off task in `TASKS.md`
- update unit tests

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test` *(fails: `jest` not found)*
- `npm run backtest` *(fails: `ts-node` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683db15f3744832381fb8f607e1012ad