### PR TITLE
Task 13: add previous day VWAP bands

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -49,9 +49,9 @@
 ---
 ### 🧩 Low-/No-cost Scalper Add-ons
 
-- [ ] **Previous Day H/L & VWAP Bands**
-  - [ ] Fetch prior-day OHLCV from Binance
-  - [ ] Plot yesterday's high, low and VWAP bands
+- [x] **Previous Day H/L & VWAP Bands**
+  - [x] Fetch prior-day OHLCV from Binance
+  - [x] Plot yesterday's high, low and VWAP bands
 - [ ] **Heat-Map of Bid/Ask Walls**
   - [ ] Build order-book heat map from depth stream
   - [ ] Highlight large resting orders

--- a/signals.json
+++ b/signals.json
@@ -1,4 +1,4 @@
 {
-  "last_task_completed": null,
+  "last_task_completed": 13,
   "error_flag": false
 }

--- a/src/app/api/prev-day/route.ts
+++ b/src/app/api/prev-day/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { cachedFetch } from '@/lib/fetchCache';
+
+interface CacheEntry {
+  data: { high: number; low: number; vwap: number };
+  ts: number;
+}
+
+let cache: CacheEntry | null = null;
+const CACHE_DURATION = 15 * 1000; // 15 seconds
+const URL =
+  'https://api.binance.com/api/v3/klines?symbol=BTCUSDT&interval=5m&limit=288';
+
+export async function GET() {
+  if (cache && Date.now() - cache.ts < CACHE_DURATION) {
+    return NextResponse.json({ ...cache.data, status: 'cached' });
+  }
+  try {
+    const data = await cachedFetch<any[]>(URL, 'reference');
+    if (!Array.isArray(data)) throw new Error('bad data');
+    let high = -Infinity;
+    let low = Infinity;
+    let pv = 0;
+    let vol = 0;
+    for (const k of data) {
+      const h = Number(k[2]);
+      const l = Number(k[3]);
+      const c = Number(k[4]);
+      const v = Number(k[5]);
+      if (h > high) high = h;
+      if (l < low) low = l;
+      pv += c * v;
+      vol += v;
+    }
+    const vwap = vol ? pv / vol : 0;
+    const result = { high, low, vwap };
+    cache = { data: result, ts: Date.now() };
+    return NextResponse.json({ ...result, status: 'fresh' });
+  } catch (e) {
+    console.error('Prev-day bands error', e);
+    if (cache)
+      return NextResponse.json({ ...cache.data, status: 'cached_error' });
+    return NextResponse.json({ high: 0, low: 0, vwap: 0, status: 'error' });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,6 +40,7 @@ import MarketChart from "@/components/MarketChart";
 import SignalHistory from "@/components/SignalHistory";
 import AtrWidget from "@/components/AtrWidget";
 import VwapWidget from "@/components/VwapWidget";
+import PrevDayBands from "@/components/PrevDayBands";
 import StochRsiWidget from "@/components/StochRsiWidget";
 import RsiWidget from "@/components/RsiWidget";
 import BollingerWidget from "@/components/BollingerWidget";
@@ -1803,6 +1804,7 @@ const CryptoDashboardPage: FC = () => {
           <FundingRateWidget />
           <TxnCountWidget />
           <VwapWidget />
+          <PrevDayBands />
           <BollingerWidget />
           <EmaCrossoverWidget />
           <RsiWidget />

--- a/src/components/PrevDayBands.tsx
+++ b/src/components/PrevDayBands.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { useEffect, useState } from 'react';
+import DataCard from '@/components/DataCard';
+
+interface BandsResp {
+  high: number;
+  low: number;
+  vwap: number;
+  status: string;
+}
+
+export default function PrevDayBands() {
+  const [data, setData] = useState<BandsResp | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch('/api/prev-day');
+        if (!res.ok) throw new Error('API error');
+        setData(await res.json());
+      } catch (e) {
+        console.error('Prev-day fetch failed', e);
+      }
+    };
+    fetchData();
+    const id = setInterval(fetchData, 60 * 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <DataCard title="Prev Day Bands">
+      {data ? (
+        <div className="text-center space-y-1">
+          <p className="text-xs">High: {data.high.toFixed(2)}</p>
+          <p className="text-xs">Low: {data.low.toFixed(2)}</p>
+          <p className="text-xs">VWAP: {data.vwap.toFixed(2)}</p>
+        </div>
+      ) : (
+        <p className="text-center p-4">Loading...</p>
+      )}
+    </DataCard>
+  );
+}


### PR DESCRIPTION
## Summary
- add API route to fetch previous day bands from Binance
- show previous-day high/low/VWAP in new widget
- include widget on dashboard
- mark task complete in TASKS
- record last completed task

## Testing
- `npm run lint` *(fails: next missing – run 'npm ci')*
- `npm run test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_683decb3d6048323b5eed263ab72410e