### PR TITLE
Add tiered caching wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,8 +70,7 @@ export type AgentRole =
   | 'SignalGenerator'
   | 'UIRenderer'
   | 'AlertLogger'
-  | 'Backtester'
-  | 'QATester'
+  | 'TestingAgent'
   | 'AutoTaskRunner';
 ```
 
@@ -87,8 +86,7 @@ export type AgentRole =
 | **SignalGenerator** | Apply trade rules to indicators                                  | `INDICATORS_5M`             | `SIGNAL_BUY/SELL` |
 | **UIRenderer**      | Render UI widgets (React), update trading views                  | `INDICATORS_5M`, `SIGNAL_*` | None              |
 | **AlertLogger**     | Log alerts to UI & persist signals locally                       | `SIGNAL_*`                  | None              |
-| **Backtester**      | Run simulations on historical data                               | Manual trigger              | Backtest report   |
-| **QATester**        | Run Jest tests & validate results; gates CI                      | Repository state            | Pass/fail report  |
+| **TestingAgent**    | Run Jest tests or backtests based on mode | Repo state or manual trigger | Test/backtest report |
 | **AutoTaskRunner**  | Automate task execution, lint/test/backtest, auto-commit results | `TASKS.md`                  | Automated commits |
 
 ---

--- a/src/lib/agents/Backtester.ts
+++ b/src/lib/agents/Backtester.ts
@@ -1,7 +1,0 @@
-import { AgentMessage } from '@/types/agent';
-
-export class Backtester {
-  handle(_msg: AgentMessage): void {
-    // Backtesting logic would go here
-  }
-}

--- a/src/lib/agents/Orchestrator.ts
+++ b/src/lib/agents/Orchestrator.ts
@@ -10,8 +10,7 @@ export class Orchestrator {
     SignalGenerator: () => {},
     UIRenderer: () => {},
     AlertLogger: () => {},
-    Backtester: () => {},
-    QATester: () => {},
+    TestingAgent: () => {},
   };
 
   register(role: AgentRole, handler: Handler): void {

--- a/src/lib/agents/QATester.ts
+++ b/src/lib/agents/QATester.ts
@@ -1,7 +1,0 @@
-import { AgentMessage } from '@/types/agent';
-
-export class QATester {
-  handle(_msg: AgentMessage): void {
-    // QA testing logic would go here
-  }
-}

--- a/src/lib/agents/TestingAgent.ts
+++ b/src/lib/agents/TestingAgent.ts
@@ -1,0 +1,23 @@
+import { AgentMessage } from '@/types/agent'
+
+export type TestMode = 'qa' | 'backtest'
+
+export class TestingAgent {
+  private mode: TestMode
+
+  constructor(mode: TestMode = 'qa') {
+    this.mode = mode
+  }
+
+  setMode(mode: TestMode): void {
+    this.mode = mode
+  }
+
+  handle(_msg: AgentMessage): void {
+    if (this.mode === 'qa') {
+      // QA testing logic would go here
+    } else {
+      // Backtesting logic would go here
+    }
+  }
+}

--- a/src/lib/data/coingecko.ts
+++ b/src/lib/data/coingecko.ts
@@ -1,4 +1,5 @@
-import { getCachedData, setCachedData } from '@/lib/cache';
+import { getCachedData, setCachedData } from '@/lib/cache'
+import { cachedFetch } from '@/lib/fetchCache'
 
 export interface Candle {
   t: number;
@@ -12,12 +13,11 @@ export interface Candle {
 const CACHE_KEY = 'cg_btc_5m';
 
 export async function fetchBackfill(): Promise<Candle[]> {
-  const cached = getCachedData<Candle[]>(CACHE_KEY);
-  if (cached) return cached;
+  const cached = getCachedData<Candle[]>(CACHE_KEY)
+  if (cached) return cached
   const url =
-    'https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days=1&interval=5m';
-  const res = await fetch(url);
-  const json = await res.json();
+    'https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days=1&interval=5m'
+  const json = await cachedFetch<any>(url, 'reference')
   const candles: Candle[] = json.prices.map((p: [number, number], idx: number) => {
     const [t, price] = p;
     const volume = json.total_volumes[idx][1];

--- a/src/lib/data/fmp.ts
+++ b/src/lib/data/fmp.ts
@@ -1,52 +1,46 @@
-const API_BASE = 'https://financialmodelingprep.com/api/v3';
-const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
+import { cachedFetch, FetchImportance } from '@/lib/fetchCache'
 
-interface CacheEntry {
-  prices: number[];
-  ts: number;
-}
+const API_BASE = 'https://financialmodelingprep.com/api/v3'
 
 interface Candle {
-  open: number;
-  high: number;
-  low: number;
-  close: number;
-  date: string;
+  open: number
+  high: number
+  low: number
+  close: number
+  date: string
 }
 
-const cache: Record<string, CacheEntry> = {};
-
-async function fetchWithRetry(url: string, retries = 2, delay = 1000): Promise<any> {
+async function fetchWithRetry(
+  url: string,
+  importance: FetchImportance,
+  retries = 2,
+  delay = 1000,
+): Promise<any> {
   try {
-    const res = await fetch(url, { cache: 'no-store' });
-    if (res.ok) return res.json();
-    throw new Error(`HTTP ${res.status}`);
+    return await cachedFetch(url, importance)
   } catch (e) {
-    if (retries <= 0) throw e;
-    await new Promise(r => setTimeout(r, delay));
-    return fetchWithRetry(url, retries - 1, delay * 2);
+    if (retries <= 0) throw e
+    await new Promise(r => setTimeout(r, delay))
+    return fetchWithRetry(url, importance, retries - 1, delay * 2)
   }
 }
 
 export async function fetchIntradayPrices(symbol: string, limit = 12): Promise<number[]> {
-  const cached = cache[symbol];
-  if (cached && Date.now() - cached.ts < CACHE_DURATION) return cached.prices;
-  const key = process.env.NEXT_PUBLIC_FMP_API_KEY;
+  const key = process.env.NEXT_PUBLIC_FMP_API_KEY
   if (!key) throw new Error('FMP API key not set');
-  const url = `${API_BASE}/historical-chart/5min/${encodeURIComponent(symbol)}?apikey=${key}`;
-  const data = await fetchWithRetry(url);
+  const url = `${API_BASE}/historical-chart/5min/${encodeURIComponent(symbol)}?apikey=${key}`
+  const data = await fetchWithRetry(url, 'context')
   const prices = Array.isArray(data)
     ? data.slice(0, limit).map((d: any) => Number(d.close)).reverse()
-    : [];
-  cache[symbol] = { prices, ts: Date.now() };
-  return prices;
+    : []
+  return prices
 }
 
 export async function fetchIntradayCandles(symbol: string, limit = 12): Promise<Candle[]> {
   const key = process.env.NEXT_PUBLIC_FMP_API_KEY;
   if (!key) throw new Error('FMP API key not set');
   const url = `${API_BASE}/historical-chart/5min/${encodeURIComponent(symbol)}?apikey=${key}`;
-  const data = await fetchWithRetry(url);
+  const data = await fetchWithRetry(url, 'context');
   if (!Array.isArray(data)) return [];
   return data
     .slice(0, limit)
@@ -64,7 +58,7 @@ export async function fetchDailyCandles(symbol: string, days = 20): Promise<Cand
   const key = process.env.NEXT_PUBLIC_FMP_API_KEY;
   if (!key) throw new Error('FMP API key not set');
   const url = `${API_BASE}/historical-price-full/${encodeURIComponent(symbol)}?timeseries=${days}&apikey=${key}`;
-  const data = await fetchWithRetry(url);
+  const data = await fetchWithRetry(url, 'reference');
   if (!Array.isArray(data?.historical)) return [];
   return data.historical
     .slice(0, days)

--- a/src/lib/fetchCache.ts
+++ b/src/lib/fetchCache.ts
@@ -1,0 +1,46 @@
+export type FetchImportance = 'critical' | 'context' | 'reference'
+
+const TTL: Record<FetchImportance, number> = {
+  critical: 60 * 1000,
+  context: 5 * 60 * 1000,
+  reference: 30 * 60 * 1000,
+}
+
+interface CacheEntry {
+  data: any
+  ts: number
+}
+
+const cache = new Map<string, CacheEntry>()
+const MAX_TTL = TTL.reference
+
+function cleanup() {
+  const now = Date.now()
+  for (const [key, entry] of cache.entries()) {
+    if (now - entry.ts > MAX_TTL) cache.delete(key)
+  }
+}
+
+export function hasFreshCache(url: string, importance: FetchImportance): boolean {
+  const entry = cache.get(url)
+  if (!entry) return false
+  return Date.now() - entry.ts < TTL[importance]
+}
+
+export async function cachedFetch<T>(
+  url: string,
+  importance: FetchImportance,
+  init?: RequestInit,
+): Promise<T> {
+  cleanup()
+  const entry = cache.get(url)
+  const ttl = TTL[importance]
+  if (entry && Date.now() - entry.ts < ttl) {
+    return entry.data as T
+  }
+  const res = await fetch(url, { cache: 'no-store', ...(init || {}) })
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  const data = (await res.json()) as T
+  cache.set(url, { data, ts: Date.now() })
+  return data
+}

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -13,5 +13,4 @@ export type AgentRole =
   | 'SignalGenerator'
   | 'UIRenderer'
   | 'AlertLogger'
-  | 'Backtester'
-  | 'QATester';
+  | 'TestingAgent';


### PR DESCRIPTION
## Summary
- add `fetchCache` with importance-based TTL
- use wrapper in CoinGecko, FMP and orderbook routes
- consolidate Backtester/QATester into `TestingAgent`

## Testing
- `npm run lint` *(fails: missing dependencies)*
- `npm run test` *(fails: jest not found)*
- `npm ci` *(fails: EHOSTUNREACH)*


------
https://chatgpt.com/codex/tasks/task_b_683dce062c588323b73a1fb85b0384b4