### PR TITLE
Add CODEX_START guidelines

### DIFF
--- a/CODEX_START.md
+++ b/CODEX_START.md
@@ -1,0 +1,36 @@
+# CODEX_START – Manual Kickoff Instructions
+
+This repository uses a commit-based memory system so Codex can recall recent work. Read this file before starting any automation run.
+
+## Codex Kickoff Prompt
+
+To begin a session in ChatGPT Codex:
+
+```text
+You are DevAgent working on the BitDash Firestudio repo.
+Load AGENTS.md for project rules, then review memory.log and context.snapshot.md to recall recent commits. Read TASKS.md to identify the next unchecked task.
+Use around 333 tokens of recent commit summaries plus the 33‑token next task as context. Obey the automation loop from AGENTS.md and update memory files after each commit.
+```
+
+Paste that block into the first message when launching Codex. The `npm run codex` script prints the latest commit summaries and next task to make this easy.
+
+## Persistent Memory Workflow
+
+- **memory.log** – append one line per commit: `hash | Task <id> | summary | files | timestamp`.
+- **context.snapshot.md** – add a new `mem-XXX` section summarizing the commit (333 tokens max) and the next goal.
+- **logs/commit.log** – run `npm run commitlog` after committing so recent history is easy to load.
+
+Codex must read these files at the start of every run to rebuild context. Commit messages themselves serve as persistent memory, so keep them descriptive and follow the Conventional Commits format.
+
+## Token Guidance
+
+Limit commit summaries in both the commit body and context snapshot to about **333 tokens**. Task descriptions in `TASKS.md` should stay near **33 tokens**. This keeps prompts concise and ensures recent memory fits in the model context window.
+
+## Recap
+
+1. Run `npm run codex` and paste the output block into ChatGPT.
+2. Confirm AGENTS.md, memory.log and context.snapshot.md are loaded.
+3. Execute the next task from TASKS.md, committing with a clear message.
+4. Append the commit info to memory.log and context.snapshot.md, then run `npm run commitlog`.
+
+Following these steps preserves context between sessions and keeps token usage manageable.

--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -78,3 +78,7 @@
 - Commit SHA: f5e545e
 - Summary: Extended README instructions to log hashes in memory files. Marked Task 91 done.
 - Next Goal: none
+### 2025-06-03 23:05 UTC | mem-021
+- Commit SHA: 38b4d2b
+- Summary: Restored CODEX_START instructions for manual kickoff and memory workflow
+- Next Goal: Implement Task 31 comparing EMA trends

--- a/memory.log
+++ b/memory.log
@@ -55,3 +55,4 @@ c5f74b9 | chore(memory) enhance npm codex alias | package.json,TASKS.md,task_que
 fea2e33 | chore(memory) expand workflow notes in AGENTS.md | AGENTS.md,TASKS.md,task_queue.json | 2025-06-03T21:15:04Z
 f753b32 | chore(memory) clarify TASKS guidance | TASKS.md,task_queue.json | 2025-06-03T21:15:36Z
 f5e545e | chore(memory) extend README memory section | README.md,TASKS.md,task_queue.json | 2025-06-03T21:16:15Z
+38b4d2b | mem-021 restore CODEX_START instructions | CODEX_START.md | 2025-06-03T23:05:26Z


### PR DESCRIPTION
## Summary
- restore `CODEX_START.md` with manual kickoff and memory workflow instructions
- record mem-021 entry for the new documentation

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run test` *(fails: jest missing)*
- `npm run backtest` *(fails: ts-node missing)*
- `npm run commitlog`

------
https://chatgpt.com/codex/tasks/task_b_683f7df2b1e88323bb0c1ba366d68fd3