### PR TITLE
Add RSI indicator widget

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -47,7 +47,7 @@
 
 ### 🛠 Technical Indicators
 
-- [ ] RSI (14)
+- [x] RSI (14)
 - [ ] MACD (12, 26, 9)
 - [x] ATR (14) for position sizing
 

--- a/src/app/api/rsi/route.ts
+++ b/src/app/api/rsi/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server'
+import { fetchBackfill } from '@/lib/data/coingecko'
+import { rsi } from '@/lib/indicators'
+
+interface CacheEntry {
+  data: { rsi: number }
+  ts: number
+}
+
+let cache: CacheEntry | null = null
+const CACHE_DURATION = 15 * 1000
+
+export async function GET() {
+  if (cache && Date.now() - cache.ts < CACHE_DURATION) {
+    return NextResponse.json({ ...cache.data, status: 'cached' })
+  }
+  try {
+    const candles = await fetchBackfill()
+    const closes = candles.map(c => c.c)
+    const value = rsi(closes, 14)
+    cache = { data: { rsi: value }, ts: Date.now() }
+    return NextResponse.json({ rsi: value, status: 'fresh' })
+  } catch (e) {
+    console.error('RSI route error', e)
+    if (cache) return NextResponse.json({ ...cache.data, status: 'cached_error' })
+    return NextResponse.json({ rsi: 50, status: 'error' })
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -41,6 +41,7 @@ import SignalHistory from "@/components/SignalHistory";
 import AtrWidget from "@/components/AtrWidget";
 import VwapWidget from "@/components/VwapWidget";
 import StochRsiWidget from "@/components/StochRsiWidget";
+import RsiWidget from "@/components/RsiWidget";
 import BollingerWidget from "@/components/BollingerWidget";
 import OrderBookWidget from "@/components/OrderBookWidget";
 import VolumeSpikeChart from "@/components/VolumeSpikeChart";
@@ -1800,6 +1801,7 @@ const CryptoDashboardPage: FC = () => {
           <VwapWidget />
           <BollingerWidget />
           <EmaCrossoverWidget />
+          <RsiWidget />
           <StochRsiWidget />
           <AtrWidget />
           <SessionTimerWidget />

--- a/src/components/RsiWidget.tsx
+++ b/src/components/RsiWidget.tsx
@@ -1,0 +1,47 @@
+'use client'
+import { useEffect, useState } from 'react'
+import DataCard from '@/components/DataCard'
+
+interface RsiResp {
+  rsi: number
+  status: string
+}
+
+export default function RsiWidget() {
+  const [data, setData] = useState<RsiResp | null>(null)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch('/api/rsi')
+        if (!res.ok) throw new Error('API error')
+        setData(await res.json())
+      } catch (e) {
+        console.error('RSI fetch failed', e)
+      }
+    }
+    fetchData()
+    const id = setInterval(fetchData, 60 * 1000)
+    return () => clearInterval(id)
+  }, [])
+
+  const value = data ? data.rsi : 50
+  let label: string | null = null
+  if (value >= 70) label = 'Overbought'
+  else if (value <= 30) label = 'Oversold'
+
+  return (
+    <DataCard title="RSI">
+      {data ? (
+        <div className="text-center space-y-1">
+          <p className="text-2xl font-bold">{value.toFixed(2)}</p>
+          {label && (
+            <p className="text-sm font-medium text-red-600">{label}</p>
+          )}
+        </div>
+      ) : (
+        <p className="text-center p-4">Loading RSI...</p>
+      )}
+    </DataCard>
+  )
+}


### PR DESCRIPTION
## Summary
- implement RSI API endpoint
- display RSI widget on dashboard
- mark RSI task complete

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: jest not found)*
- `npm run backtest` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_b_683db94e899483238268b9d51ad94233