### PR TITLE
Add memlog post-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ Personal dashboard for tracking Bitcoin and SPX/SPY price action and technical i
    npm install
    ```
 
-3. Start the development server:
+3. Set up git hooks:
+   ```bash
+   npm run setup
+   ```
+
+4. Start the development server:
    ```bash
    npm run dev
    ```
@@ -116,7 +121,7 @@ npm run commitlog
 1. Run `npm ci` once when you start a session.
 2. Review `memory.log` for the latest summary line.
 3. Open `TASKS.md` and complete the next task.
-4. After each commit `memory.log` is updated automatically with metadata.
+4. After each commit `memory.log` and `logs/commit.log` are refreshed automatically by the `post-commit` hook.
 5. When resuming after a break, run `npm run commitlog` to review recent commits.
 6. Test and backtest outputs are logged in `logs/`.
 
@@ -126,6 +131,7 @@ npm run commitlog
 | ------- | ------- |
 | `npm run auto` | Execute the AutoTaskRunner to process tasks in `task_queue.json` |
 | `npm run commitlog` | Generate `logs/commit.log` from the last entries in `memory.log` |
+| `npm run setup` | Install the post-commit hook for automatic memlog updates |
 | `npm run dev-deps` | Install dev dependencies if `node_modules` is missing |
 | `bash scripts/check-env.sh` | Verify required CLIs (`next`, `jest`, `ts-node`) are installed |
 | `node scripts/try-cmd.js <cmd>` | Run a command only if the binary exists |

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "commitlog": "ts-node scripts/commit-log.ts",
     "memlog": "ts-node scripts/update-memory-log.ts && npm run commitlog",
     "codex": "bash scripts/codex_context.sh",
-    "bootstrap": "npm ci && npm run lint && npm run test && npm run backtest"
+    "setup": "bash scripts/setup-hooks.sh",
+    "bootstrap": "npm ci && npm run lint && npm run test && npm run backtest",
+    "postinstall": "npm run setup"
   },
   "dependencies": {
     "@hookform/resolvers": "^4.1.3",

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOK_PATH="$REPO_ROOT/.git/hooks/post-commit"
+
+cat > "$HOOK_PATH" <<'HOOK'
+#!/usr/bin/env bash
+npm run memlog >/dev/null 2>&1
+HOOK
+
+chmod +x "$HOOK_PATH"
+echo "post-commit hook installed at $HOOK_PATH"
+


### PR DESCRIPTION
## Summary
- create script to install `.git/hooks/post-commit`
- wire `setup` and `postinstall` scripts in `package.json`
- document git hook setup and automatic memlog updates in README

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`
- `npm run commitlog` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_b_683f9da910188323af1e8404b05071fe