### PR TITLE
Task 32: unify memory error handling

### DIFF
--- a/PERSISTENT_MEMORY_GUIDE.md
+++ b/PERSISTENT_MEMORY_GUIDE.md
@@ -1,6 +1,6 @@
-# PERSISTENT\_MEMORY\_GUIDE.md – Codex Memory‑Maintenance Rules
+# PERSISTENT_MEMORY_GUIDE.md – Codex Memory‑Maintenance Rules
 
-> **Mission:** Maintain the repository’s persistent memory **only**.  Codex may touch *documentation and agent‑instruction* files but **must never modify application code** (TypeScript, React, configs, builds).  All activity revolves around appending or archiving memory blocks and keeping the docs that govern that workflow up‑to‑date.
+> **Mission:** Maintain the repository’s persistent memory **only**. Codex may touch _documentation and agent‑instruction_ files but **must never modify application code** (TypeScript, React, configs, builds). All activity revolves around appending or archiving memory blocks and keeping the docs that govern that workflow up‑to‑date.
 
 ---
 
@@ -10,12 +10,12 @@
 | ---------------------------- | ----------------------------------- | ----------------------------------------------------------------------------------------- |
 | `context.snapshot.md`        | Live chronological memory log       | **Append‑only** new blocks                                                                |
 | `archive/`                   | Historical snapshots (month‑rolled) | Create new archive files, move old blocks                                                 |
-| `PERSISTENT_MEMORY_GUIDE.md` | This rule set                       | Amend wording or policy *only* to clarify memory workflow                                 |
+| `PERSISTENT_MEMORY_GUIDE.md` | This rule set                       | Amend wording or policy _only_ to clarify memory workflow                                 |
 | `AGENTS.md`                  | Agent charter                       | Update **memory‑related sections** or references to snapshot workflow. No other sections. |
-| `TASKS.md`                   | Task queue                          | Add / reorder / clarify *documentation or memory* tasks. **Do NOT add code tasks.**       |
+| `TASKS.md`                   | Task queue                          | Add / reorder / clarify _documentation or memory_ tasks. **Do NOT add code tasks.**       |
 | `/logs/memory‑*.txt`         | Diagnostic logs on failure          | Auto‑generate                                                                             |
 
-> **Forbidden:** Editing any `.ts`, `.tsx`, `.js`, runtime `.json` (except archives), `/app`, `/lib`, build files, or config files unrelated to memory.  If uncertain, log an error and stop.
+> **Forbidden:** Editing any `.ts`, `.tsx`, `.js`, runtime `.json` (except archives), `/app`, `/lib`, build files, or config files unrelated to memory. If uncertain, log an error and stop.
 
 ---
 
@@ -23,6 +23,7 @@
 
 ```md
 ### 2025‑06‑05 14:12 UTC | mem‑001
+
 - **Commit SHA:** abc123f
 - **Summary:** <≤333‑token description of change>
 - **Next Goal:** <next memory or doc objective>
@@ -30,20 +31,20 @@
 
 **Rules**
 
-* Keep each block ≤ 333 tokens.
-* UTC timestamp format `YYYY‑MM‑DD HH:MM UTC`.
-* Monotonic `mem‑###` counter.
-* Never alter prior blocks; use append‑only semantics.
+- Keep each block ≤ 333 tokens.
+- UTC timestamp format `YYYY‑MM‑DD HH:MM UTC`.
+- Monotonic `mem‑###` counter.
+- Never alter prior blocks; use append‑only semantics.
 
 ---
 
 ## 3 · Commit Policy
 
-* **One memory/document task → one commit.**
-* Allowed commit types: `docs(memory)` or `chore(memory)`.
-* Subject line ≤ 50 chars and must include `mem‑ID`.
-* Commit body **must equal** the memory block being appended (plus optional diagnostics below it).
-* For changes in `AGENTS.md` or `TASKS.md`, mention them briefly in the summary.
+- **One memory/document task → one commit.**
+- Allowed commit types: `docs(memory)` or `chore(memory)`.
+- Subject line ≤ 50 chars and must include `mem‑ID`.
+- Commit body **must equal** the memory block being appended (plus optional diagnostics below it).
+- For changes in `AGENTS.md` or `TASKS.md`, mention them briefly in the summary.
 
 Example commit message:
 
@@ -63,12 +64,34 @@ docs(memory): mem‑031 archive May‑2025 snapshot
 1. **Append Snapshot** – default action on each run.
 2. **Archive Older Snapshots** – trigger when `context.snapshot.md` > 5 000 lines **or** calendar month changes:
 
-   * Move all but the last block to `archive/context_snapshot_<YYYY‑MM>.md`.
-   * Log an archive memory block.
+   - Move all but the last block to `archive/context_snapshot_<YYYY‑MM>.md`.
+   - Log an archive memory block.
+
 3. **Update Docs** – if snapshot format, counter, or archive policy needs change, update this guide (`PERSISTENT_MEMORY_GUIDE.md`) **and** the relevant memory sections of `AGENTS.md` and `TASKS.md`.
-4. **Diagnostics** – on any append/archive error, write `/logs/memory‑error‑<timestamp>.txt`.
+4. **Diagnostics** – on any append/archive error, write `/logs/memory-error-<timestamp>.txt`.
 
 No other edits are allowed.
+
+### Log Examples
+
+`memory.log` lines follow this pipe-delimited format:
+
+```
+<hash> | <task or note> | <summary> | <files> | <ISO timestamp>
+```
+
+Example:
+
+```
+abc1234 | Task 31 | Removed obsolete migrate-memory script | scripts/migrate-memory.js | 2025-06-03T11:06:03Z
+```
+
+Errors append output and stack trace to files like `logs/memory-error-2025-06-03T11-10-00Z.txt`.
+
+```
+<command output>
+Error: stack trace...
+```
 
 ---
 
@@ -89,11 +112,11 @@ You are Codex DocAgent. Focus solely on persistent‑memory maintenance.
 
 ### Checklist for Codex
 
-* [ ] Read last snapshot & line count.
-* [ ] Decide: append or archive.
-* [ ] Perform memory/document task only.
-* [ ] Run `npm run lint` (markdown lint) if available.
-* [ ] Commit & push.
-* [ ] Verify **only allowed files** changed.
+- [ ] Read last snapshot & line count.
+- [ ] Decide: append or archive.
+- [ ] Perform memory/document task only.
+- [ ] Run `npm run lint` (markdown lint) if available.
+- [ ] Commit & push.
+- [ ] Verify **only allowed files** changed.
 
 > **Remember:** No application code edits. Your sole domain is documentation & memory integrity.

--- a/logs/commit.log
+++ b/logs/commit.log
@@ -1,5 +1,3 @@
-ee5bc9e | Docs | Refine memory and task sync | AGENTS.md, TASKS.md | 2025-06-02T23:10:57Z
-ab0b2fa | Docs | Refine memory and task sync | AGENTS.md, TASKS.md, logs/commit.log | 2025-06-02T23:21:07Z
 5a61018 | Docs | Clarify persistent memory steps | AGENTS.md, TASKS.md | 2025-06-02T23:32:18Z
 2e9e35e | Docs tasks | Expand task list granularity | TASKS.md | 2025-06-02T23:46:36Z
 7f94b9c | Sync tasks | Updated task_queue.json to match granular checklist | task_queue.json | 2025-06-02T23:54:52Z
@@ -18,3 +16,5 @@ a3ed0a6 | remove AI tools | cleaned leftover Genkit scripts and dependencies aft
 b5ea277 | removed old liquidation modules | src/lib/data/bybitLiquidations.ts src/lib/liquidationClusters.ts | 2025-06-03T05:16:13Z
 ffa63b7 | Task 30 | fetch 1h and 4h candles | TASKS.md, src/app/api/higher-candles/route.ts, src/lib/data/binanceCandles.ts, task_queue.json | 2025-06-03T05:28:46Z
 2813caa | Task 31 | Removed obsolete migrate-memory script | scripts/migrate-memory.js | 2025-06-03T11:06:03Z
+668e0c0 | fix(signals) | update last task completion to 31 | signals.json | 2025-06-03T11:23:26Z
+ae72496 | Task 32 | unify memory error handling | scripts/autoTaskRunner.js, scripts/commit-log.js, PERSISTENT_MEMORY_GUIDE.md | 2025-06-03T14:04:54Z

--- a/memory.log
+++ b/memory.log
@@ -26,3 +26,4 @@ b5ea277 | removed old liquidation modules | src/lib/data/bybitLiquidations.ts sr
 ffa63b7 | Task 30 | fetch 1h and 4h candles | TASKS.md, src/app/api/higher-candles/route.ts, src/lib/data/binanceCandles.ts, task_queue.json | 2025-06-03T05:28:46Z
 2813caa | Task 31 | Removed obsolete migrate-memory script | scripts/migrate-memory.js | 2025-06-03T11:06:03Z
 668e0c0 | fix(signals) | update last task completion to 31 | signals.json | 2025-06-03T11:23:26Z
+ae72496 | Task 32 | unify memory error handling | scripts/autoTaskRunner.js, scripts/commit-log.js, PERSISTENT_MEMORY_GUIDE.md | 2025-06-03T14:04:54Z

--- a/scripts/autoTaskRunner.js
+++ b/scripts/autoTaskRunner.js
@@ -1,53 +1,70 @@
-const fs = require('fs');
-const path = require('path');
-const { spawnSync, execSync } = require('child_process');
+const fs = require("fs");
+const path = require("path");
+const { spawnSync, execSync } = require("child_process");
 
 function run(cmd) {
-  const res = spawnSync(cmd, { shell: true, encoding: 'utf8' });
-  return { output: (res.stdout || '') + (res.stderr || ''), code: res.status };
+  try {
+    const res = spawnSync(cmd, { shell: true, encoding: "utf8" });
+    const output = (res.stdout || "") + (res.stderr || "");
+    if (res.error) logError(res.error, output);
+    return { output, code: res.status };
+  } catch (err) {
+    logError(err);
+    return { output: "", code: 1 };
+  }
 }
 
 function tryExec(cmd) {
   try {
-    execSync(cmd, { stdio: 'inherit' });
+    return execSync(cmd, { stdio: "pipe", encoding: "utf8" });
   } catch (e) {
+    const output = (e.stdout || "") + (e.stderr || "");
+    logError(e, output);
     console.error(`Command failed: ${cmd}`);
+    return "";
   }
 }
 
-const repoRoot = path.resolve(__dirname, '..');
-const tasksPath = path.join(repoRoot, 'TASKS.md');
-const signalsPath = path.join(repoRoot, 'signals.json');
-const logDir = path.join(repoRoot, 'logs');
+const repoRoot = path.resolve(__dirname, "..");
+const tasksPath = path.join(repoRoot, "TASKS.md");
+const signalsPath = path.join(repoRoot, "signals.json");
+const logDir = path.join(repoRoot, "logs");
 fs.mkdirSync(logDir, { recursive: true });
-const memoryPath = path.join(repoRoot, 'memory.log');
+
+function logError(err, output = "") {
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const file = path.join(logDir, `memory-error-${ts}.txt`);
+  const content = `${output}\n${err.stack || err}\n`;
+  fs.appendFileSync(file, content);
+}
+const memoryPath = path.join(repoRoot, "memory.log");
 process.chdir(repoRoot);
 
-tryExec('npm ci');
+tryExec("npm ci");
 
 while (true) {
-  const lines = fs.readFileSync(tasksPath, 'utf8').split('\n');
-  const idx = lines.findIndex(l => l.startsWith('- [ ]'));
+  const lines = fs.readFileSync(tasksPath, "utf8").split("\n");
+  const idx = lines.findIndex((l) => l.startsWith("- [ ]"));
   if (idx === -1) {
-    console.log('No open tasks found.');
+    console.log("No open tasks found.");
     break;
   }
 
   let taskLine = lines[idx];
-  let taskDesc = taskLine.replace('- [ ]', '').trim();
-  const signals = JSON.parse(fs.readFileSync(signalsPath, 'utf8'));
+  let taskDesc = taskLine.replace("- [ ]", "").trim();
+  const signals = JSON.parse(fs.readFileSync(signalsPath, "utf8"));
   const explicit = taskDesc.match(/Task\s*(\d+)\s*:/i);
   const taskNum = explicit
     ? parseInt(explicit[1], 10)
-    : typeof signals.last_task_completed === 'number'
+    : typeof signals.last_task_completed === "number"
       ? signals.last_task_completed + 1
       : 0;
-  if (explicit) taskDesc = taskDesc.replace(explicit[0], '').trim();
+  if (explicit) taskDesc = taskDesc.replace(explicit[0], "").trim();
 
-  lines[idx] = taskLine.replace('- [ ]', '- [x]');
-  fs.writeFileSync(tasksPath, lines.join('\n'));
+  lines[idx] = taskLine.replace("- [ ]", "- [x]");
+  fs.writeFileSync(tasksPath, lines.join("\n"));
   signals.last_task_completed = taskNum;
-  fs.writeFileSync(signalsPath, JSON.stringify(signals, null, 2) + '\n');
+  fs.writeFileSync(signalsPath, JSON.stringify(signals, null, 2) + "\n");
 
   let success = true;
   function logRun(name, cmd) {
@@ -56,53 +73,59 @@ while (true) {
     if (res.code !== 0) success = false;
   }
 
-  logRun('lint', 'npm run lint');
-  logRun('test', 'npm run test');
-  logRun('backtest', 'npm run backtest');
+  logRun("lint", "npm run lint");
+  logRun("test", "npm run test");
+  logRun("backtest", "npm run backtest");
 
   if (!success) {
     signals.error_flag = true;
-    fs.writeFileSync(signalsPath, JSON.stringify(signals, null, 2) + '\n');
-    fs.writeFileSync(path.join(logDir, `block-${taskNum}.txt`), 'Task failed.');
-    console.error('Task failed. See logs for details.');
+    fs.writeFileSync(signalsPath, JSON.stringify(signals, null, 2) + "\n");
+    fs.writeFileSync(path.join(logDir, `block-${taskNum}.txt`), "Task failed.");
+    logError(new Error("Task failed"));
+    console.error("Task failed. See logs for details.");
     process.exit(1);
   }
 
-  execSync('git add TASKS.md logs signals.json');
+  execSync("git add TASKS.md logs signals.json");
 
-  const nextIdx = lines.findIndex(l => l.startsWith('- [ ]'));
-  const nextTask = nextIdx === -1 ? 'none' : lines[nextIdx].replace('- [ ]', '').trim();
+  const nextIdx = lines.findIndex((l) => l.startsWith("- [ ]"));
+  const nextTask =
+    nextIdx === -1 ? "none" : lines[nextIdx].replace("- [ ]", "").trim();
 
   function generateBody(desc) {
     const part1 = `What I did: ${desc}`;
     const part2 = `What's next: continue with the remaining tasks.`;
-    let words = (part1 + ' ' + part2).trim().split(/\s+/);
+    let words = (part1 + " " + part2).trim().split(/\s+/);
     const fillerCount = 333 - words.length;
     if (fillerCount > 0) {
-      words = words.concat(new Array(fillerCount).fill('context'));
+      words = words.concat(new Array(fillerCount).fill("context"));
     }
-    return `${part1}\n\n${part2}\n\n${words.slice((part1 + ' ' + part2).trim().split(/\s+/).length).join(' ')}`;
+    return `${part1}\n\n${part2}\n\n${words.slice((part1 + " " + part2).trim().split(/\s+/).length).join(" ")}`;
   }
 
   const body = generateBody(taskDesc).replace(/"/g, '\"');
 
-  const diffFiles = execSync('git diff --cached --name-only', { encoding: 'utf8' })
+  const diffFiles = execSync("git diff --cached --name-only", {
+    encoding: "utf8",
+  })
     .trim()
-    .split('\n')
+    .split("\n")
     .filter(Boolean)
-    .join(', ');
+    .join(", ");
 
   const header = `Task ${taskNum}: ${taskDesc}`;
   execSync(`git commit -m "${header}" -m "${body}"`);
 
-  const hash = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
+  const hash = execSync("git rev-parse --short HEAD", {
+    encoding: "utf8",
+  }).trim();
   const entry = `${hash} | Task ${taskNum} | ${taskDesc} | ${diffFiles} | ${new Date().toISOString()}\n`;
   fs.appendFileSync(memoryPath, entry);
   execSync(`git add ${memoryPath}`);
   execSync(`git commit -m "chore(memory): record task ${taskNum}"`);
 
-  tryExec('git pull --rebase origin main');
-  tryExec('git push origin HEAD:main');
+  tryExec("git pull --rebase origin main");
+  tryExec("git push origin HEAD:main");
 
-  tryExec('npm run commitlog');
+  tryExec("npm run commitlog");
 }

--- a/scripts/commit-log.js
+++ b/scripts/commit-log.js
@@ -1,13 +1,28 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
-const memPath = path.join(__dirname, '../memory.log');
-let lines = [];
-if (fs.existsSync(memPath)) {
-  lines = fs.readFileSync(memPath, 'utf8').trim().split('\n');
+const memPath = path.join(__dirname, "../memory.log");
+const logDir = path.join(__dirname, "../logs");
+fs.mkdirSync(logDir, { recursive: true });
+
+function logError(err, output = "") {
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const file = path.join(logDir, `memory-error-${ts}.txt`);
+  const content = `${output}\n${err.stack || err}\n`;
+  fs.appendFileSync(file, content);
 }
-const log = lines.slice(-20).join('\n');
-const outPath = path.join(__dirname, '../logs/commit.log');
-fs.writeFileSync(outPath, log + '\n');
-console.log(`Commit log written to ${outPath}`);
 
+try {
+  let lines = [];
+  if (fs.existsSync(memPath)) {
+    lines = fs.readFileSync(memPath, "utf8").trim().split("\n");
+  }
+  const log = lines.slice(-20).join("\n");
+  const outPath = path.join(logDir, "commit.log");
+  fs.writeFileSync(outPath, log + "\n");
+  console.log(`Commit log written to ${outPath}`);
+} catch (err) {
+  logError(err);
+  console.error("Failed to write commit log");
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- handle spawn and exec errors for autoTaskRunner
- capture failures when generating commit logs
- show example `memory.log` and error log formats in the guide
- record task completion in memory log

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_683f0053fb248323a8b4ee5414b7dabe