### PR TITLE
Add Codex workflow instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,3 +184,40 @@ Editable signal thresholds (hot-reloadable):
 
 > **Follow exactly as specified.**
 > Commits automatically track and document changes; review `/logs` regularly.
+
+---
+
+## 10. Codex Workflow Reference
+
+These additional notes are distilled from `codesetuptolearnfrom.md` to guide
+the Codex developer agent.
+
+### Task Cycle
+
+1. Open `TASKS.md` and select the first unchecked item.
+2. Implement only that single task with small, incremental edits.
+3. Run `npm run lint` and `npm run test` when available.
+4. Mark the task as `[x]` in `TASKS.md`.
+5. Commit using `Task <number>:` followed by a short summary. Provide context in
+   the body if needed.
+6. Repeat until all tasks are complete or more input is required.
+
+### Commit Guidelines
+
+- One task per commit.
+- Keep subject lines around 50 characters and wrap body text near 72
+  characters.
+- Mention key decisions or affected modules in the commit body.
+- Never commit secrets; copy `.env.local.example` to `.env.local` locally.
+- `signals.json` may store `last_task_completed` or `error_flag` for context
+  between runs.
+
+### Initialization Prompt
+
+```
+You are an AI Developer Agent working on this repository.
+Open AGENTS.md and TASKS.md, execute the first unchecked task, mark it
+complete, commit with "Task <number>:" and continue to the next task.
+```
+
+Following this workflow keeps contributions deterministic and lightweight.

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -1,0 +1,30 @@
+# INSTRUCTIONS.md
+
+This repository uses a Codex developer agent. The notes below summarize the
+workflow described in `codesetuptolearnfrom.md`.
+
+## Quick Start
+
+1. Read `AGENTS.md` for project rules and open `TASKS.md` to locate the next
+   unchecked task.
+2. Implement only that task with minimal changes.
+3. Run `npm run lint` and `npm run test` if available.
+4. Mark the task as `[x]` in `TASKS.md`.
+5. Commit with a message starting `Task <number>:` and provide context in the
+   body when helpful.
+6. Repeat until all tasks are done or more input is needed.
+
+## Commit Example
+
+```text
+Task 3: Add agent interface
+- created `types/agent.ts` with AgentMessage schema
+- enables structured communication between agents
+```
+
+## Additional Notes
+
+- Use `.env.local.example` as a template for environment variables.
+- `signals.json` may store flags such as `last_task_completed` or `error_flag`.
+- Keep commit subjects around 50 characters and wrap body lines near 72.
+- Pause and ask for clarification if a task is unclear.


### PR DESCRIPTION
## Summary
- expand AGENTS.md with a Codex workflow reference
- add INSTRUCTIONS.md summarizing task and commit rules

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683dbb5a1dc883239aeefc40086d7dac