### PR TITLE
Add memory util tests

### DIFF
--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -90,3 +90,7 @@
 - Commit SHA: b2a16c3
 - Summary: Added snapshotPath constant and nextMemId helper. Introduced append-memory.js and simplified shell wrapper.
 - Next Goal: Implement Task 31 comparing 5m EMA trend with higher timeframes
+### 2025-06-04 01:19 UTC | mem-024
+- Commit SHA: 2939801
+- Summary: Added tests for nextMemId and update-memory-log using temp files and mocks.
+- Next Goal: continue with remaining tasks

--- a/memory.log
+++ b/memory.log
@@ -564,3 +564,4 @@ d2623d5 | chore(memory): update logs after docs cleanup | logs/commit.log, memor
 5e61721 | chore(memory): record mem-022 | context.snapshot.md, logs/commit.log, memory.log, src/app/page.tsx | 2025-06-03T19:49:37-04:00
 9cfb60c | chore(memory): update logs | logs/commit.log, memory.log, scripts/append-memory.sh, scripts/autoTaskRunner.js, scripts/update-memory-log.js | 2025-06-03T20:18:45-04:00
 b2a16c3 | feat(memory): add helpers and node append script | scripts/append-memory.js, scripts/append-memory.sh, scripts/memory-utils.js | 2025-06-04T00:27:47+00:00
+2939801 | test(memory): add memory utils tests | src/__tests__/memory-utils.test.ts | 2025-06-04T01:19:44+00:00


### PR DESCRIPTION
## Summary
- add tests for nextMemId and update-memory-log
- record mem-024 snapshot

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_683f9e52d5948323862d77c6930604f5