### PR TITLE
Update automation docs for git memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@
    b. Create `context.snapshot.md` if missing.
    c. Ensure package scripts `lint`, `test`, `backtest` run.
    d. Commit as `chore(bootstrap): automation rules` with a 333‑token summary.
+   e. Append commit details to `memory.md` so the Git log mirrors persistent memory.
 2. **Task Commit**
    a. Load `task_queue.json` and `TASKS.md`, choosing the first entry with `status: "pending"`.
    b. Implement **only** that task.
@@ -54,10 +55,11 @@
 | --------------------- | ----------------------------------------------------- |
 | `context.snapshot.md` | Rolling log – every commit appends its 333‑token memo |
 | `memory.md`           | Append-only history of commits and key notes |
+| Git history           | Persistent record of diffs and messages |
 | `task_queue.json`     | Machine-readable list of tasks with status |
 | `/logs/*.txt`         | Fail‑logs, backtest output, debug notes               |
 
-Codex must **read `context.snapshot.md` and `memory.md` first** on each new session to recall context.
+Codex must **read `context.snapshot.md`, `memory.md` and the latest git log first** on each new session to recall context.
 
 ---
 
@@ -72,6 +74,7 @@ BREAKING CHANGE: <optional>
 Closes: TASKS.md #<line‑no>
 ```
 
+Every commit message doubles as persistent memory. Append the summary, hash and changed files to `memory.md` and `context.snapshot.md`.
 *Types*: `feat`, `fix`, `chore`, `docs`, `test`.
 
 ---
@@ -142,6 +145,7 @@ Run `npm ci` once when the environment starts (or `npm run dev-deps` if offline)
 
 * Task checkbox ✅ in `TASKS.md`
 * Tests & lint pass
+* `memory.md` updated with commit hash and summary
 * Commit merged to `main`
 * 333‑token memo saved to `context.snapshot.md`
 * No unresolved errors or conflicts

--- a/TASKS.md
+++ b/TASKS.md
@@ -8,9 +8,10 @@
 1. Run `npm run auto` to let the AutoTaskRunner process tasks sequentially.
 2. Tasks are loaded from `task_queue.json`; keep this file in sync with the checklist.
 3. Each task runs lint, test and backtest.
-4. After success the task is marked `[x]`, `signals.json` and `task_queue.json` are updated and both `context.snapshot.md` and `memory.md` are written.
-5. The commit message follows `Task <number>:` with a 333-token summary.
-6. The runner rebases on `main` and pushes after each commit.
+4. After success the task is marked `[x]`, `signals.json` and `task_queue.json` are updated.
+5. Append the 333‑token commit summary with hash and files to `context.snapshot.md` and `memory.md`.
+6. The commit message follows `Task <number>:` so the git log stays in sync with the memory files.
+7. The runner rebases on `main` and pushes after each commit.
 
 ---
 
@@ -90,3 +91,4 @@
 - Test, lint and backtest logs are saved under `/logs`.
 - Each completed task is auto-committed with a passing build and updated `signals.json`.
 - `task_queue.json`, `context.snapshot.md` and `memory.md` reflect the new status.
+- Git log mirrors TASKS.md history for quick recovery.

--- a/memory.md
+++ b/memory.md
@@ -1,3 +1,3 @@
 # Memory Log
 
-This file records a running history of completed tasks and key decisions. After each commit, append the 333-token summary along with the commit hash and timestamp. Use it alongside `context.snapshot.md` to rebuild context between sessions.
+This file records a running history of completed tasks and key decisions. After each commit, append the 333-token summary along with the commit hash, timestamp and list of changed files. Git commit messages mirror these entries so the log acts as persistent memory. Use it alongside `context.snapshot.md` to rebuild context between sessions or recover after interruptions.


### PR DESCRIPTION
## Summary
- refine core loop to log bootstrap commit to memory
- document git history in memory files section
- clarify commit message acts as persistent memory
- update tasks workflow and definition of done
- explain commit-log usage in memory log

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_683e27aee6388323baa8d99925c9e893