### PR TITLE
Implement MACD indicator

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -48,7 +48,7 @@
 ### 🛠 Technical Indicators
 
 - [x] RSI (14)
-- [ ] MACD (12, 26, 9)
+- [x] MACD (12, 26, 9)
 - [x] ATR (14) for position sizing
 
 ### 💧 Volume & Liquidity

--- a/src/__tests__/indicators.test.ts
+++ b/src/__tests__/indicators.test.ts
@@ -10,6 +10,7 @@ import {
   buyPressurePercent,
   emaCrossoverState,
   ichimokuCloud,
+  macd,
   OHLC,
 } from "../lib/indicators";
 
@@ -81,5 +82,12 @@ describe("indicator calculations", () => {
     const res = ichimokuCloud(data);
     expect(res.tenkan).toBeGreaterThan(0);
     expect(res.spanA).toBeGreaterThan(0);
+  });
+  it("macd", () => {
+    const prices = Array.from({ length: 60 }, (_, i) => i + 1);
+    const res = macd(prices, 12, 26, 9);
+    expect(res.macd).toBeDefined();
+    expect(res.signal).toBeDefined();
+    expect(res.histogram).toBeDefined();
   });
 });

--- a/src/lib/indicators.ts
+++ b/src/lib/indicators.ts
@@ -207,3 +207,31 @@ export function ichimokuCloud(data: OHLC[]): IchimokuLines {
 
   return { tenkan, kijun, spanA, spanB, chikou };
 }
+
+export interface MacdResult {
+  macd: number;
+  signal: number;
+  histogram: number;
+}
+
+export function macd(
+  prices: number[],
+  fast = 12,
+  slow = 26,
+  signalPeriod = 9,
+): MacdResult {
+  if (prices.length < slow) {
+    return { macd: 0, signal: 0, histogram: 0 };
+  }
+  const macdSeries: number[] = [];
+  for (let i = slow - 1; i < prices.length; i++) {
+    const slice = prices.slice(0, i + 1);
+    const fastEma = exponentialMovingAverage(slice, fast);
+    const slowEma = exponentialMovingAverage(slice, slow);
+    macdSeries.push(fastEma - slowEma);
+  }
+  const macdValue = macdSeries[macdSeries.length - 1];
+  const signalValue = exponentialMovingAverage(macdSeries, signalPeriod);
+  const histogram = macdValue - signalValue;
+  return { macd: macdValue, signal: signalValue, histogram };
+}


### PR DESCRIPTION
## Summary
- add MACD calculation to indicators library
- test MACD results in unit tests
- mark MACD task complete in TASKS.md

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683dbc9a14108323a46538d3c6cf068b