### PR TITLE
Remove trending and fear/greed features

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,26 +40,6 @@ export interface StockData {
   signal?: 'buy' | 'sell' | 'hold';
 }
 
-export interface TrendingCoinItem {
-  id: string;
-  name: string;
-  symbol: string;
-  market_cap_rank: number;
-  thumb: string; // image URL from CoinGecko trending
-  price_btc?: number;
-}
-
-export interface TrendingData {
-  coins: TrendingCoinItem[];
-  status: 'fresh' | 'cached_error' | 'error' | 'loading';
-}
-
-export interface FearGreedData {
-  value: string;
-  value_classification: string;
-  timestamp?: string; // Unix timestamp string
-  status: 'fresh' | 'cached_error' | 'error' | 'loading';
-}
 
 export interface AppData {
   btc: CoinData | null;
@@ -68,8 +48,6 @@ export interface AppData {
   spx: StockData | null;
   dxy: StockData | null;
   us10y: StockData | null;
-  trending: TrendingData | null;
-  fearGreed: FearGreedData | null;
   lastUpdated: string | null; // Timestamp of the last successful simulated fetch
   globalError: string | null; // For errors fetching the main /api/dashboard
   loading: boolean; // Global loading state for the initial "simulated" fetch


### PR DESCRIPTION
## Summary
- strip TrendingCoinItem, TrendingData and FearGreedData types
- stop requesting trending coins & fear/greed index
- remove related state persistence
- drop Fear & Greed and Trending Coins cards

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_683e6d190fcc83239afe0de9f043e493