### PR TITLE
Initialize Codex memory helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,4 +203,12 @@ Run `npm ci` once when the environment starts (or `npm run dev-deps` if offline)
 3. **Sync Tasks** – update `task_queue.json` and check the box in `TASKS.md`.
 4. **Reference History** – use commit hashes from `memory.log` when describing follow-up tasks.
 
+### Codex Workflow
+
+1. Run `npm run codex` at the start of each ChatGPT session.
+2. Paste the printed context block into your first message to Codex.
+3. Craft descriptive commit messages referencing `TASKS.md`.
+
+Commit messages serve as the last 333-token memory "before" and the top unchecked task becomes the 33-token goal "after".
+
 > End of AGENTS.md – obey without deviation.

--- a/README.md
+++ b/README.md
@@ -131,3 +131,9 @@ npm run commitlog
 | `node scripts/try-cmd.js <cmd>` | Run a command only if the binary exists |
 | `npm run backtest` | Launch the backtest defined in `scripts/backtest.ts` |
 
+## Using Codex with Persistent Memory
+
+1. Run `npm run codex` and copy the output block.
+2. Paste that context into the first prompt of your ChatGPT Codex session.
+3. Commit code changes with descriptive messages linked to `TASKS.md`.
+

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,4 +1,5 @@
 # BitDash Firestudio – TASKS.md
+<!-- Write each task in one short line (~33 tokens) so Codex can ingest it as next objective. -->
 
 > **Goal:** Optimize 5-minute BTC scalping with SPX context through small, atomic tasks Codex can execute autonomously.
 
@@ -43,6 +44,11 @@ All tasks live in `task_queue.json` as `{ "id": number, "description": string, "
 - [x] Task 79: mem-008 remove outdated memory guide
 - [x] Task 80: mem-009 backfill snapshot
 - [x] Task 81: mem-010 record log entry
+- [x] Task 82: create codex_context helper script
+- [x] Task 83: add codex npm alias
+- [x] Task 84: document codex workflow in AGENTS.md
+- [x] Task 85: refine TASKS.md template
+- [x] Task 86: document codex usage routine
 
 ### Bitcoin Dashboard
 

--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -42,3 +42,19 @@
 - Commit SHA: b0aa95e
 - Summary: Reorganized TASKS.md with a new Persistent Memory section listing completed mem tasks 72-81 and placed Bitcoin Dashboard categories afterward in priority order. Updated task_queue.json accordingly.
 - Next Goal: resume development with Task 31 comparing EMA trends.
+### 2025-06-03 19:42 UTC | mem-012
+- Commit SHA: 854808e
+- Summary: Added codex_context.sh to output recent commits and next task. Introduced tasks 82-86 in TASKS.md.
+- Next Goal: Add npm alias for codex context
+### 2025-06-03 19:43 UTC | mem-013
+- Commit SHA: 351641e
+- Summary: Added npm script 'codex' to run codex_context.sh for easy context retrieval.
+- Next Goal: Document codex workflow in AGENTS.md
+### 2025-06-03 19:45 UTC | mem-014
+- Commit SHA: 2e5ebf5
+- Summary: Added guidance comment to TASKS.md and marked Task 85 complete.
+- Next Goal: Document codex usage routine
+### 2025-06-03 19:46 UTC | mem-015
+- Commit SHA: e5ffe2f
+- Summary: Added section in README describing how to run npm codex and feed context to Codex. Marked Task 86 done.
+- Next Goal: All tasks complete

--- a/logs/commit.log
+++ b/logs/commit.log
@@ -1,8 +1,3 @@
-668e0c0 | fix(signals) | update last task completion to 31 | signals.json | 2025-06-03T11:23:26Z
-574856c | add append-memory helper | scripts/append-memory.sh, PERSISTENT_MEMORY_GUIDE.md | 2025-06-03T14:18:37Z
-229b8e4 | mem-001 context snapshot | AGENTS.md, context.snapshot.md | 2025-06-03T13:50:25Z
-994a3c9 | mem-002 script docs and guide note | AGENTS.md, PERSISTENT_MEMORY_GUIDE.md, README.md | 2025-06-03T14:09:45Z
-6e882f0 | chore log update | PERSISTENT_MEMORY_GUIDE.md, logs/commit.log, memory.log, scripts/append-memory.sh | 2025-06-03T14:19:26Z
 59778e6 | improve memory append durability | PERSISTENT_MEMORY_GUIDE.md, scripts/append-memory.sh | 2025-06-03T14:38:41Z
 949ea11 | mem-002 allow memory.log edits | PERSISTENT_MEMORY_GUIDE.md, context.snapshot.md, scripts/append-memory.sh | 2025-06-03T14:47:56Z
 2819790 | mem-004 update DocAgent protocol | PERSISTENT_MEMORY_GUIDE.md | 2025-06-03T15:43:31Z
@@ -18,3 +13,8 @@ e2f193e | docs(memory) enforce context snapshot updates | AGENTS.md, context.sna
 e6aa08f | docs(memory) record mem-008 snapshot backfill | context.snapshot.md, logs/commit.log, memory.log | 2025-06-03T17:51:30Z
 334e253 | chore(memory) log mem-009 entry | context.snapshot.md, logs/commit.log, memory.log | 2025-06-03T17:52:26Z
 b0aa95e | docs(tasks) categorize persistent memory | TASKS.md, task_queue.json | 2025-06-03T19:34:41Z
+854808e | chore(memory) add codex context helper script | scripts/codex_context.sh,TASKS.md | 2025-06-03T19:42:58Z
+351641e | chore(memory) add codex npm script | package.json,TASKS.md | 2025-06-03T19:43:38Z
+2e5ebf5 | chore(memory) refine tasks template | TASKS.md | 2025-06-03T19:45:47Z
+9013ea9 | chore(memory) document codex workflow | AGENTS.md | 2025-06-03T19:44:17Z
+e5ffe2f | chore(memory) document codex usage | README.md,TASKS.md | 2025-06-03T19:46:27Z

--- a/memory.log
+++ b/memory.log
@@ -45,3 +45,8 @@ e2f193e | docs(memory) enforce context snapshot updates | AGENTS.md, context.sna
 e6aa08f | docs(memory) record mem-008 snapshot backfill | context.snapshot.md, logs/commit.log, memory.log | 2025-06-03T17:51:30Z
 334e253 | chore(memory) log mem-009 entry | context.snapshot.md, logs/commit.log, memory.log | 2025-06-03T17:52:26Z
 b0aa95e | docs(tasks) categorize persistent memory | TASKS.md, task_queue.json | 2025-06-03T19:34:41Z
+854808e | chore(memory) add codex context helper script | scripts/codex_context.sh,TASKS.md | 2025-06-03T19:42:58Z
+351641e | chore(memory) add codex npm script | package.json,TASKS.md | 2025-06-03T19:43:38Z
+2e5ebf5 | chore(memory) refine tasks template | TASKS.md | 2025-06-03T19:45:47Z
+9013ea9 | chore(memory) document codex workflow | AGENTS.md | 2025-06-03T19:44:17Z
+e5ffe2f | chore(memory) document codex usage | README.md,TASKS.md | 2025-06-03T19:46:27Z

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dev-deps": "bash scripts/dev-deps.sh",
     "auto": "node scripts/autoTaskRunner.js",
     "commitlog": "node scripts/commit-log.js",
+    "codex": "./scripts/codex_context.sh",
     "bootstrap": "npm ci && npm run lint && npm run test && npm run backtest"
   },
   "dependencies": {

--- a/scripts/codex_context.sh
+++ b/scripts/codex_context.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+commits=$(git log -n 5 --pretty=format:'%h %s')
+
+next_task=$(grep -m 1 '^\- \[ \]' TASKS.md | sed -E 's/^\- \[ \] //')
+
+printf "Recent work:\n%s\nNext task: %s\n" "$commits" "$next_task"


### PR DESCRIPTION
## Summary
- create `scripts/codex_context.sh` to print recent commits and next task
- expose helper via `npm run codex`
- document workflow for Codex memory in AGENTS.md
- clarify TASKS.md template and mark setup tasks complete
- explain codex usage in README
- record mem-012 through mem-015

## Testing
- `./scripts/codex_context.sh`
- `npm run commitlog`


------
https://chatgpt.com/codex/tasks/task_b_683f4f575c888323aa5c88051c9600b3