### PR TITLE
Improve memory append durability

### DIFF
--- a/PERSISTENT_MEMORY_GUIDE.md
+++ b/PERSISTENT_MEMORY_GUIDE.md
@@ -102,7 +102,8 @@ You are Codex DocAgent. Focus solely on persistent‑memory maintenance.
 ## 6 · append-memory.sh
 
 Run `scripts/append-memory.sh "Summary" "Next goal"` to append a new memory block.
-The script reads the last `mem-###` ID in `context.snapshot.md`, increments it,
-and writes the block with the current UTC timestamp and short commit hash. It
-uses a temporary file and atomic move to avoid corruption. If the append fails,
-a log is written to `logs/memory-error-<timestamp>.txt`.
+The script reads only the last 20 lines of `context.snapshot.md` to find the most
+recent `mem-###` ID, increments it, and writes the block with the current UTC
+timestamp and short commit hash. The data is written to a temporary file, flushed
+to disk with `fsync`, and then atomically moved into place to avoid corruption.
+If the append fails, a log is written to `logs/memory-error-<timestamp>.txt`.

--- a/scripts/append-memory.sh
+++ b/scripts/append-memory.sh
@@ -13,7 +13,7 @@ on_error() {
 }
 trap on_error ERR
 
-last_id=$(grep -o 'mem-[0-9]\+' "$MEM_FILE" | tail -n 1 | grep -o '[0-9]\+' || echo '0')
+last_id=$(tail -n 20 "$MEM_FILE" | grep -o 'mem-[0-9]\+' | tail -n 1 | grep -o '[0-9]\+' || echo '0')
 next_id=$(printf "%03d" $((10#$last_id + 1)))
 
 timestamp=$(date -u '+%Y-%m-%d %H:%M UTC')
@@ -30,5 +30,11 @@ cat "$MEM_FILE" > "$TMP"
   echo "- Summary: $summary"
   echo "- Next Goal: $next_goal"
 } >> "$TMP"
+python3 - <<'EOF'
+import os, sys
+fd = os.open(sys.argv[1], os.O_RDWR)
+os.fsync(fd)
+os.close(fd)
+EOF "$TMP"
 mv "$TMP" "$MEM_FILE"
 


### PR DESCRIPTION
## Summary
- only scan the last 20 lines when finding the last mem ID
- fsync temporary memory file before moving it into place
- document the durability change in the persistent memory guide

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_683f0776995c83238e4793ffe353023e