### PR TITLE
Implement mem-rotate utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ npm run commitlog
 1. Run `npm ci` once when you start a session.
 2. Review `memory.log` for the latest summary line.
 3. Open `TASKS.md` and complete the next task.
-4. After each commit `memory.log` and `logs/commit.log` are refreshed automatically by the `post-commit` hook.
+4. After each commit `memory.log` and `logs/commit.log` are refreshed automatically by the `post-commit` hook. The hook also trims `memory.log` to the last 200 entries.
 5. When resuming after a break, run `npm run commitlog` to review recent commits.
 6. Test and backtest outputs are logged in `logs/`.
 
@@ -131,11 +131,14 @@ npm run commitlog
 | ------- | ------- |
 | `npm run auto` | Execute the AutoTaskRunner to process tasks in `task_queue.json` |
 | `npm run commitlog` | Generate `logs/commit.log` from the last entries in `memory.log` |
+| `npm run mem-rotate` | Trim `memory.log` to a set number of entries and refresh `logs/commit.log` |
 | `npm run setup` | Install the post-commit hook for automatic memlog updates |
 | `npm run dev-deps` | Install dev dependencies if `node_modules` is missing |
 | `bash scripts/check-env.sh` | Verify required CLIs (`next`, `jest`, `ts-node`) are installed |
 | `node scripts/try-cmd.js <cmd>` | Run a command only if the binary exists |
 | `npm run backtest` | Launch the backtest defined in `scripts/backtest.ts` |
+
+Use `MEM_ROTATE_LIMIT` or a numeric argument to `npm run mem-rotate` to change the number of retained lines.
 
 ## Using Codex with Persistent Memory
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "auto": "node scripts/try-cmd.js ts-node src/scripts/autoTaskRunner.ts",
     "commitlog": "ts-node scripts/commit-log.ts",
     "memlog": "ts-node scripts/update-memory-log.ts && npm run commitlog",
+    "mem-rotate": "ts-node scripts/mem-rotate.ts",
     "codex": "bash scripts/codex_context.sh",
     "setup": "bash scripts/setup-hooks.sh",
     "bootstrap": "npm ci && npm run lint && npm run test && npm run backtest",

--- a/scripts/mem-rotate.ts
+++ b/scripts/mem-rotate.ts
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import { execSync } from 'child_process';
+import { repoRoot, memPath, readMemoryLines } from './memory-utils';
+
+const limit = parseInt(process.argv[2] || process.env.MEM_ROTATE_LIMIT || '200', 10);
+
+const lines = readMemoryLines();
+
+if (lines.length > limit) {
+  const trimmed = lines.slice(-limit);
+  fs.writeFileSync(memPath, trimmed.join('\n') + '\n');
+  console.log(`memory.log trimmed to last ${limit} entries`);
+} else {
+  console.log('memory.log already within limit');
+}
+
+execSync('ts-node scripts/commit-log.ts', { cwd: repoRoot, stdio: 'inherit' });

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -6,6 +6,7 @@ HOOK_PATH="$REPO_ROOT/.git/hooks/post-commit"
 cat > "$HOOK_PATH" <<'HOOK'
 #!/usr/bin/env bash
 npm run memlog >/dev/null 2>&1
+npm run mem-rotate >/dev/null 2>&1
 HOOK
 
 chmod +x "$HOOK_PATH"


### PR DESCRIPTION
## Summary
- add `mem-rotate.ts` to trim memory.log and update commit log
- document automatic rotation in README
- expose `npm run mem-rotate` and update post-commit hook

## Testing
- `npm run dev-deps` *(fails: 403 Forbidden)*
- `npm run lint`
- `npm run test`
- `npm run backtest`
- `npm run commitlog` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_b_683f9f8b4dcc832384942b9f442e0b11