### PR TITLE
Implement Node memory append helper

### DIFF
--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -86,3 +86,7 @@
 - Commit SHA: c4c4e8b
 - Summary: Switched BTC chart icon from BarChart3 to BarChart2 to resolve runtime error.
 - Next Goal: Implement Task 31 comparing EMA trends
+### 2025-06-04 00:27 UTC | mem-023
+- Commit SHA: b2a16c3
+- Summary: Added snapshotPath constant and nextMemId helper. Introduced append-memory.js and simplified shell wrapper.
+- Next Goal: Implement Task 31 comparing 5m EMA trend with higher timeframes

--- a/logs/commit.log
+++ b/logs/commit.log
@@ -1,4 +1,3 @@
-7d30dae | chore(memory): update commit history | AGENTS.md, PERSISTENT_MEMORY_GUIDE.md, context.snapshot.md, logs/commit.log, memory.log | 2025-06-03T12:10:30-04:00
 66b6689 | Add files via upload | CODEX_START.md | 2025-06-03T13:09:43-04:00
 53a7019 | Delete PERSISTENT_MEMORY_GUIDE.md | PERSISTENT_MEMORY_GUIDE.md | 2025-06-03T13:10:43-04:00
 e2f193e | docs(memory): enforce context snapshot updates | AGENTS.md, context.snapshot.md, logs/commit.log, memory.log | 2025-06-03T13:16:24-04:00
@@ -17,4 +16,5 @@ d2623d5 | chore(memory): update logs after docs cleanup | logs/commit.log, memor
 2dc331a | fix(docs): clean memory guide and add memlog script | README.md, logs/commit.log, memory.log, memorymaker.md, package.json, scripts/update-memory-log.js | 2025-06-03T19:30:49-04:00
 76da9a2 | refactor(memory): centralize log helpers | scripts/autoTaskRunner.js, scripts/commit-log.js, scripts/memory-utils.js, scripts/update-memory-log.js | 2025-06-03T19:41:40-04:00
 5e61721 | chore(memory): record mem-022 | context.snapshot.md, logs/commit.log, memory.log, src/app/page.tsx | 2025-06-03T19:49:37-04:00
-99c276d | Task 92: streamline memory scripts | scripts/append-memory.sh, scripts/autoTaskRunner.js, scripts/update-memory-log.js | 2025-06-04T00:12:33+00:00
+9cfb60c | chore(memory): update logs | logs/commit.log, memory.log, scripts/append-memory.sh, scripts/autoTaskRunner.js, scripts/update-memory-log.js | 2025-06-03T20:18:45-04:00
+b2a16c3 | feat(memory): add helpers and node append script | scripts/append-memory.js, scripts/append-memory.sh, scripts/memory-utils.js | 2025-06-04T00:27:47+00:00

--- a/memory.log
+++ b/memory.log
@@ -394,3 +394,173 @@ d2623d5 | chore(memory): update logs after docs cleanup | logs/commit.log, memor
 76da9a2 | refactor(memory): centralize log helpers | scripts/autoTaskRunner.js, scripts/commit-log.js, scripts/memory-utils.js, scripts/update-memory-log.js | 2025-06-03T19:41:40-04:00
 5e61721 | chore(memory): record mem-022 | context.snapshot.md, logs/commit.log, memory.log, src/app/page.tsx | 2025-06-03T19:49:37-04:00
 99c276d | Task 92: streamline memory scripts | scripts/append-memory.sh, scripts/autoTaskRunner.js, scripts/update-memory-log.js | 2025-06-04T00:12:33+00:00
+0ff8ebb | initial scaffold | .gitignore, .idx/dev.nix, README.md, components.json, next.config.ts, package-lock.json, package.json, postcss.config.mjs, src/ai/dev.ts, src/ai/genkit.ts, src/app/favicon.ico, src/app/globals.css, src/app/layout.tsx, src/app/page.tsx, src/components/ui/accordion.tsx, src/components/ui/alert-dialog.tsx, src/components/ui/alert.tsx, src/components/ui/avatar.tsx, src/components/ui/badge.tsx, src/components/ui/button.tsx, src/components/ui/calendar.tsx, src/components/ui/card.tsx, src/components/ui/chart.tsx, src/components/ui/checkbox.tsx, src/components/ui/dialog.tsx, src/components/ui/dropdown-menu.tsx, src/components/ui/form.tsx, src/components/ui/input.tsx, src/components/ui/label.tsx, src/components/ui/menubar.tsx, src/components/ui/popover.tsx, src/components/ui/progress.tsx, src/components/ui/radio-group.tsx, src/components/ui/scroll-area.tsx, src/components/ui/select.tsx, src/components/ui/separator.tsx, src/components/ui/sheet.tsx, src/components/ui/sidebar.tsx, src/components/ui/skeleton.tsx, src/components/ui/slider.tsx, src/components/ui/switch.tsx, src/components/ui/table.tsx, src/components/ui/tabs.tsx, src/components/ui/textarea.tsx, src/components/ui/toast.tsx, src/components/ui/toaster.tsx, src/components/ui/tooltip.tsx, src/hooks/use-mobile.tsx, src/hooks/use-toast.ts, src/lib/utils.ts, tailwind.config.ts, tsconfig.json | 2025-05-15T18:14:26+00:00
+33391af | Update app | .modified, docs/blueprint.md, src/ai/dev.ts, src/ai/flows/market-sentiment-analysis.ts, src/app/globals.css, src/app/layout.tsx, src/app/page.tsx, src/components/DashboardHeader.tsx, src/components/DataCard.tsx, src/components/ValueDisplay.tsx, src/types/index.ts, tailwind.config.ts | 2025-05-21T12:46:03+00:00
+4a1991c | I need you to only grab FREE api data with lowest usage to prevent ERRORS, and don't let page ever be blank, use last known values always | src/app/page.tsx, src/types/index.ts | 2025-05-21T13:04:37+00:00
+3d8e0b1 | I see this error with the app, reported by NextJS, please fix it. The error is reported as HTML but presented visually to the user). | next.config.ts | 2025-05-21T13:04:54+00:00
+1dc3d78 | edit error | next.config.ts | 2025-05-21T13:06:17+00:00
+b3a3068 | I see this error with the app, reported by NextJS, please fix it. The error is reported as HTML but presented visually to the user). | src/app/page.tsx | 2025-05-21T13:14:59+00:00
+5a5fb78 | make sure SPY and SPX use real current data as best it can, remember everything has to use FREE API with low usage and checking websites for current data | src/app/page.tsx | 2025-05-21T13:17:52+00:00
+672098b | why error, my api key is correct | .vscode/settings.json, src/app/page.tsx | 2025-05-21T13:24:10+00:00
+764fbe8 | why this: "Notice: Failed to fetch stock data from FMP: (status 403)." | src/app/page.tsx | 2025-05-21T13:25:50+00:00
+728f906 | only look at this as reference to make sure api works fine: "Based on the sources, here are the instructions necessary to get SPY (as an ETF) and SPX (as the S&P 500 index, using the symbol `^GSPC` as indicated in the sources) data from the FMP API, which you can provide to your developer. | src/app/page.tsx | 2025-05-21T13:32:18+00:00
+3c0c115 | I see this error with the app, reported by NextJS, please fix it. The error is reported as HTML but presented visually to the user). | src/app/page.tsx | 2025-05-21T13:34:15+00:00
+f1588d1 | I see this error with the app, reported by NextJS, please fix it. The error is reported as HTML but presented visually to the user). | src/app/page.tsx | 2025-05-21T13:36:26+00:00
+d93cc5c | make each box have a quick 1 click close and open, where it just shrinks and verything can be moved by mouse click and drag | src/components/DataCard.tsx | 2025-05-21T13:48:16+00:00
+2b05f3a | ok ONLY DO THIS, the collapse works, I want the box to shrink up to where the shrinking happens | src/components/DataCard.tsx | 2025-05-21T13:50:17+00:00
+24366b6 | make sure the 7 coins are on bottom of page | src/app/page.tsx | 2025-05-21T13:52:32+00:00
+53a81b7 | ok add DXY and US10Y and put them next to the SPX | src/ai/flows/market-sentiment-analysis.ts, src/app/page.tsx, src/types/index.ts | 2025-05-21T14:01:35+00:00
+7d6e31c | ok remove anything that we are not using | src/components/DataCard.tsx | 2025-05-21T14:24:16+00:00
+c91a650 | don't fetch DXY and US10YY from FMP, get it from any other free place and limit any calls or usage to no more than 1 per minute | src/app/page.tsx | 2025-05-21T14:30:27+00:00
+31a48b4 | integrate a free way get those results in US dollar and 10 year treasury | src/app/page.tsx | 2025-05-21T14:33:37+00:00
+02c5cf9 | only do what is best from these instructions and easiest and don't break anything: "Configure this agent to retrieve and report the latest DXY (U.S. Dollar Index) and 10-Year U.S. Treasury Yield. | src/ai/dev.ts, src/ai/flows/report-financial-data-flow.ts, src/ai/tools/get-financial-market-data-tool.ts | 2025-05-21T15:04:05+00:00
+77abb9f | Initial commit for windsurf branch with project setup | .gitignore, .windsurfrules, PLANNING.md, README.md, TASKS.md, src/app/page.tsx, src/components/CorrelationPanel.tsx, updates.md, windsurfrules.txt | 2025-05-21T14:07:22-04:00
+0330f1c | wind rules | .windsurfrules | 2025-05-21T14:10:44-04:00
+f928e30 | feat(market-data): implement robust DXY and US10Y data fetching | PLANNING.md, README.md, TASKS.md, get_dxy.py, package.json, src/ai/flows/market-sentiment-analysis.ts, src/app/page.tsx, src/components/MarketDataCard.tsx, src/lib/dataQuality.ts, src/lib/marketData.ts | 2025-05-22T07:43:46-04:00
+664ac7d | feat(market-data): implement robust DXY and US10Y data fetching | TASKS.md | 2025-05-22T07:47:43-04:00
+b26d5a1 | docs: simplify project documentation and development rules for trading focus | .windsurfrules, PLANNING.md, README.md, TASKS.md, windsurfrules.txt | 2025-05-22T09:11:45-04:00
+6ffc4c1 | feat(ui): add 50/200 MA crossover | TASKS.md, src/app/page.tsx, src/lib/indicators.ts, src/types/index.ts | 2025-05-22T10:26:21-04:00
+59db7d9 | Merge pull request #1 from gevans3000/codex/complete-first-task |  | 2025-05-22T10:26:32-04:00
+5ba64ad | feat: add DXY and US10Y data integration | TASKS.md | 2025-05-22T10:28:39-04:00
+5f9d298 | feat: add DXY and US10Y data integration | src/app/api/dxy/route.ts, src/app/api/us10y/route.ts, src/app/page.tsx, windsurfrules.txt | 2025-05-22T10:29:03-04:00
+2b8f772 | feat: add moving averages for BTC and resolve merge conflicts |  | 2025-05-22T10:31:20-04:00
+5fc95f0 | fix: resolve hydration errors in data cards and dashboard components | .gitignore, .modified, .windsurfrules, src/app/api/dxy/route.ts, src/app/api/us10y/route.ts, src/app/page.tsx, src/components/DashboardHeader.tsx, src/components/DataCard.tsx, src/lib/cache.ts | 2025-05-22T13:14:16-04:00
+eb8a53d | fix: add missing try block in US10Y API route | src/app/api/us10y/route.ts | 2025-05-22T13:24:23-04:00
+5cdbff3 | Merge pull request #2 from gevans3000/codex/fix-hydration-errors-in-dashboard |  | 2025-05-22T14:58:32-04:00
+545b222 | feat(macro): add refresh demo page | README.md, src/app/refresh-demo/page.tsx | 2025-05-25T08:54:19-04:00
+9d65c0a | Merge pull request #3 from gevans3000/codex/fetch-real-time-values-on-refresh |  | 2025-05-25T08:54:41-04:00
+95d2693 | feat: add initial dashboard with crypto, stocks, DXY, and US10Y data fetching | src/app/api/dxy/route.ts, src/app/api/us10y/route.ts, src/app/page.tsx, src/components/MarketDataCard.tsx, src/lib/marketData.ts | 2025-05-25T08:57:47-04:00
+7aebad3 | Merge branch 'windsurf' of https://github.com/gevans3000/bitdashfirestudio into windsurf |  | 2025-05-25T08:58:40-04:00
+cf5d1b2 | fix: improve 10-year treasury yield data fetching | src/app/api/dxy/route.ts, src/app/api/us10y/route.ts, src/app/page.tsx | 2025-05-28T13:34:32-04:00
+18df5ec | feat: add RSI and signals | src/app/page.tsx, src/lib/indicators.ts, src/types/index.ts | 2025-05-28T15:12:11-04:00
+05a6461 | Merge pull request #4 from gevans3000/codex/implement-rsi-function-and-update-components |  | 2025-05-28T15:13:03-04:00
+9bf3211 | Merge pull request #5 from gevans3000/windsurf |  | 2025-05-28T15:22:15-04:00
+622c10b | feat(indicators): add EMA and volume profile | src/app/page.tsx, src/lib/indicators.ts, src/types/index.ts | 2025-05-28T16:41:56-04:00
+24e8afc | Adjust arbitrage polling interval and add toggle | package-lock.json, package.json, server.js, src/components/ArbAlertCard.tsx | 2025-05-29T09:29:09-04:00
+cd1c88a | docs: add AGENTS instructions | AGENTS.md | 2025-05-29T09:57:43-04:00
+b47e50f | Update AGENTS.md | AGENTS.md | 2025-05-30T13:10:32-04:00
+9971791 | feat(signals): add 5m btc signal architecture | .husky/pre-commit, README.md, jest.config.js, package.json, src/__tests__/indicators.test.ts, src/__tests__/signals.test.ts, src/app/page.tsx, src/components/MarketChart.tsx, src/components/SignalCard.tsx, src/components/SignalHistory.tsx, src/config/signals.json, src/lib/agents/AlertLogger.ts, src/lib/agents/DataCollector.ts, src/lib/agents/IndicatorEngine.ts, src/lib/agents/Orchestrator.ts, src/lib/agents/SignalGenerator.ts, src/lib/data/binanceWs.ts, src/lib/data/coingecko.ts, src/lib/indicators.ts, src/lib/signals.ts, src/scripts/backtest.ts, src/scripts/seedSignals.ts, src/types/agent.ts, src/types/index.ts | 2025-05-30T13:20:08-04:00
+163fa8a | Add new agent roles and handler stubs | src/lib/agents/Backtester.ts, src/lib/agents/Orchestrator.ts, src/lib/agents/QATester.ts, src/lib/agents/UIRenderer.ts, src/types/agent.ts | 2025-05-30T14:40:30-04:00
+b089a27 | Refactor types for signal generator and handlers | src/app/page.tsx, src/components/MarketChart.tsx, src/lib/agents/SignalGenerator.ts, src/scripts/backtest.ts, src/types/tradingview.d.ts | 2025-05-30T16:35:56-04:00
+22e3ac2 | docs(tasks): add top priority roadmap | TASKS.md | 2025-05-31T13:04:08-04:00
+a20d473 | feat(data): use FRED for DXY with 15m cache | README.md, TASKS.md, src/app/api/dxy/route.ts, src/app/page.tsx, src/lib/marketData.ts | 2025-05-31T13:09:10-04:00
+96604b7 | Update AGENTS.md | AGENTS.md | 2025-05-31T13:26:23-04:00
+13ed773 | fix(api): fetch US10Y from FRED | src/app/api/us10y/route.ts | 2025-06-01T09:57:55-04:00
+c06da0b | Update AGENTS.md | AGENTS.md | 2025-06-01T10:23:26-04:00
+eb18ca1 | docs(data): clarify correlation helper\n\nRefs: TASKS.md#L9 | TASKS.md, src/__tests__/correlation.test.ts, src/app/api/correlation/route.ts, src/app/page.tsx, src/lib/correlation.ts, src/lib/data/fmp.ts, src/lib/marketData.ts | 2025-06-01T10:32:19-04:00
+80e5905 | Update AGENTS.md | AGENTS.md | 2025-06-01T10:36:17-04:00
+c6550ac | Update AGENTS.md | AGENTS.md | 2025-06-01T10:37:03-04:00
+6deb183 | docs(tasks): mark US10Y fetch complete | TASKS.md | 2025-06-01T10:43:07-04:00
+fe9a912 | refactor: reposition BTC chart and signal components | src/app/page.tsx | 2025-06-01T10:53:51-04:00
+ee20e6c | Update TASKS.md | TASKS.md | 2025-06-01T11:03:37-04:00
+083fe46 | feat(atr): add 1h ATR widget | TASKS.md, src/__tests__/indicators.test.ts, src/app/api/atr/route.ts, src/app/page.tsx, src/components/AtrWidget.tsx, src/lib/data/fmp.ts, src/lib/indicators.ts | 2025-06-01T11:11:16-04:00
+407a446 | fix(ui): resolve hydration mismatch | src/app/page.tsx, src/components/SignalCard.tsx | 2025-06-01T11:16:17-04:00
+25803c2 | feat(depth): add Binance order book widget\n\nImplements real-time depth view for BTCUSDT via Binance API and highlights imbalance.\n\nRefs: TASKS.md#L10-L12 | src/app/api/orderbook/route.ts, src/app/page.tsx, src/components/OrderBookWidget.tsx | 2025-06-01T11:41:40-04:00
+c7ba6aa | fix(ui): mark cards as client components | src/components/DataCard.tsx, src/components/OrderBookWidget.tsx, src/components/ui/card.tsx | 2025-06-01T12:54:33-04:00
+e1fc223 | feat(auto): add AutoTaskRunner script | logs/.gitkeep, package.json, src/scripts/autoTaskRunner.ts | 2025-06-02T08:35:14-04:00
+793e70d | feat(depth): highlight order book walls\n\nCompletes TASKS.md#L10-L12 | TASKS.md, logs/backtest.log, logs/lint.log, logs/test.log, src/components/OrderBookWidget.tsx | 2025-06-02T08:40:19-04:00
+b989916 | Add files via upload | Codex Automation System for Next.js Bitcoin Dashboard.pdf | 2025-06-02T09:07:28-04:00
+c41eaa7 | feat(volume): add spike detection chart\n\nCompletes TASKS.md#L13-L15 | TASKS.md, logs/backtest.log, logs/lint.log, logs/test.log, src/app/api/volume-spikes/route.ts, src/app/page.tsx, src/components/VolumeSpikeChart.tsx | 2025-06-02T09:18:04-04:00
+3a61961 | feat(vwap): add VWAP indicator and widget | TASKS.md, src/__tests__/indicators.test.ts, src/app/api/vwap/route.ts, src/app/page.tsx, src/components/VwapWidget.tsx, src/lib/indicators.ts | 2025-06-02T09:23:02-04:00
+308a45f | feat(indicator): add Stochastic RSI widget and API | TASKS.md, src/__tests__/indicators.test.ts, src/app/api/stoch-rsi/route.ts, src/app/page.tsx, src/components/StochRsiWidget.tsx, src/lib/indicators.ts | 2025-06-02T09:28:28-04:00
+1bab8ca | feat(order-flow): add cumulative delta widget and API | TASKS.md, logs/backtest.log, logs/lint.log, logs/test.log, src/__tests__/indicators.test.ts, src/app/api/cum-delta/route.ts, src/app/page.tsx, src/components/OrderFlowWidget.tsx, src/lib/indicators.ts | 2025-06-02T09:36:50-04:00
+9128902 | feat(session): add market session timers | TASKS.md, src/__tests__/sessions.test.ts, src/app/page.tsx, src/components/SessionTimerWidget.tsx, src/lib/marketSessions.ts | 2025-06-02T09:46:08-04:00
+0439d58 | feat(ema): add EMA crossover widget and API\n\nImplements EMA crossovers for 10/20/50/200 and displays trend. Updates TASKS.md. | TASKS.md, logs/backtest.log, logs/lint.log, logs/test.log, src/__tests__/indicators.test.ts, src/app/api/ema-crossovers/route.ts, src/app/page.tsx, src/components/EmaCrossoverWidget.tsx, src/lib/indicators.ts, src/types/index.ts | 2025-06-02T09:53:13-04:00
+8df8c93 | feat(bollinger): add bands widget and API | TASKS.md, src/app/api/bollinger/route.ts, src/app/page.tsx, src/components/BollingerWidget.tsx | 2025-06-02T10:01:33-04:00
+27fbef5 | feat(chart): add volume profile visualization | TASKS.md, src/app/api/volume-profile/route.ts, src/app/page.tsx, src/components/VolumeProfileChart.tsx | 2025-06-02T10:12:32-04:00
+131b6f6 | feat(chart): add Ichimoku cloud overlay | TASKS.md, logs/backtest.log, logs/lint.log, logs/test.log, src/__tests__/indicators.test.ts, src/app/api/ichimoku/route.ts, src/app/page.tsx, src/components/IchimokuWidget.tsx, src/lib/indicators.ts | 2025-06-02T10:39:12-04:00
+f151941 | feat(indicator): add RSI widget and API | TASKS.md, src/app/api/rsi/route.ts, src/app/page.tsx, src/components/RsiWidget.tsx | 2025-06-02T10:49:40-04:00
+2452be3 | Add files via upload | codesetuptolearnfrom.md | 2025-06-02T10:51:20-04:00
+6bc70be | Delete Codex Automation System for Next.js Bitcoin Dashboard.pdf | Codex Automation System for Next.js Bitcoin Dashboard.pdf | 2025-06-02T10:51:41-04:00
+ea51b7e | docs: extend agent instructions | AGENTS.md, INSTRUCTIONS.md | 2025-06-02T10:58:31-04:00
+71fd69f | Task 1: add MACD indicator | TASKS.md, src/__tests__/indicators.test.ts, src/lib/indicators.ts | 2025-06-02T11:06:13-04:00
+d9fd120 | Task 1: add funding rate widget | TASKS.md, src/app/api/funding-rate/route.ts, src/app/page.tsx, src/components/FundingRateWidget.tsx | 2025-06-02T11:10:25-04:00
+8ce0973 | Task 7: note dependency drift task | .github/workflows/ci.yml, .nvmrc, AGENTS.md, TASKS.md, package-lock.json, package.json, scripts/backtest.ts, scripts/check-env.sh | 2025-06-02T11:27:14-04:00
+55ac5fa | Task 0: record failed dependency install | TASKS.md, logs/backtest.log, logs/lint.log, logs/test.log | 2025-06-02T11:37:38-04:00
+80eafbf | Task 8: add BTC txn count widget | TASKS.md, logs/lint.log, src/app/api/btc-txcount/route.ts, src/app/page.tsx, src/components/TxnCountWidget.tsx | 2025-06-02T11:49:21-04:00
+64b67ad | Task 9: add scalper add-on tasks | TASKS.md | 2025-06-02T11:57:37-04:00
+c573fb0 | Add files via upload | CODEX-INSTRUCTIONS.txt | 2025-06-02T12:05:03-04:00
+8263f44 | chore: update commit log | AGENTS.md, README.md, docs/CODEX_WORKFLOW.md, logs/commit.log, package.json, scripts/commit-log.js | 2025-06-02T12:13:41-04:00
+aa566ef | feat(cache): add importance-based TTL | src/app/api/orderbook/route.ts, src/lib/data/coingecko.ts, src/lib/data/fmp.ts, src/lib/fetchCache.ts | 2025-06-02T12:23:01-04:00
+b70f9c4 | Task 10: merge testing agents | AGENTS.md, src/lib/agents/Backtester.ts, src/lib/agents/Orchestrator.ts, src/lib/agents/QATester.ts, src/lib/agents/TestingAgent.ts, src/types/agent.ts | 2025-06-02T12:34:08-04:00
+668907b | docs: update signal references and add root state file | AGENTS.md, INSTRUCTIONS.md, README.md, signals.json | 2025-06-02T12:43:27-04:00
+b2f54dc | Task 11: update autoTaskRunner commit format | src/scripts/autoTaskRunner.ts | 2025-06-02T13:39:11-04:00
+22f5dd0 | docs: add workflow summary | README.md, docs/CODEX_WORKFLOW.md | 2025-06-02T14:00:58-04:00
+a7a6b2a | Delete .windsurfrules | .windsurfrules | 2025-06-02T14:11:08-04:00
+de8515d | Task 12: refine task workflow | TASKS.md, logs/commit.log | 2025-06-02T14:17:26-04:00
+78a6f32 | Task 13: add previous day VWAP bands | TASKS.md, signals.json, src/app/api/prev-day/route.ts, src/app/page.tsx, src/components/PrevDayBands.tsx | 2025-06-02T14:41:41-04:00
+ee0d620 | Task 14: add order book heatmap | AGENTS.md, TASKS.md, logs/backtest.log, logs/block-14.txt, logs/lint.log, logs/test.log, package.json, scripts/autoTaskRunner.js, signals.json, src/app/page.tsx, src/components/OrderBookHeatmap.tsx | 2025-06-02T15:05:29-04:00
+811cea5 | Task 15: enable autonomous merges | AGENTS.md, TASKS.md, scripts/autoTaskRunner.js, signals.json | 2025-06-02T15:21:51-04:00
+8ce0b6c | Task 16: enable context snapshot | AGENTS.md, CODEX-INSTRUCTIONS.txt, INSTRUCTIONS.md, README.md, TASKS.md, context.snapshot.md, docs/CODEX_WORKFLOW.md, scripts/autoTaskRunner.js | 2025-06-02T15:41:06-04:00
+c101376 | Task 17: reorganize TASKS | TASKS.md | 2025-06-02T15:51:35-04:00
+dd5af4c | Update AGENTS.md | AGENTS.md | 2025-06-02T15:52:32-04:00
+98191e9 | Merge task 17 | AGENTS.md, TASKS.md, context.snapshot.md, package.json, scripts/dev-deps.sh, scripts/try-cmd.js, src/components/OrderBookHeatmap.tsx | 2025-06-02T17:47:20-04:00
+008cd8e | Add files via upload | auto-instruct-codex.md | 2025-06-02T17:57:56-04:00
+6b2492d | Add files via upload | newcodex1.md | 2025-06-02T18:11:54-04:00
+314de5c | chore(docs): add task queue and memory guide | AGENTS.md, TASKS.md, docs/CODEX_WORKFLOW.md, memory.md, task_queue.json | 2025-06-02T18:37:12-04:00
+796ed43 | chore(docs): refine automation memory rules | AGENTS.md, TASKS.md, memory.md | 2025-06-02T18:49:58-04:00
+c409552 | docs(workflow): clarify commit-based memory | AGENTS.md, TASKS.md, docs/CODEX_WORKFLOW.md | 2025-06-02T19:04:53-04:00
+ee5bc9e | docs(workflow): refine memory and task sync | AGENTS.md, TASKS.md, memory.md | 2025-06-02T19:10:57-04:00
+ab0b2fa | docs(workflow): refine memory and task sync | AGENTS.md, TASKS.md, context.snapshot.md, logs/commit.log, memory.md | 2025-06-02T19:21:07-04:00
+5a61018 | docs(workflow): clarify persistent memory steps | AGENTS.md, TASKS.md, memory.md | 2025-06-02T19:32:18-04:00
+2e9e35e | docs(tasks): expand task list granularity | TASKS.md | 2025-06-02T19:46:36-04:00
+df3d2c4 | chore(memory): record task sync | context.snapshot.md, logs/commit.log, memory.md, task_queue.json | 2025-06-02T19:57:11-04:00
+7e84b40 | chore(bootstrap): enable full automation loop Bootstrap adjustments finalize the autonomous loop. I created a dedicated `main` branch so future rebases have a stable target. The lint script previously failed because `check-env.sh` exited when dependencies like `next` were missing. Without node modules this blocked test and backtest scripts from running. I changed the npm `lint` command to call `node scripts/try-cmd.js eslint . --ext .ts,.tsx | logs/commit.log, package.json | 
+cb82868 | chore(memory): record tasks 21-27 | TASKS.md, context.snapshot.md, logs/commit.log, memory.md, src/app/api/bb-width/route.ts, src/app/api/funding-schedule/route.ts, src/app/api/liquidation-clusters/route.ts, src/app/api/open-interest-delta/route.ts, src/app/api/open-interest/route.ts, src/app/page.tsx, src/components/BbWidthAlert.tsx, src/components/FundingCountdown.tsx, src/components/LiquidationClustersChart.tsx, src/components/OpenInterestDeltaChart.tsx, src/lib/agents/DataCollector.ts, src/lib/data/bybitLiquidations.ts, src/lib/data/bybitOpenInterest.ts, src/lib/data/fundingSchedule.ts, src/lib/indicators.ts, src/lib/liquidationClusters.ts, src/lib/openInterest.ts, task_queue.json | 2025-06-02T20:57:32-04:00
+a7fc266 | chore(memory): migrate to memory.log | AGENTS.md, INSTRUCTIONS.md, README.md, context.snapshot.md, docs/CODEX_WORKFLOW.md, memory.log, scripts/autoTaskRunner.js, scripts/commit-log.js, scripts/migrate-memory.js | 2025-06-02T21:18:46-04:00
+1bfa90b | chore(memory): backfill commit history | logs/commit.log, memory.log | 2025-06-02T22:03:05-04:00
+1e87497 | feat(cleanup): remove unused server and optimize polling | README.md, package-lock.json, package.json, server.js, src/app/api/bb-width/route.ts, src/app/api/bollinger/route.ts, src/app/api/btc-txcount/route.ts, src/app/api/cum-delta/route.ts, src/app/api/ema-crossovers/route.ts, src/app/api/funding-rate/route.ts, src/app/api/funding-schedule/route.ts, src/app/api/ichimoku/route.ts, src/app/api/open-interest/route.ts, src/app/api/prev-day/route.ts, src/app/api/rsi/route.ts, src/app/api/stoch-rsi/route.ts, src/app/api/volume-profile/route.ts, src/app/api/volume-spikes/route.ts, src/app/api/vwap/route.ts, src/components/ArbAlertCard.tsx, src/components/BbWidthAlert.tsx, src/components/FundingCountdown.tsx, src/components/OrderBookWidget.tsx, src/components/OrderFlowWidget.tsx | 2025-06-02T22:09:44-04:00
+fe596e0 | chore(bootstrap): automation rules | TASKS.md, logs/commit.log, memory.log, src/app/api/volume-profile/route.ts, src/lib/data/coingecko.ts, task_queue.json | 2025-06-02T22:47:18-04:00
+fb393bb | docs(readme): remove server.js reference | README.md | 2025-06-02T22:47:39-04:00
+5d2fa24 | chore(memory): update commit logs | AGENTS.md, TASKS.md, logs/commit.log, memory.log, src/app/api/volume-profile/route.ts, src/app/page.tsx, src/components/VolumePeakDistance.tsx, task_queue.json | 2025-06-02T23:04:12-04:00
+7dae4ab | Task 30: remove signal components and agents | README.md, TASKS.md, src/__tests__/signals.test.ts, src/app/page.tsx, src/components/SignalCard.tsx, src/components/SignalHistory.tsx, src/lib/agents/AlertLogger.ts, src/lib/agents/SignalGenerator.ts | 2025-06-02T23:09:34-04:00
+90628c9 | feat(ai): remove AI sentiment analysis | src/ai/dev.ts, src/ai/flows/market-sentiment-analysis.ts, src/ai/flows/report-financial-data-flow.ts, src/ai/genkit.ts, src/ai/tools/get-financial-market-data-tool.ts, src/app/page.tsx, src/types/index.ts | 2025-06-02T23:33:21-04:00
+6d3189d | fix(app): cleanup removed features | src/app/page.tsx, src/types/index.ts | 2025-06-02T23:39:02-04:00
+3c018d5 | feat(app): remove macro stock features | src/app/api/correlation/route.ts, src/app/api/dxy/route.ts, src/app/api/us10y/route.ts, src/app/page.tsx, src/types/index.ts | 2025-06-03T01:04:29-04:00
+02b8f90 | fix(agent): remove bybit liquidation logic | src/app/api/liquidation-clusters/route.ts, src/app/page.tsx, src/components/LiquidationClustersChart.tsx, src/lib/agents/DataCollector.ts | 2025-06-03T01:04:38-04:00
+ddeb329 | chore(memory): update commit logs | logs/commit.log, memory.log, package.json | 2025-06-03T01:06:54-04:00
+d99da90 | chore(memory): update logs | logs/commit.log, memory.log, src/lib/data/bybitLiquidations.ts, src/lib/liquidationClusters.ts | 2025-06-03T01:18:39-04:00
+285cd6d | chore(cleanup): remove obsolete market data modules | get_dxy.py, src/app/refresh-demo/page.tsx, src/components/MarketDataCard.tsx, src/lib/marketData.ts | 2025-06-03T01:19:12-04:00
+994b7ff | chore(cleanup): remove orderbook components and routes | src/app/api/cum-delta/route.ts, src/app/api/orderbook/route.ts, src/app/page.tsx, src/components/OrderBookHeatmap.tsx, src/components/OrderBookWidget.tsx, src/components/OrderFlowWidget.tsx | 2025-06-03T06:51:39-04:00
+56fef38 | chore(memory): record task 30 | TASKS.md, logs/commit.log, memory.log, src/app/api/higher-candles/route.ts, src/lib/data/binanceCandles.ts, task_queue.json | 2025-06-03T06:56:17-04:00
+5a8106e | docs: update memory workflow | AGENTS.md | 2025-06-03T07:06:32-04:00
+456728a | chore(memory): update logs | logs/commit.log, memory.log, scripts/migrate-memory.js | 2025-06-03T07:07:14-04:00
+10bc5ee | docs(workflow): reference memory.log | TASKS.md | 2025-06-03T07:09:21-04:00
+ce899bc | fix(signals): update last task completion | signals.json | 2025-06-03T07:13:10-04:00
+a40a52d | chore(memory): sort log and trim old refs | logs/commit.log, memory.log | 2025-06-03T07:33:37-04:00
+1d206b3 | chore(memory): record last task completion | memory.log, signals.json | 2025-06-03T07:34:02-04:00
+16f1022 | Delete CODEX-INSTRUCTIONS.txt | CODEX-INSTRUCTIONS.txt | 2025-06-03T07:41:36-04:00
+b25c3b9 | Delete auto-instruct-codex.md | auto-instruct-codex.md | 2025-06-03T07:41:48-04:00
+f4a9685 | Delete codesetuptolearnfrom.md | codesetuptolearnfrom.md | 2025-06-03T07:52:51-04:00
+0a98b67 | Add files via upload | PERSISTENT_MEMORY_GUIDE.md | 2025-06-03T09:41:05-04:00
+dc4bff5 | Update AGENTS.md | AGENTS.md | 2025-06-03T09:41:41-04:00
+229b8e4 | docs(memory): mem-001 create context snapshot | AGENTS.md, context.snapshot.md | 2025-06-03T09:50:35-04:00
+994a3c9 | docs(memory): mem-002 script docs and guide note | AGENTS.md, PERSISTENT_MEMORY_GUIDE.md, README.md | 2025-06-03T10:09:45-04:00
+6e882f0 | chore(log): update commit history | PERSISTENT_MEMORY_GUIDE.md, logs/commit.log, memory.log, scripts/append-memory.sh | 2025-06-03T10:19:26-04:00
+59778e6 | fix(script): improve memory append durability | PERSISTENT_MEMORY_GUIDE.md, scripts/append-memory.sh | 2025-06-03T10:38:41-04:00
+949ea11 | docs(memory): mem-002 allow memory.log edits | PERSISTENT_MEMORY_GUIDE.md, context.snapshot.md, scripts/append-memory.sh | 2025-06-03T10:47:56-04:00
+2fb0e88 | chore(memory): mem-003 backfill logs | context.snapshot.md, logs/commit.log, memory.log | 2025-06-03T11:14:59-04:00
+ff4aa4f | chore(memory): mem-004 log DocAgent guide update | PERSISTENT_MEMORY_GUIDE.md, logs/commit.log, memory.log | 2025-06-03T11:52:49-04:00
+af2aefd | docs(memory): mem-005 document mem-ID counter | PERSISTENT_MEMORY_GUIDE.md | 2025-06-03T11:55:17-04:00
+2c87fa8 | chore(log): update commit history | AGENTS.md, logs/commit.log, memory.log | 2025-06-03T12:02:45-04:00
+7d30dae | chore(memory): update commit history | AGENTS.md, PERSISTENT_MEMORY_GUIDE.md, context.snapshot.md, logs/commit.log, memory.log | 2025-06-03T12:10:30-04:00
+66b6689 | Add files via upload | CODEX_START.md | 2025-06-03T13:09:43-04:00
+53a7019 | Delete PERSISTENT_MEMORY_GUIDE.md | PERSISTENT_MEMORY_GUIDE.md | 2025-06-03T13:10:43-04:00
+e2f193e | docs(memory): enforce context snapshot updates | AGENTS.md, context.snapshot.md, logs/commit.log, memory.log | 2025-06-03T13:16:24-04:00
+3ef091d | docs(memory): backfill snapshot | AGENTS.md, context.snapshot.md, logs/commit.log, memory.log | 2025-06-03T13:47:45-04:00
+3dce8d1 | chore(memory): record mem-010 | context.snapshot.md, logs/commit.log, memory.log | 2025-06-03T13:54:27-04:00
+5a59e6c | Delete CODEX_START.md | CODEX_START.md | 2025-06-03T15:17:17-04:00
+421b38a | Delete INSTRUCTIONS.md | INSTRUCTIONS.md | 2025-06-03T15:17:35-04:00
+1a51b8e | Delete PLANNING.md | PLANNING.md | 2025-06-03T15:17:51-04:00
+556adb4 | Delete newcodex1.md | newcodex1.md | 2025-06-03T15:18:03-04:00
+90cc68f | Add files via upload | memorymaker.md | 2025-06-03T15:35:46-04:00
+ef3aca9 | chore(memory): record mem-011 | TASKS.md, context.snapshot.md, logs/commit.log, memory.log, task_queue.json | 2025-06-03T15:37:45-04:00
+6b43f4d | chore(memory): record mem-015 | AGENTS.md, README.md, TASKS.md, context.snapshot.md, logs/commit.log, memory.log, package.json, scripts/codex_context.sh | 2025-06-03T17:07:51-04:00
+f77da08 | chore(memory): correct mem-020 logs | AGENTS.md, README.md, TASKS.md, context.snapshot.md, logs/commit.log, memory.log, package.json, scripts/codex_context.sh, task_queue.json | 2025-06-03T18:49:18-04:00
+5b0a31c | chore(memory): record mem-021 | CODEX_START.md, context.snapshot.md, memory.log | 2025-06-03T19:07:13-04:00
+d2623d5 | chore(memory): update logs after docs cleanup | logs/commit.log, memory.log, memorymaker.md | 2025-06-03T19:21:03-04:00
+2dc331a | fix(docs): clean memory guide and add memlog script | README.md, logs/commit.log, memory.log, memorymaker.md, package.json, scripts/update-memory-log.js | 2025-06-03T19:30:49-04:00
+76da9a2 | refactor(memory): centralize log helpers | scripts/autoTaskRunner.js, scripts/commit-log.js, scripts/memory-utils.js, scripts/update-memory-log.js | 2025-06-03T19:41:40-04:00
+5e61721 | chore(memory): record mem-022 | context.snapshot.md, logs/commit.log, memory.log, src/app/page.tsx | 2025-06-03T19:49:37-04:00
+9cfb60c | chore(memory): update logs | logs/commit.log, memory.log, scripts/append-memory.sh, scripts/autoTaskRunner.js, scripts/update-memory-log.js | 2025-06-03T20:18:45-04:00
+b2a16c3 | feat(memory): add helpers and node append script | scripts/append-memory.js, scripts/append-memory.sh, scripts/memory-utils.js | 2025-06-04T00:27:47+00:00

--- a/scripts/append-memory.js
+++ b/scripts/append-memory.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const { repoRoot, snapshotPath, nextMemId } = require('./memory-utils');
+
+function logError(ts) {
+  const logDir = path.join(repoRoot, 'logs');
+  fs.mkdirSync(logDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(logDir, `memory-error-${ts}.txt`),
+    `Memory append failed at ${ts}`
+  );
+}
+
+function formatTimestamp() {
+  const iso = new Date().toISOString();
+  return iso.slice(0, 16).replace('T', ' ') + ' UTC';
+}
+
+function errorTimestamp() {
+  const iso = new Date().toISOString();
+  return iso.slice(0, 19).replace(/[-:]/g, '') + 'Z';
+}
+
+try {
+  const summary = process.argv[2] || 'No summary provided.';
+  const nextGoal = process.argv[3] || 'TBD.';
+  const ts = formatTimestamp();
+  const sha = execSync('git rev-parse --short HEAD', {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  }).trim();
+  const id = nextMemId();
+  const entry =
+    `### ${ts} | mem-${id}\n` +
+    `- Commit SHA: ${sha}\n` +
+    `- Summary: ${summary}\n` +
+    `- Next Goal: ${nextGoal}\n`;
+
+  let content = '';
+  if (fs.existsSync(snapshotPath)) {
+    content = fs.readFileSync(snapshotPath, 'utf8');
+    if (content.length && !content.endsWith('\n')) content += '\n';
+  }
+  fs.writeFileSync(snapshotPath, content + entry);
+} catch (err) {
+  const ts = errorTimestamp();
+  logError(ts);
+  throw err;
+}

--- a/scripts/append-memory.sh
+++ b/scripts/append-memory.sh
@@ -2,33 +2,5 @@
 set -euo pipefail
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$DIR/.."
-MEM_FILE="$REPO_ROOT/context.snapshot.md"
-LOG_DIR="$REPO_ROOT/logs"
-
-on_error() {
-  ts=$(date -u +%Y%m%dT%H%M%SZ)
-  mkdir -p "$LOG_DIR"
-  echo "Memory append failed at $ts" > "$LOG_DIR/memory-error-$ts.txt"
-}
-trap on_error ERR
-
-last_id=$(tail -n 20 "$MEM_FILE" | grep -o 'mem-[0-9]\+' | tail -n 1 | grep -o '[0-9]\+' || echo '0')
-next_id=$(printf "%03d" $((10#$last_id + 1)))
-
-timestamp=$(date -u '+%Y-%m-%d %H:%M UTC')
-sha=$(git -C "$REPO_ROOT" rev-parse --short HEAD)
-
-summary=${1:-"No summary provided."}
-next_goal=${2:-"TBD."}
-
-TMP=$(mktemp "$MEM_FILE.tmp.XXXX")
-cat "$MEM_FILE" > "$TMP"
-{
-  echo "### $timestamp | mem-$next_id"
-  echo "- Commit SHA: $sha"
-  echo "- Summary: $summary"
-  echo "- Next Goal: $next_goal"
-} >> "$TMP"
-mv "$TMP" "$MEM_FILE"
+node "$DIR/append-memory.js" "$@"
 

--- a/scripts/memory-utils.js
+++ b/scripts/memory-utils.js
@@ -3,10 +3,25 @@ const path = require('path');
 
 const repoRoot = path.resolve(__dirname, '..');
 const memPath = path.join(repoRoot, 'memory.log');
+const snapshotPath = path.join(repoRoot, 'context.snapshot.md');
 
 function readMemoryLines() {
   if (!fs.existsSync(memPath)) return [];
   return fs.readFileSync(memPath, 'utf8').trim().split('\n').filter(Boolean);
 }
 
-module.exports = { repoRoot, memPath, readMemoryLines };
+function nextMemId() {
+  let last = 0;
+  if (fs.existsSync(snapshotPath)) {
+    const matches = fs
+      .readFileSync(snapshotPath, 'utf8')
+      .match(/mem-(\d+)/g);
+    if (matches && matches.length) {
+      const lastMatch = matches[matches.length - 1];
+      last = parseInt(lastMatch.replace('mem-', ''), 10);
+    }
+  }
+  return String(last + 1).padStart(3, '0');
+}
+
+module.exports = { repoRoot, memPath, snapshotPath, readMemoryLines, nextMemId };


### PR DESCRIPTION
## Summary
- extend `memory-utils` with `snapshotPath` and `nextMemId`
- add `append-memory.js` and simplify the shell wrapper
- record mem-023 with updated logs

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`

------
https://chatgpt.com/codex/tasks/task_b_683f9237e9788323b0eba6114dbbfca3