### PR TITLE
Update workflow instructions for memory.log

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -8,17 +8,17 @@ All tasks live in `task_queue.json` as `{ "id": number, "description": string, "
 
 ## Workflow
 
-1. Review `context.snapshot.md`, `memory.md` and `logs/commit.log` for context.
+1. Review `memory.log` and `logs/commit.log` for context.
 2. Run `npm run auto` to let the AutoTaskRunner process tasks sequentially.
 3. Tasks are loaded from `task_queue.json`; keep this file in sync with the checklist.
 4. Each task runs lint, test and backtest.
 5. After success the task is marked `[x]` and `task_queue.json` is updated.
-6. Append the 333‑token commit summary with hash and files to `context.snapshot.md` and `memory.md` using the one-line format described in `AGENTS.md`.
+6. Append the 333‑token commit summary with hash and files to `memory.log` using the one-line format described in `AGENTS.md`.
 7. The commit message begins with `Task <number>:` so the git log stays in sync with the memory files.
 8. Run `npm run commitlog` after committing to capture the latest history.
-9. Review `logs/commit.log` before starting a new session and reload recent summaries from `memory.md`.
+9. Review `logs/commit.log` before starting a new session and reload recent summaries from `memory.log`.
 10. The runner rebases on `main` and pushes after each commit.
-11. Reference commit hashes from `memory.md` when creating follow-up tasks.
+11. Reference commit hashes from `memory.log` when creating follow-up tasks.
 
 ---
 


### PR DESCRIPTION
## Summary
- update `TASKS.md` workflow to use `memory.log`
- mention only `memory.log` and `logs/commit.log` when saving commit summaries

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`
- `npm run commitlog`


------
https://chatgpt.com/codex/tasks/task_b_683ed67d62bc8323a342e0047bbd8a9a