### PR TITLE
Update memory docs and script references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,8 +167,11 @@ export interface AgentMessage<T = unknown> {
 | `npm run test`     | Jest unit tests          |
 | `npm run backtest` | Historical strategy test |
 | `npm run dev-deps` | Install local dev deps   |
+| `npm run commitlog` | Update `logs/commit.log` |
+| `npm run auto` | Process tasks via AutoTaskRunner |
+| `npm run bootstrap` | Install deps then lint, test and backtest |
 
-Run `npm ci` once when the environment starts (or `npm run dev-deps` if offline). Reuse dependencies for subsequent tasks. If installation fails due to missing network access, continue using the helper scripts which skip missing binaries so lint, test and backtest do not block commits.
+Run `npm ci` once when the environment starts (or `npm run dev-deps` if offline). `bash scripts/check-env.sh` verifies that `next`, `jest` and `ts-node` are available. The helper `scripts/try-cmd.js` is used by lint, test and backtest commands to skip missing binaries so automation never blocks.
 
 ---
 
@@ -185,8 +188,8 @@ Run `npm ci` once when the environment starts (or `npm run dev-deps` if offline)
 
 ## 9 · Commit-Based Memory Workflow
 
-1. **Pre-Session** – read `memory.log` and recent commits.
-2. **After Commit** – append the 333‑token summary to `memory.log` and run `npm run commitlog`.
+1. **Pre-Session** – run `npm run dev-deps` if `node_modules` is missing, then read `memory.log` and recent commits.
+2. **After Commit** – append the 333‑token summary to `memory.log`, run `npm run commitlog` and continue with `npm run auto` when applicable.
 3. **Sync Tasks** – update `task_queue.json` and check the box in `TASKS.md`.
 4. **Reference History** – use commit hashes from `memory.log` when describing follow-up tasks.
 

--- a/PERSISTENT_MEMORY_GUIDE.md
+++ b/PERSISTENT_MEMORY_GUIDE.md
@@ -32,7 +32,8 @@
 
 * Keep each block ≤ 333 tokens.
 * UTC timestamp format `YYYY‑MM‑DD HH:MM UTC`.
-* Monotonic `mem‑###` counter.
+* Monotonic `mem‑###` counter. The `mem‑ID` value is global and keeps increasing
+  even when snapshots are archived.
 * Never alter prior blocks; use append‑only semantics.
 
 ---

--- a/README.md
+++ b/README.md
@@ -120,3 +120,14 @@ npm run commitlog
 5. When resuming after a break, run `npm run commitlog` to review recent commits.
 6. Test and backtest outputs are logged in `logs/`.
 
+## Automation Scripts
+
+| Command | Purpose |
+| ------- | ------- |
+| `npm run auto` | Execute the AutoTaskRunner to process tasks in `task_queue.json` |
+| `npm run commitlog` | Generate `logs/commit.log` from the last entries in `memory.log` |
+| `npm run dev-deps` | Install dev dependencies if `node_modules` is missing |
+| `bash scripts/check-env.sh` | Verify required CLIs (`next`, `jest`, `ts-node`) are installed |
+| `node scripts/try-cmd.js <cmd>` | Run a command only if the binary exists |
+| `npm run backtest` | Launch the backtest defined in `scripts/backtest.ts` |
+


### PR DESCRIPTION
## Summary
- clarify global mem-ID counter in persistent memory guide
- list automation scripts in README with usage notes
- mention new helper scripts in AGENTS table
- tweak memory workflow instructions to run helper scripts

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_683f005616d08323b17255053da21724