### PR TITLE
Optimize memory utilities

### DIFF
--- a/scripts/autoTaskRunner.js
+++ b/scripts/autoTaskRunner.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { spawnSync, execSync } = require('child_process');
+const { repoRoot, memPath } = require('./memory-utils');
 
 function run(cmd) {
   const res = spawnSync(cmd, { shell: true, encoding: 'utf8' });
@@ -15,12 +16,11 @@ function tryExec(cmd) {
   }
 }
 
-const repoRoot = path.resolve(__dirname, '..');
 const tasksPath = path.join(repoRoot, 'TASKS.md');
 const signalsPath = path.join(repoRoot, 'signals.json');
 const logDir = path.join(repoRoot, 'logs');
 fs.mkdirSync(logDir, { recursive: true });
-const memoryPath = path.join(repoRoot, 'memory.log');
+const memoryPath = memPath;
 process.chdir(repoRoot);
 
 tryExec('npm ci');

--- a/scripts/commit-log.js
+++ b/scripts/commit-log.js
@@ -1,13 +1,9 @@
 const fs = require('fs');
 const path = require('path');
+const { memPath, readMemoryLines } = require('./memory-utils');
 
-const memPath = path.join(__dirname, '../memory.log');
-let lines = [];
-if (fs.existsSync(memPath)) {
-  lines = fs.readFileSync(memPath, 'utf8').trim().split('\n');
-}
-const log = lines.slice(-20).join('\n');
+const log = readMemoryLines().slice(-20).join('\n');
 const outPath = path.join(__dirname, '../logs/commit.log');
-fs.writeFileSync(outPath, log + '\n');
+fs.writeFileSync(outPath, `${log}\n`);
 console.log(`Commit log written to ${outPath}`);
 

--- a/scripts/memory-utils.js
+++ b/scripts/memory-utils.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const memPath = path.join(repoRoot, 'memory.log');
+
+function readMemoryLines() {
+  if (!fs.existsSync(memPath)) return [];
+  return fs.readFileSync(memPath, 'utf8').trim().split('\n').filter(Boolean);
+}
+
+module.exports = { repoRoot, memPath, readMemoryLines };

--- a/scripts/update-memory-log.js
+++ b/scripts/update-memory-log.js
@@ -1,14 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
+const { repoRoot, memPath, readMemoryLines } = require('./memory-utils');
 
-const repoRoot = path.resolve(__dirname, '..');
-const memPath = path.join(repoRoot, 'memory.log');
-
-let entries = [];
-if (fs.existsSync(memPath)) {
-  entries = fs.readFileSync(memPath, 'utf8').trim().split('\n').filter(Boolean);
-}
+let entries = readMemoryLines();
 let lastHash = '';
 if (entries.length) {
   const candidate = entries[entries.length - 1].split(' | ')[0];


### PR DESCRIPTION
## Summary
- add `memory-utils.js` helper for memory operations
- refactor autoTaskRunner, commit-log and update-memory-log scripts to use helper

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_683f878193448323a5d3797ad698b028