### PR TITLE
Update memory policy & fix append script

### DIFF
--- a/PERSISTENT_MEMORY_GUIDE.md
+++ b/PERSISTENT_MEMORY_GUIDE.md
@@ -9,6 +9,7 @@
 | File / Directory             | Purpose                             | Allowed Actions                                                                           |
 | ---------------------------- | ----------------------------------- | ----------------------------------------------------------------------------------------- |
 | `context.snapshot.md`        | Live chronological memory log       | **Append‑only** new blocks                                                                |
+| `memory.log`                 | Commit summary history              | Append commit info after each commit |
 | `archive/`                   | Historical snapshots (month‑rolled) | Create new archive files, move old blocks                                                 |
 | `PERSISTENT_MEMORY_GUIDE.md` | This rule set                       | Amend wording or policy *only* to clarify memory workflow                                 |
 | `AGENTS.md`                  | Agent charter                       | Update **memory‑related sections** or references to snapshot workflow. No other sections. |

--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -2,3 +2,7 @@
 - Commit SHA: 4d8e022
 - Summary: Initialized persistent memory tracking by creating `context.snapshot.md`. Added this snapshot file to the memory section of `AGENTS.md` so future agents append updates. Summarized the repository's status after early cleanup and completion of tasks up to 31. Documentation tasks starting at 62 remain pending. This foundation ensures continuity for upcoming work.
 - Next Goal: Generate API reference documentation for existing modules.
+### 2025-06-03 14:46 UTC | mem-002
+- Commit SHA: 59778e6
+- Summary: Allow editing memory.log in guide
+- Next Goal: Verify memory logs are complete

--- a/scripts/append-memory.sh
+++ b/scripts/append-memory.sh
@@ -30,11 +30,11 @@ cat "$MEM_FILE" > "$TMP"
   echo "- Summary: $summary"
   echo "- Next Goal: $next_goal"
 } >> "$TMP"
-python3 - <<'EOF'
+python3 - "$TMP" <<'EOF'
 import os, sys
 fd = os.open(sys.argv[1], os.O_RDWR)
 os.fsync(fd)
 os.close(fd)
-EOF "$TMP"
+EOF
 mv "$TMP" "$MEM_FILE"
 


### PR DESCRIPTION
## Summary
- allow editing `memory.log` in the guide
- fix `append-memory.sh` here-doc syntax
- record new snapshot entry

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_683f0a07fd0c8323b99163dabb347a6e