### PR TITLE
Implement API to fetch 1h/4h candles

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -7,6 +7,7 @@ All tasks live in `task_queue.json` as `{ "id": number, "description": string, "
 ---
 
 ## Workflow
+
 1. Review `context.snapshot.md`, `memory.md` and `logs/commit.log` for context.
 2. Run `npm run auto` to let the AutoTaskRunner process tasks sequentially.
 3. Tasks are loaded from `task_queue.json`; keep this file in sync with the checklist.
@@ -22,6 +23,7 @@ All tasks live in `task_queue.json` as `{ "id": number, "description": string, "
 ---
 
 ## Completed Tasks
+
 - [x] Task 0: initial dependency install attempt
 - [x] Task 1–16: prior setup and feature groundwork
 
@@ -30,86 +32,97 @@ All tasks live in `task_queue.json` as `{ "id": number, "description": string, "
 ## Pending Tasks
 
 ### Scalper Add-ons
+
 - [x] Task 17: highlight large resting orders on depth heat map
 - [x] Task 18: connect to Bybit liquidation WebSocket
 - [x] Task 19: aggregate liquidations into clusters
 - [x] Task 20: overlay liquidation clusters on chart
- - [x] Task 21: fetch open-interest data from Bybit
- - [x] Task 22: compute 1 h open-interest delta
- - [x] Task 23: chart open-interest delta line
- - [x] Task 24: fetch funding rate schedule
- - [x] Task 25: display countdown timer to next funding
- - [x] Task 26: compute Bollinger Band width
+- [x] Task 21: fetch open-interest data from Bybit
+- [x] Task 22: compute 1 h open-interest delta
+- [x] Task 23: chart open-interest delta line
+- [x] Task 24: fetch funding rate schedule
+- [x] Task 25: display countdown timer to next funding
+- [x] Task 26: compute Bollinger Band width
 - [x] Task 27: alert when width falls below threshold
 - [x] Task 28: build volume profile from recent data
 - [x] Task 29: show distance to nearest volume peak
- - [ ] Task 30: fetch 1 h and 4 h candles
- - [ ] Task 31: compare 5 m EMA trend with higher timeframes
- - [ ] Task 32: flag upcoming high-impact economic events
- - [ ] Task 33: notify on daily Google Trends spike
- - [ ] Task 34: integrate mempool fee pressure gauge
- - [ ] Task 35: implement risk/position-size calculator logic
- - [ ] Task 36: add UI for risk/position-size calculator
- - [ ] Task 37: track trades for session stats
- - [ ] Task 38: display session P&L and hit rate
+- [x] Task 30: fetch 1 h and 4 h candles
+- [ ] Task 31: compare 5 m EMA trend with higher timeframes
+- [ ] Task 32: flag upcoming high-impact economic events
+- [ ] Task 33: notify on daily Google Trends spike
+- [ ] Task 34: integrate mempool fee pressure gauge
+- [ ] Task 35: implement risk/position-size calculator logic
+- [ ] Task 36: add UI for risk/position-size calculator
+- [ ] Task 37: track trades for session stats
+- [ ] Task 38: display session P&L and hit rate
 
 ### Volume & Liquidity
- - [ ] Task 39: fetch SPY volume using Yahoo Finance
- - [ ] Task 40: correlate SPY volume with BTC moves
+
+- [ ] Task 39: fetch SPY volume using Yahoo Finance
+- [ ] Task 40: correlate SPY volume with BTC moves
 
 ### Sentiment & Correlation
- - [ ] Task 41: collect Crypto-Twitter sentiment data
- - [ ] Task 42: compute short-term sentiment index
- - [ ] Task 43: stream liquidations and open interest
- - [ ] Task 44: merge liquidation and open-interest data
- - [ ] Task 45: calculate rolling BTC/SPX correlation
- - [ ] Task 46: chart correlation over time
+
+- [ ] Task 41: collect Crypto-Twitter sentiment data
+- [ ] Task 42: compute short-term sentiment index
+- [ ] Task 43: stream liquidations and open interest
+- [ ] Task 44: merge liquidation and open-interest data
+- [ ] Task 45: calculate rolling BTC/SPX correlation
+- [ ] Task 46: chart correlation over time
 
 ### Macro Indicators
- - [ ] Task 47: pull Fed funds rate schedule
- - [ ] Task 48: integrate economic-event calendar feed
+
+- [ ] Task 47: pull Fed funds rate schedule
+- [ ] Task 48: integrate economic-event calendar feed
 
 ### Data Management
- - [ ] Task 49: Binance order-book WebSocket
- - [ ] Task 50: stream Binance OHLCV candles
- - [ ] Task 51: CoinGecko historical BTC fetcher
- - [ ] Task 52: Yahoo Finance fetcher for SPX/SPY/VIX/DXY
- - [ ] Task 53: FRED macro series fetcher
- - [ ] Task 54: caching layer with 15 s TTL and rate limits
+
+- [ ] Task 49: Binance order-book WebSocket
+- [ ] Task 50: stream Binance OHLCV candles
+- [ ] Task 51: CoinGecko historical BTC fetcher
+- [ ] Task 52: Yahoo Finance fetcher for SPX/SPY/VIX/DXY
+- [ ] Task 53: FRED macro series fetcher
+- [ ] Task 54: caching layer with 15 s TTL and rate limits
 
 ### Alerts & Notifications
- - [ ] Task 55: show toast alerts on key events
- - [ ] Task 56: configurable alert panel
- - [ ] Task 57: quick-entry trade journal
- - [ ] Task 58: annotate historical events on the chart
+
+- [ ] Task 55: show toast alerts on key events
+- [ ] Task 56: configurable alert panel
+- [ ] Task 57: quick-entry trade journal
+- [ ] Task 58: annotate historical events on the chart
 
 ### Testing & Validation
- - [ ] Task 59: unit tests for each indicator
- - [ ] Task 60: validate indicators on historical data
- - [ ] Task 61: real-time backtester with metrics
+
+- [ ] Task 59: unit tests for each indicator
+- [ ] Task 60: validate indicators on historical data
+- [ ] Task 61: real-time backtester with metrics
 
 ### Documentation & Configuration
- - [ ] Task 62: generate API reference documentation
- - [ ] Task 63: create user guide
- - [ ] Task 64: write developer setup guide
- - [ ] Task 65: document configuration thresholds
- - [ ] Task 66: describe each configuration parameter
+
+- [ ] Task 62: generate API reference documentation
+- [ ] Task 63: create user guide
+- [ ] Task 64: write developer setup guide
+- [ ] Task 65: document configuration thresholds
+- [ ] Task 66: describe each configuration parameter
 
 ### UI Enhancements
- - [ ] Task 67: key-level proximity indicators
- - [ ] Task 68: customizable TradingView widget
- - [ ] Task 69: one-click indicator toggles
+
+- [ ] Task 67: key-level proximity indicators
+- [ ] Task 68: customizable TradingView widget
+- [ ] Task 69: one-click indicator toggles
 
 ### Performance & Monitoring
- - [ ] Task 70: real-time strategy-performance tracker
- - [ ] Task 71: monitor data latency and system load
+
+- [ ] Task 70: real-time strategy-performance tracker
+- [ ] Task 71: monitor data latency and system load
 
 ---
 
 ## Definition of Done
+
 - Priority widgets and indicators are functional and visible.
 - Test, lint and backtest logs are saved under `/logs`.
- - Each completed task is auto-committed with a passing build.
+- Each completed task is auto-committed with a passing build.
 - `task_queue.json`, `context.snapshot.md` and `memory.md` reflect the new status.
 - Git log mirrors TASKS.md history for quick recovery.
 - `logs/commit.log` provides a concise memory dump via `npm run commitlog`.

--- a/logs/commit.log
+++ b/logs/commit.log
@@ -1,4 +1,3 @@
-dd5af4c | Update AGENTS | Updated AGENTS.md | AGENTS.md | 2025-06-02T19:52:32Z
 98191e9 | Merge task 17 | Merge branch features | AGENTS.md, TASKS.md, context.snapshot.md, package.json, scripts/dev-deps.sh, scripts/try-cmd.js, src/components/OrderBookHeatmap.tsx | 2025-06-02T21:47:20Z
 008cd8e | Add guide | Add auto-instruct codex doc | auto-instruct-codex.md | 2025-06-02T21:57:56Z
 6b2492d | Add doc | Add newcodex1 markdown | newcodex1.md | 2025-06-02T22:11:54Z
@@ -18,3 +17,4 @@ bf9190526674efb5ddf73c162235c286be315bab | Task 28 | Implemented volume profile 
 eee778d | Task 29 | Added volume peak distance component and API | AGENTS.md TASKS.md src/app/api/volume-profile/route.ts src/app/page.tsx src/components/VolumePeakDistance.tsx task_queue.json | 2025-06-03T03:02:04Z
 a3ed0a6 | remove AI tools | cleaned leftover Genkit scripts and dependencies after deleting src/ai | package.json | 2025-06-03T03:36:48Z
 b5ea277 | removed old liquidation modules | src/lib/data/bybitLiquidations.ts src/lib/liquidationClusters.ts | 2025-06-03T05:16:13Z
+ffa63b7 | Task 30 | fetch 1h and 4h candles | TASKS.md, src/app/api/higher-candles/route.ts, src/lib/data/binanceCandles.ts, task_queue.json | 2025-06-03T05:28:46Z

--- a/memory.log
+++ b/memory.log
@@ -23,3 +23,4 @@ bf9190526674efb5ddf73c162235c286be315bab | Task 28 | Implemented volume profile 
 eee778d | Task 29 | Added volume peak distance component and API | AGENTS.md TASKS.md src/app/api/volume-profile/route.ts src/app/page.tsx src/components/VolumePeakDistance.tsx task_queue.json | 2025-06-03T03:02:04Z
 a3ed0a6 | remove AI tools | cleaned leftover Genkit scripts and dependencies after deleting src/ai | package.json | 2025-06-03T03:36:48Z
 b5ea277 | removed old liquidation modules | src/lib/data/bybitLiquidations.ts src/lib/liquidationClusters.ts | 2025-06-03T05:16:13Z
+ffa63b7 | Task 30 | fetch 1h and 4h candles | TASKS.md, src/app/api/higher-candles/route.ts, src/lib/data/binanceCandles.ts, task_queue.json | 2025-06-03T05:28:46Z

--- a/src/app/api/higher-candles/route.ts
+++ b/src/app/api/higher-candles/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import {
+  fetchHourlyCandles,
+  fetchFourHourCandles,
+} from "@/lib/data/binanceCandles";
+
+interface CacheEntry {
+  data: { hourly: any[]; fourHour: any[] };
+  ts: number;
+}
+
+let cache: CacheEntry | null = null;
+const TTL = 60 * 1000;
+
+export async function GET() {
+  if (cache && Date.now() - cache.ts < TTL) {
+    return NextResponse.json({ ...cache.data, status: "cached" });
+  }
+  try {
+    const [hourly, fourHour] = await Promise.all([
+      fetchHourlyCandles(),
+      fetchFourHourCandles(),
+    ]);
+    cache = { data: { hourly, fourHour }, ts: Date.now() };
+    return NextResponse.json({ hourly, fourHour, status: "fresh" });
+  } catch (e) {
+    console.error("Higher timeframe candles error", e);
+    if (cache)
+      return NextResponse.json({ ...cache.data, status: "cached_error" });
+    return NextResponse.json({ hourly: [], fourHour: [], status: "error" });
+  }
+}

--- a/src/lib/data/binanceCandles.ts
+++ b/src/lib/data/binanceCandles.ts
@@ -1,0 +1,39 @@
+import { cachedFetch } from "@/lib/fetchCache";
+
+export interface Candle {
+  openTime: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+  closeTime: number;
+}
+
+const BASE = "https://api.binance.com/api/v3/klines";
+
+async function fetchCandles(
+  interval: "1h" | "4h",
+  limit = 24,
+): Promise<Candle[]> {
+  const url = `${BASE}?symbol=BTCUSDT&interval=${interval}&limit=${limit}`;
+  const data = await cachedFetch<any[]>(url, "reference");
+  if (!Array.isArray(data)) return [];
+  return data.map((k) => ({
+    openTime: Number(k[0]),
+    open: Number(k[1]),
+    high: Number(k[2]),
+    low: Number(k[3]),
+    close: Number(k[4]),
+    volume: Number(k[5]),
+    closeTime: Number(k[6]),
+  }));
+}
+
+export function fetchHourlyCandles(limit = 24): Promise<Candle[]> {
+  return fetchCandles("1h", limit);
+}
+
+export function fetchFourHourCandles(limit = 24): Promise<Candle[]> {
+  return fetchCandles("4h", limit);
+}

--- a/task_queue.json
+++ b/task_queue.json
@@ -1,57 +1,277 @@
 [
-  {"id": 17, "description": "highlight large resting orders on depth heat map", "status": "done"},
-  {"id": 18, "description": "connect to Bybit liquidation WebSocket", "status": "done"},
-  {"id": 19, "description": "aggregate liquidations into clusters", "status": "done"},
-  {"id": 20, "description": "overlay liquidation clusters on chart", "status": "done"},
-  {"id": 21, "description": "fetch open-interest data from Bybit", "status": "done"},
-  {"id": 22, "description": "compute 1 h open-interest delta", "status": "done"},
-  {"id": 23, "description": "chart open-interest delta line", "status": "done"},
-  {"id": 24, "description": "fetch funding rate schedule", "status": "done"},
-  {"id": 25, "description": "display countdown timer to next funding", "status": "done"},
-  {"id": 26, "description": "compute Bollinger Band width", "status": "done"},
-  {"id": 27, "description": "alert when width falls below threshold", "status": "done"},
-  {"id": 28, "description": "build volume profile from recent data", "status": "done"},
-  {"id": 29, "description": "show distance to nearest volume peak", "status": "done"},
-  {"id": 30, "description": "fetch 1 h and 4 h candles", "status": "pending"},
-  {"id": 31, "description": "compare 5 m EMA trend with higher timeframes", "status": "pending"},
-  {"id": 32, "description": "flag upcoming high-impact economic events", "status": "pending"},
-  {"id": 33, "description": "notify on daily Google Trends spike", "status": "pending"},
-  {"id": 34, "description": "integrate mempool fee pressure gauge", "status": "pending"},
-  {"id": 35, "description": "implement risk/position-size calculator logic", "status": "pending"},
-  {"id": 36, "description": "add UI for risk/position-size calculator", "status": "pending"},
-  {"id": 37, "description": "track trades for session stats", "status": "pending"},
-  {"id": 38, "description": "display session P&L and hit rate", "status": "pending"},
-  {"id": 39, "description": "fetch SPY volume using Yahoo Finance", "status": "pending"},
-  {"id": 40, "description": "correlate SPY volume with BTC moves", "status": "pending"},
-  {"id": 41, "description": "collect Crypto-Twitter sentiment data", "status": "pending"},
-  {"id": 42, "description": "compute short-term sentiment index", "status": "pending"},
-  {"id": 43, "description": "stream liquidations and open interest", "status": "pending"},
-  {"id": 44, "description": "merge liquidation and OI signals", "status": "pending"},
-  {"id": 45, "description": "calculate rolling BTC/SPX correlation", "status": "pending"},
-  {"id": 46, "description": "chart correlation over time", "status": "pending"},
-  {"id": 47, "description": "pull Fed funds rate schedule", "status": "pending"},
-  {"id": 48, "description": "integrate economic-event calendar feed", "status": "pending"},
-  {"id": 49, "description": "Binance order-book WebSocket", "status": "pending"},
-  {"id": 50, "description": "stream Binance OHLCV candles", "status": "pending"},
-  {"id": 51, "description": "CoinGecko historical BTC fetcher", "status": "pending"},
-  {"id": 52, "description": "Yahoo Finance fetcher for SPX/SPY/VIX/DXY", "status": "pending"},
-  {"id": 53, "description": "FRED macro series fetcher", "status": "pending"},
-  {"id": 54, "description": "caching layer with 15 s TTL and rate limits", "status": "pending"},
-  {"id": 55, "description": "show toast alerts on signals", "status": "pending"},
-  {"id": 56, "description": "configurable alert panel", "status": "pending"},
-  {"id": 57, "description": "quick-entry trade journal", "status": "pending"},
-  {"id": 58, "description": "annotate historical signals on the chart", "status": "pending"},
-  {"id": 59, "description": "unit tests for each indicator", "status": "pending"},
-  {"id": 60, "description": "validate indicators on historical data", "status": "pending"},
-  {"id": 61, "description": "real-time backtester with metrics", "status": "pending"},
-  {"id": 62, "description": "generate API reference documentation", "status": "pending"},
-  {"id": 63, "description": "create user guide", "status": "pending"},
-  {"id": 64, "description": "write developer setup guide", "status": "pending"},
-  {"id": 65, "description": "document signals.json thresholds", "status": "pending"},
-  {"id": 66, "description": "describe each configuration parameter", "status": "pending"},
-  {"id": 67, "description": "key-level proximity indicators", "status": "pending"},
-  {"id": 68, "description": "customizable TradingView widget", "status": "pending"},
-  {"id": 69, "description": "one-click indicator toggles", "status": "pending"},
-  {"id": 70, "description": "real-time strategy-performance tracker", "status": "pending"},
-  {"id": 71, "description": "monitor data latency and system load", "status": "pending"}
+  {
+    "id": 17,
+    "description": "highlight large resting orders on depth heat map",
+    "status": "done"
+  },
+  {
+    "id": 18,
+    "description": "connect to Bybit liquidation WebSocket",
+    "status": "done"
+  },
+  {
+    "id": 19,
+    "description": "aggregate liquidations into clusters",
+    "status": "done"
+  },
+  {
+    "id": 20,
+    "description": "overlay liquidation clusters on chart",
+    "status": "done"
+  },
+  {
+    "id": 21,
+    "description": "fetch open-interest data from Bybit",
+    "status": "done"
+  },
+  {
+    "id": 22,
+    "description": "compute 1 h open-interest delta",
+    "status": "done"
+  },
+  {
+    "id": 23,
+    "description": "chart open-interest delta line",
+    "status": "done"
+  },
+  {
+    "id": 24,
+    "description": "fetch funding rate schedule",
+    "status": "done"
+  },
+  {
+    "id": 25,
+    "description": "display countdown timer to next funding",
+    "status": "done"
+  },
+  {
+    "id": 26,
+    "description": "compute Bollinger Band width",
+    "status": "done"
+  },
+  {
+    "id": 27,
+    "description": "alert when width falls below threshold",
+    "status": "done"
+  },
+  {
+    "id": 28,
+    "description": "build volume profile from recent data",
+    "status": "done"
+  },
+  {
+    "id": 29,
+    "description": "show distance to nearest volume peak",
+    "status": "done"
+  },
+  {
+    "id": 30,
+    "description": "fetch 1 h and 4 h candles",
+    "status": "done"
+  },
+  {
+    "id": 31,
+    "description": "compare 5 m EMA trend with higher timeframes",
+    "status": "pending"
+  },
+  {
+    "id": 32,
+    "description": "flag upcoming high-impact economic events",
+    "status": "pending"
+  },
+  {
+    "id": 33,
+    "description": "notify on daily Google Trends spike",
+    "status": "pending"
+  },
+  {
+    "id": 34,
+    "description": "integrate mempool fee pressure gauge",
+    "status": "pending"
+  },
+  {
+    "id": 35,
+    "description": "implement risk/position-size calculator logic",
+    "status": "pending"
+  },
+  {
+    "id": 36,
+    "description": "add UI for risk/position-size calculator",
+    "status": "pending"
+  },
+  {
+    "id": 37,
+    "description": "track trades for session stats",
+    "status": "pending"
+  },
+  {
+    "id": 38,
+    "description": "display session P&L and hit rate",
+    "status": "pending"
+  },
+  {
+    "id": 39,
+    "description": "fetch SPY volume using Yahoo Finance",
+    "status": "pending"
+  },
+  {
+    "id": 40,
+    "description": "correlate SPY volume with BTC moves",
+    "status": "pending"
+  },
+  {
+    "id": 41,
+    "description": "collect Crypto-Twitter sentiment data",
+    "status": "pending"
+  },
+  {
+    "id": 42,
+    "description": "compute short-term sentiment index",
+    "status": "pending"
+  },
+  {
+    "id": 43,
+    "description": "stream liquidations and open interest",
+    "status": "pending"
+  },
+  {
+    "id": 44,
+    "description": "merge liquidation and OI signals",
+    "status": "pending"
+  },
+  {
+    "id": 45,
+    "description": "calculate rolling BTC/SPX correlation",
+    "status": "pending"
+  },
+  {
+    "id": 46,
+    "description": "chart correlation over time",
+    "status": "pending"
+  },
+  {
+    "id": 47,
+    "description": "pull Fed funds rate schedule",
+    "status": "pending"
+  },
+  {
+    "id": 48,
+    "description": "integrate economic-event calendar feed",
+    "status": "pending"
+  },
+  {
+    "id": 49,
+    "description": "Binance order-book WebSocket",
+    "status": "pending"
+  },
+  {
+    "id": 50,
+    "description": "stream Binance OHLCV candles",
+    "status": "pending"
+  },
+  {
+    "id": 51,
+    "description": "CoinGecko historical BTC fetcher",
+    "status": "pending"
+  },
+  {
+    "id": 52,
+    "description": "Yahoo Finance fetcher for SPX/SPY/VIX/DXY",
+    "status": "pending"
+  },
+  {
+    "id": 53,
+    "description": "FRED macro series fetcher",
+    "status": "pending"
+  },
+  {
+    "id": 54,
+    "description": "caching layer with 15 s TTL and rate limits",
+    "status": "pending"
+  },
+  {
+    "id": 55,
+    "description": "show toast alerts on signals",
+    "status": "pending"
+  },
+  {
+    "id": 56,
+    "description": "configurable alert panel",
+    "status": "pending"
+  },
+  {
+    "id": 57,
+    "description": "quick-entry trade journal",
+    "status": "pending"
+  },
+  {
+    "id": 58,
+    "description": "annotate historical signals on the chart",
+    "status": "pending"
+  },
+  {
+    "id": 59,
+    "description": "unit tests for each indicator",
+    "status": "pending"
+  },
+  {
+    "id": 60,
+    "description": "validate indicators on historical data",
+    "status": "pending"
+  },
+  {
+    "id": 61,
+    "description": "real-time backtester with metrics",
+    "status": "pending"
+  },
+  {
+    "id": 62,
+    "description": "generate API reference documentation",
+    "status": "pending"
+  },
+  {
+    "id": 63,
+    "description": "create user guide",
+    "status": "pending"
+  },
+  {
+    "id": 64,
+    "description": "write developer setup guide",
+    "status": "pending"
+  },
+  {
+    "id": 65,
+    "description": "document signals.json thresholds",
+    "status": "pending"
+  },
+  {
+    "id": 66,
+    "description": "describe each configuration parameter",
+    "status": "pending"
+  },
+  {
+    "id": 67,
+    "description": "key-level proximity indicators",
+    "status": "pending"
+  },
+  {
+    "id": 68,
+    "description": "customizable TradingView widget",
+    "status": "pending"
+  },
+  {
+    "id": 69,
+    "description": "one-click indicator toggles",
+    "status": "pending"
+  },
+  {
+    "id": 70,
+    "description": "real-time strategy-performance tracker",
+    "status": "pending"
+  },
+  {
+    "id": 71,
+    "description": "monitor data latency and system load",
+    "status": "pending"
+  }
 ]


### PR DESCRIPTION
## Summary
- add Binance candle fetcher
- expose hourly & four-hour candle API
- mark Task 30 complete and update memory

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_683e86a60c4c8323b06b5877cd973c51