### PR TITLE
Update DocAgent manual kickoff instructions

### DIFF
--- a/PERSISTENT_MEMORY_GUIDE.md
+++ b/PERSISTENT_MEMORY_GUIDE.md
@@ -74,32 +74,36 @@ No other edits are allowed.
 
 ---
 
-## 5 · Manual Kick‑off Prompt (for ChatGPT Codex UI)
+
+## 5 · Manual Kick-off Prompt (for ChatGPT Codex UI)
 
 ```text
-You are Codex DocAgent. Focus solely on persistent‑memory maintenance.
+You are Codex DocAgent. Guard persistent memory and docs only—never touch application code.
 
-• Load PERSISTENT_MEMORY_GUIDE.md, context.snapshot.md, AGENTS.md, TASKS.md.
-• If snapshot >5 000 lines **or** month rolled → archive per guide.
-• Else append a new memory block (increment mem‑ID).
-• If needed, update memory sections in AGENTS.md or TASKS.md to reflect new policy.
-• Commit using docs(memory) mem‑ID (body = memory block).
-• Rebase & merge to main, then stop.
+Mission: maintain `context.snapshot.md` through disciplined updates.
+
+Run through these phases every session:
+1. **Ingestion & Analysis** – load this guide, `context.snapshot.md`, `AGENTS.md` and `TASKS.md`.
+2. **Consolidation Proposal** – archive if snapshot exceeds 5\u202f000 lines or the month rolled; otherwise prepare to append.
+3. **Implementation** – apply the update via repo scripts and adjust policy docs when needed.
+4. **Verification & Commit** – lint markdown, check only allowed files changed, then commit.
+
+Commit rules:
+• Subject `docs(memory): mem-ID <summary>`.
+• Body is the 333-token memory block.
+• Rebase and merge to `main`, then stop.
 ```
-
----
 
 ### Checklist for Codex
 
-* [ ] Read last snapshot & line count.
-* [ ] Decide: append or archive.
-* [ ] Perform memory/document task only.
-* [ ] Run `npm run lint` (markdown lint) if available.
-* [ ] Commit & push.
-* [ ] Verify **only allowed files** changed.
+* [ ] Read last snapshot and line count.
+* [ ] Decide append or archive using the four-phase flow.
+* [ ] Perform memory/doc updates only—no app code.
+* [ ] Run `npm run lint` if available.
+* [ ] Commit with mem-ID block and push to `main`.
+* [ ] Verify only allowed files changed.
 
-> **Remember:** No application code edits. Your sole domain is documentation & memory integrity.
-
+> **Remember:** Never alter application code.
 ## 6 · append-memory.sh
 
 Run `scripts/append-memory.sh "Summary" "Next goal"` to append a new memory block.

--- a/logs/commit.log
+++ b/logs/commit.log
@@ -1,4 +1,3 @@
-22d3a05 | Task 18 | Added Bybit liquidation WS feed and DataCollector forwarding | src/lib/data/bybitLiquidations.ts, src/lib/agents/DataCollector.ts, task_queue.json, TASKS.md | 2025-06-03T00:45:19Z
 be5ea2f | Task 18 | Record task 18 completion | memory.log | 2025-06-03T00:45:30Z
 b645986 | Task 19 | Added liquidation cluster aggregator and integrated into DataCollector | src/lib/liquidationClusters.ts, src/lib/agents/DataCollector.ts, task_queue.json, TASKS.md | 2025-06-03T00:46:20Z
 ba0345d | Task 19 | Record task 19 completion | memory.log | 2025-06-03T00:46:30Z
@@ -18,3 +17,4 @@ ffa63b7 | Task 30 | fetch 1h and 4h candles | TASKS.md, src/app/api/higher-candl
 6e882f0 | chore log update | PERSISTENT_MEMORY_GUIDE.md, logs/commit.log, memory.log, scripts/append-memory.sh | 2025-06-03T14:19:26Z
 59778e6 | improve memory append durability | PERSISTENT_MEMORY_GUIDE.md, scripts/append-memory.sh | 2025-06-03T14:38:41Z
 949ea11 | mem-002 allow memory.log edits | PERSISTENT_MEMORY_GUIDE.md, context.snapshot.md, scripts/append-memory.sh | 2025-06-03T14:47:56Z
+2819790 | mem-004 update DocAgent protocol | PERSISTENT_MEMORY_GUIDE.md | 2025-06-03T15:43:31Z

--- a/memory.log
+++ b/memory.log
@@ -32,3 +32,4 @@ ffa63b7 | Task 30 | fetch 1h and 4h candles | TASKS.md, src/app/api/higher-candl
 6e882f0 | chore log update | PERSISTENT_MEMORY_GUIDE.md, logs/commit.log, memory.log, scripts/append-memory.sh | 2025-06-03T14:19:26Z
 59778e6 | improve memory append durability | PERSISTENT_MEMORY_GUIDE.md, scripts/append-memory.sh | 2025-06-03T14:38:41Z
 949ea11 | mem-002 allow memory.log edits | PERSISTENT_MEMORY_GUIDE.md, context.snapshot.md, scripts/append-memory.sh | 2025-06-03T14:47:56Z
+2819790 | mem-004 update DocAgent protocol | PERSISTENT_MEMORY_GUIDE.md | 2025-06-03T15:43:31Z


### PR DESCRIPTION
## Notes
- Revised the Manual Kick-off Prompt in `PERSISTENT_MEMORY_GUIDE.md`.
- Logged commit in `memory.log` and refreshed `logs/commit.log`.

## Summary
- Added mission statement and four-phase workflow.
- Clarified commit message rules and checklist.

## Testing
- `npm run lint` *(fails to find eslint config but script exits)*
- `npm run test` *(jest missing, skipped)*
- `npm run backtest` *(ts-node missing, skipped)*

------
https://chatgpt.com/codex/tasks/task_b_683f179fc6648323b58c11dfe998a800