### PR TITLE
Improve docs for persistent memory workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,15 @@
 
 > This document is the **system‑prompt on disk** that governs every Codex session. Follow it verbatim unless a maintainer overrides you via commit or chat.
 
+## Roles & Responsibilities
+
+- **Planner** – reads `task_queue.json` to prioritize and split work.
+- **Coder** – implements features and fixes according to each task.
+- **Tester** – runs lint, test and backtest commands, reporting failures.
+- **Reviewer** – checks commit quality and ensures guidelines are met.
+
+These roles operate sequentially within the `DevAgent` to keep automation predictable.
+
 ---
 
 ## 0 · Hard Constraints
@@ -60,6 +69,7 @@
 | `/logs/*.txt`         | Fail‑logs, backtest output, debug notes               |
 
 Codex must **read `context.snapshot.md`, `memory.md` and the latest git log first** on each new session to recall context.
+Use `npm run commitlog` to generate `logs/commit.log` for quick review of recent commits.
 
 ---
 
@@ -74,7 +84,7 @@ BREAKING CHANGE: <optional>
 Closes: TASKS.md #<line‑no>
 ```
 
-Every commit message doubles as persistent memory. Append the summary, hash and changed files to `memory.md` and `context.snapshot.md`.
+Every commit message doubles as persistent memory. Append the summary, commit hash and changed files to `memory.md` and `context.snapshot.md` so agents can recall which code was touched.
 *Types*: `feat`, `fix`, `chore`, `docs`, `test`.
 
 ---
@@ -148,6 +158,7 @@ Run `npm ci` once when the environment starts (or `npm run dev-deps` if offline)
 * `memory.md` updated with commit hash and summary
 * Commit merged to `main`
 * 333‑token memo saved to `context.snapshot.md`
+* `task_queue.json` and `TASKS.md` in sync
 * No unresolved errors or conflicts
 
 > End of AGENTS.md – obey without deviation.

--- a/TASKS.md
+++ b/TASKS.md
@@ -11,7 +11,8 @@
 4. After success the task is marked `[x]`, `signals.json` and `task_queue.json` are updated.
 5. Append the 333‑token commit summary with hash and files to `context.snapshot.md` and `memory.md`.
 6. The commit message follows `Task <number>:` so the git log stays in sync with the memory files.
-7. The runner rebases on `main` and pushes after each commit.
+7. Use `npm run commitlog` to review recent history when resuming work.
+8. The runner rebases on `main` and pushes after each commit.
 
 ---
 
@@ -92,3 +93,4 @@
 - Each completed task is auto-committed with a passing build and updated `signals.json`.
 - `task_queue.json`, `context.snapshot.md` and `memory.md` reflect the new status.
 - Git log mirrors TASKS.md history for quick recovery.
+- `logs/commit.log` provides a concise memory dump via `npm run commitlog`.

--- a/docs/CODEX_WORKFLOW.md
+++ b/docs/CODEX_WORKFLOW.md
@@ -9,6 +9,7 @@ This document distills the key points from `CODEX-INSTRUCTIONS.txt` for working 
 - Include a 333-token body that doubles as the entry for `context.snapshot.md`.
 - Keep the subject line around 50 characters; wrap body lines near 72 characters.
 - Commit history, `context.snapshot.md`, and `memory.md` act as long-term memory. Review them before starting a new session.
+- Generate `logs/commit.log` via `npm run commitlog` to quickly recall recent commits.
 - Keep `task_queue.json` synchronized with `TASKS.md` so automation can resume accurately.
 - Run `npm ci` once at the start of a session. Subsequent commits can reuse the installed `node_modules`.
 


### PR DESCRIPTION
## Summary
- clarify roles and workflow in `AGENTS.md`
- emphasize commitlog usage and sync tasks
- note commitlog review in workflow
- mention commitlog generation in docs guide

## Testing
- `npm run lint` *(fails: Command jest missing)*
- `npm run test` *(skipped: Command jest missing)*
- `npm run backtest` *(skipped: Command ts-node missing)*

------
https://chatgpt.com/codex/tasks/task_b_683e2aa2e4888323ad37ce3d2da7105f