### PR TITLE
Add Codex workflow guide and commit log

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,3 +222,7 @@ complete, commit with "Task <number>:" and continue to the next task.
 ```
 
 Following this workflow keeps contributions deterministic and lightweight.
+
+Additional tips are available in `docs/CODEX_WORKFLOW.md`, including how to
+keep the container alive and generate a commit history log with
+`npm run commitlog`.

--- a/README.md
+++ b/README.md
@@ -97,3 +97,12 @@ MIT
 ## Backtest Results
 
 Using 5-minute BTC data from CoinGecko (90 days) the strategy achieved roughly a 55% win rate on historical candles. Run `npm run backtest` to reproduce.
+
+## Codex Workflow
+
+See `docs/CODEX_WORKFLOW.md` for tips on using the Codex agent effectively.
+Generate a recent commit summary anytime with:
+
+```bash
+npm run commitlog
+```

--- a/docs/CODEX_WORKFLOW.md
+++ b/docs/CODEX_WORKFLOW.md
@@ -1,0 +1,39 @@
+# Codex Workflow Guide
+
+This document distills the key points from `CODEX-INSTRUCTIONS.txt` for working with this repository using the Codex agent.
+
+## Commit-Based Memory
+
+- Each task in `TASKS.md` should be completed in a single commit.
+- Prefix commit messages with `Task <number>:` followed by a short summary.
+- Keep the subject line around 50 characters; wrap body lines near 72 characters.
+- Commit history acts as long-term memory for the agent. Review recent commits before starting a new session.
+- Run `npm ci` once at the start of a session. Subsequent commits can reuse the installed `node_modules`.
+
+## Keeping the Workspace Alive
+
+Codex runs in an ephemeral container. To avoid losing context:
+
+1. Queue multiple subtasks in one card and keep the card open.
+2. Avoid closing the task panel between commits.
+3. Use a long-lived branch if working on a larger feature.
+4. Optionally create a small keep-alive script (e.g., `touch KEEPALIVE`) to prevent idle shutdown.
+
+### Recommended Prompt Pattern
+
+```
+We will complete Tasks X–Y in one session.
+1. Run `npm ci` once.
+2. Work through each task sequentially, committing after each.
+Keep this workspace running until I say "close workspace".
+```
+
+## Commit Log Utility
+
+A helper script `scripts/commit-log.js` is provided to generate `logs/commit.log` with the latest commit messages:
+
+```bash
+npm run commitlog
+```
+
+Use this log to quickly review recent work when resuming the project.

--- a/logs/commit.log
+++ b/logs/commit.log
@@ -1,0 +1,20 @@
+ec979b0 2025-06-02 docs: add Codex workflow guide and commit log
+c573fb0 2025-06-02 Add files via upload
+64b67ad 2025-06-02 Task 9: add scalper add-on tasks
+80eafbf 2025-06-02 Task 8: add BTC txn count widget
+55ac5fa 2025-06-02 Task 0: record failed dependency install
+8ce0973 2025-06-02 Task 7: note dependency drift task
+d9fd120 2025-06-02 Task 1: add funding rate widget
+71fd69f 2025-06-02 Task 1: add MACD indicator
+ea51b7e 2025-06-02 docs: extend agent instructions
+6bc70be 2025-06-02 Delete Codex Automation System for Next.js Bitcoin Dashboard.pdf
+2452be3 2025-06-02 Add files via upload
+f151941 2025-06-02 feat(indicator): add RSI widget and API
+131b6f6 2025-06-02 feat(chart): add Ichimoku cloud overlay
+27fbef5 2025-06-02 feat(chart): add volume profile visualization
+8df8c93 2025-06-02 feat(bollinger): add bands widget and API
+0439d58 2025-06-02 feat(ema): add EMA crossover widget and API\n\nImplements EMA crossovers for 10/20/50/200 and displays trend. Updates TASKS.md.
+9128902 2025-06-02 feat(session): add market session timers
+1bab8ca 2025-06-02 feat(order-flow): add cumulative delta widget and API
+308a45f 2025-06-02 feat(indicator): add Stochastic RSI widget and API
+3a61961 2025-06-02 feat(vwap): add VWAP indicator and widget

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test": "jest",
     "backtest": "ts-node scripts/backtest.ts",
     "auto": "ts-node src/scripts/autoTaskRunner.ts",
+    "commitlog": "node scripts/commit-log.js",
     "bootstrap": "npm ci && npm run lint && npm run test && npm run backtest"
   },
   "dependencies": {

--- a/scripts/commit-log.js
+++ b/scripts/commit-log.js
@@ -1,0 +1,11 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const log = execSync('git log --pretty=format:"%h %ad %s" --date=short -n 20', {
+  encoding: 'utf8'
+});
+const outPath = path.join(__dirname, '../logs/commit.log');
+fs.writeFileSync(outPath, log + '\n');
+console.log(`Commit log written to ${outPath}`);
+


### PR DESCRIPTION
## Summary
- document how to keep the container alive and use commit-based memory
- add `scripts/commit-log.js` and npm script `commitlog`
- mention workflow docs and log in `AGENTS.md` and `README.md`
- update initial commit log

## Testing
- `npm run lint` *(fails: next missing – run 'npm ci')*
- `npm run test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_b_683dcbfc16d083238663ca59eb559aa2