### PR TITLE
Add atomic file writer

### DIFF
--- a/scripts/append-memory.ts
+++ b/scripts/append-memory.ts
@@ -1,12 +1,12 @@
 import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
-import { repoRoot, snapshotPath, nextMemId } from './memory-utils';
+import { repoRoot, snapshotPath, nextMemId, atomicWrite } from './memory-utils';
 
 function logError(ts: string) {
   const logDir = path.join(repoRoot, 'logs');
   fs.mkdirSync(logDir, { recursive: true });
-  fs.writeFileSync(path.join(logDir, `memory-error-${ts}.txt`), `Memory append failed at ${ts}`);
+  atomicWrite(path.join(logDir, `memory-error-${ts}.txt`), `Memory append failed at ${ts}`);
 }
 
 function formatTimestamp(): string {
@@ -36,7 +36,7 @@ try {
     content = fs.readFileSync(snapshotPath, 'utf8');
     if (content.length && !content.endsWith('\n')) content += '\n';
   }
-  fs.writeFileSync(snapshotPath, content + entry);
+  atomicWrite(snapshotPath, content + entry);
 } catch (err) {
   const ts = errorTimestamp();
   logError(ts);

--- a/scripts/commit-log.ts
+++ b/scripts/commit-log.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import path from 'path';
-import { memPath, readMemoryLines } from './memory-utils';
+import { memPath, readMemoryLines, atomicWrite } from './memory-utils';
 
 const log = readMemoryLines().slice(-20).join('\n');
 const outPath = path.join(__dirname, '../logs/commit.log');
-fs.writeFileSync(outPath, `${log}\n`);
+atomicWrite(outPath, `${log}\n`);
 console.log(`Commit log written to ${outPath}`);

--- a/scripts/mem-rotate.ts
+++ b/scripts/mem-rotate.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { execSync } from 'child_process';
-import { repoRoot, memPath, readMemoryLines } from './memory-utils';
+import { repoRoot, memPath, readMemoryLines, atomicWrite } from './memory-utils';
 
 const limit = parseInt(process.argv[2] || process.env.MEM_ROTATE_LIMIT || '200', 10);
 
@@ -8,7 +8,7 @@ const lines = readMemoryLines();
 
 if (lines.length > limit) {
   const trimmed = lines.slice(-limit);
-  fs.writeFileSync(memPath, trimmed.join('\n') + '\n');
+  atomicWrite(memPath, trimmed.join('\n') + '\n');
   console.log(`memory.log trimmed to last ${limit} entries`);
 } else {
   console.log('memory.log already within limit');

--- a/scripts/memory-utils.ts
+++ b/scripts/memory-utils.ts
@@ -21,3 +21,10 @@ export function nextMemId(): string {
   }
   return String(last + 1).padStart(3, '0');
 }
+
+export function atomicWrite(file: string, data: string): void {
+  const dir = path.dirname(file);
+  const tmp = path.join(dir, `.${path.basename(file)}.tmp`);
+  fs.writeFileSync(tmp, data);
+  fs.renameSync(tmp, file);
+}

--- a/scripts/update-memory-log.ts
+++ b/scripts/update-memory-log.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { execSync } from 'child_process';
-import { repoRoot, memPath, readMemoryLines } from './memory-utils';
+import { repoRoot, memPath, readMemoryLines, atomicWrite } from './memory-utils';
 
 let entries = readMemoryLines();
 let lastHash = '';
@@ -39,5 +39,5 @@ if (current) {
   entries.push(`${current.h} | ${current.s} | ${current.f.join(', ')} | ${current.d}`);
 }
 
-fs.writeFileSync(memPath, entries.join('\n') + '\n');
+atomicWrite(memPath, entries.join('\n') + '\n');
 console.log('memory.log updated');

--- a/src/__tests__/mem-rotate.test.ts
+++ b/src/__tests__/mem-rotate.test.ts
@@ -7,32 +7,48 @@ import * as utils from "../../scripts/memory-utils";
 const { memPath, repoRoot } = utils;
 
 function withFsMocks(paths: Record<string, string>, fn: () => void) {
+  const expanded: Record<string, string> = {};
+  for (const [k, v] of Object.entries(paths)) {
+    expanded[k] = v;
+    const tmpK = path.join(path.dirname(k), `.${path.basename(k)}.tmp`);
+    const tmpV = path.join(path.dirname(v), `.${path.basename(v)}.tmp`);
+    expanded[tmpK] = tmpV;
+  }
+
   const origExists = fs.existsSync;
   const origRead = fs.readFileSync;
   const origWrite = fs.writeFileSync;
+  const origRename = fs.renameSync;
   const existsMock = jest
     .spyOn(fs, "existsSync")
     .mockImplementation((p: any) => {
-      if (paths[p as string]) {
-        return origExists.call(fs, paths[p as string]);
+      if (expanded[p as string]) {
+        return origExists.call(fs, expanded[p as string]);
       }
       return origExists.call(fs, p);
     });
   const readMock = jest
     .spyOn(fs, "readFileSync")
     .mockImplementation((p: any, opt?: any) => {
-      if (paths[p as string]) {
-        p = paths[p as string];
+      if (expanded[p as string]) {
+        p = expanded[p as string];
       }
       return origRead.call(fs, p, opt);
     });
   const writeMock = jest
     .spyOn(fs, "writeFileSync")
     .mockImplementation((p: any, data: any, opt?: any) => {
-      if (paths[p as string]) {
-        p = paths[p as string];
+      if (expanded[p as string]) {
+        p = expanded[p as string];
       }
       return origWrite.call(fs, p, data, opt as any);
+    });
+  const renameMock = jest
+    .spyOn(fs, "renameSync")
+    .mockImplementation((a: any, b: any) => {
+      if (expanded[a as string]) a = expanded[a as string];
+      if (expanded[b as string]) b = expanded[b as string];
+      return origRename.call(fs, a, b);
     });
   try {
     fn();
@@ -40,6 +56,7 @@ function withFsMocks(paths: Record<string, string>, fn: () => void) {
     existsMock.mockRestore();
     readMock.mockRestore();
     writeMock.mockRestore();
+    renameMock.mockRestore();
   }
 }
 


### PR DESCRIPTION
## Summary
- write files atomically with a new helper
- switch memory management scripts to use `atomicWrite`
- update unit test mocks for new rename step

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_683fa619f1dc832393c78e71694ab78e