### PR TITLE
Add commit snapshot updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ npm run commitlog
 1. Run `npm ci` once when you start a session.
 2. Review `memory.log` for the latest summary line.
 3. Open `TASKS.md` and complete the next task.
-4. After each commit `memory.log` and `logs/commit.log` are refreshed automatically by the `post-commit` hook. The hook also trims `memory.log` to the last 200 entries.
+4. After each commit `memory.log`, `logs/commit.log` and `context.snapshot.md` are refreshed automatically by the `post-commit` hook. The hook also trims `memory.log` to the last 200 entries.
 5. When resuming after a break, run `npm run commitlog` to review recent commits.
 6. Test and backtest outputs are logged in `logs/`.
 
@@ -133,6 +133,7 @@ npm run commitlog
 | `npm run commitlog` | Generate `logs/commit.log` from the last entries in `memory.log` |
 | `npm run mem-rotate` | Trim `memory.log` to a set number of entries and refresh `logs/commit.log` |
 | `npm run mem-check` | Verify memory.log hashes exist and snapshot blocks are present |
+| `ts-node scripts/update-snapshot.ts` | Append commit summary and next task to `context.snapshot.md` |
 | `npm run setup` | Install the post-commit hook for automatic memlog updates |
 | `npm run dev-deps` | Install dev dependencies if `node_modules` is missing |
 | `bash scripts/check-env.sh` | Verify required CLIs (`next`, `jest`, `ts-node`) are installed |

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -7,6 +7,7 @@ cat > "$HOOK_PATH" <<'HOOK'
 #!/usr/bin/env bash
 npm run memlog >/dev/null 2>&1
 npm run mem-rotate >/dev/null 2>&1
+ts-node scripts/update-snapshot.ts >/dev/null 2>&1
 HOOK
 
 chmod +x "$HOOK_PATH"

--- a/scripts/update-snapshot.ts
+++ b/scripts/update-snapshot.ts
@@ -1,0 +1,33 @@
+import { execSync } from 'child_process';
+import { repoRoot } from './memory-utils';
+
+function lastCommitSummary(): string {
+  const out = execSync('git log -1 --pretty=format:%s%n%n%b', {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  }).trim();
+  return out || 'No summary';
+}
+
+function nextOpenTask(): string {
+  try {
+    const cmd = "grep -m 1 '^- \[ \]' TASKS.md | sed -E 's/^- \[ \] //'";
+    const task = execSync(cmd, {
+      cwd: repoRoot,
+      shell: '/bin/bash',
+      encoding: 'utf8',
+    }).trim();
+    return task || 'none';
+  } catch {
+    return 'none';
+  }
+}
+
+const summary = lastCommitSummary();
+const nextTask = nextOpenTask();
+
+execSync(`ts-node scripts/append-memory.ts ${JSON.stringify(summary)} ${JSON.stringify(nextTask)}`, {
+  cwd: repoRoot,
+  stdio: 'inherit',
+  shell: '/bin/bash',
+});


### PR DESCRIPTION
## Summary
- update post-commit hook to keep the snapshot fresh
- implement `update-snapshot.ts` script to capture last commit and next task
- document new script in README

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_683fa31586ac83238611409dd8173c5e