### PR TITLE
Implement memory file locks

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -54,6 +54,7 @@ All tasks live in `task_queue.json` as `{ "id": number, "description": string, "
 - [x] Task 89: expand workflow notes in AGENTS.md
 - [x] Task 90: clarify TASKS.md guidance wording
 - [x] Task 91: extend README with persistent memory section
+- [x] Task 92: add file locking for memory writes
 
 
 ### Bitcoin Dashboard

--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -94,3 +94,8 @@
 - Commit SHA: 2939801
 - Summary: Added tests for nextMemId and update-memory-log using temp files and mocks.
 - Next Goal: continue with remaining tasks
+### 2025-06-04 11:29 UTC | mem-025
+- Commit SHA: bd46999
+- Summary: Added file locking to memory utils and wrapped writes in append-memory, update-memory-log and mem-rotate. Created concurrent write test and updated mocks.
+- Next Goal: Implement Task 31 comparing 5m EMA trend with higher timeframes
+

--- a/logs/commit.log
+++ b/logs/commit.log
@@ -18,3 +18,4 @@ d2623d5 | chore(memory): update logs after docs cleanup | logs/commit.log, memor
 5e61721 | chore(memory): record mem-022 | context.snapshot.md, logs/commit.log, memory.log, src/app/page.tsx | 2025-06-03T19:49:37-04:00
 9cfb60c | chore(memory): update logs | logs/commit.log, memory.log, scripts/append-memory.sh, scripts/autoTaskRunner.js, scripts/update-memory-log.js | 2025-06-03T20:18:45-04:00
 b2a16c3 | feat(memory): add helpers and node append script | scripts/append-memory.js, scripts/append-memory.sh, scripts/memory-utils.js | 2025-06-04T00:27:47+00:00
+bd46999 | feat(memory): add file locking | TASKS.md, scripts/append-memory.ts, scripts/mem-rotate.ts, scripts/memory-utils.ts, scripts/update-memory-log.ts, src/__tests__/file-lock.test.ts, src/__tests__/mem-rotate.test.ts, src/__tests__/memory-utils.test.ts, task_queue.json | 2025-06-04T11:29:47+00:00

--- a/memory.log
+++ b/memory.log
@@ -565,3 +565,4 @@ d2623d5 | chore(memory): update logs after docs cleanup | logs/commit.log, memor
 9cfb60c | chore(memory): update logs | logs/commit.log, memory.log, scripts/append-memory.sh, scripts/autoTaskRunner.js, scripts/update-memory-log.js | 2025-06-03T20:18:45-04:00
 b2a16c3 | feat(memory): add helpers and node append script | scripts/append-memory.js, scripts/append-memory.sh, scripts/memory-utils.js | 2025-06-04T00:27:47+00:00
 2939801 | test(memory): add memory utils tests | src/__tests__/memory-utils.test.ts | 2025-06-04T01:19:44+00:00
+bd46999 | feat(memory): add file locking | TASKS.md, scripts/append-memory.ts, scripts/mem-rotate.ts, scripts/memory-utils.ts, scripts/update-memory-log.ts, src/__tests__/file-lock.test.ts, src/__tests__/mem-rotate.test.ts, src/__tests__/memory-utils.test.ts, task_queue.json | 2025-06-04T11:29:47+00:00

--- a/scripts/mem-rotate.ts
+++ b/scripts/mem-rotate.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { execSync } from 'child_process';
-import { repoRoot, memPath, readMemoryLines, atomicWrite } from './memory-utils';
+import { repoRoot, memPath, readMemoryLines, atomicWrite, withFileLock } from './memory-utils';
 
 const limit = parseInt(process.argv[2] || process.env.MEM_ROTATE_LIMIT || '200', 10);
 
@@ -8,7 +8,9 @@ const lines = readMemoryLines();
 
 if (lines.length > limit) {
   const trimmed = lines.slice(-limit);
-  atomicWrite(memPath, trimmed.join('\n') + '\n');
+  withFileLock(memPath, () => {
+    atomicWrite(memPath, trimmed.join('\n') + '\n');
+  });
   console.log(`memory.log trimmed to last ${limit} entries`);
 } else {
   console.log('memory.log already within limit');

--- a/scripts/update-memory-log.ts
+++ b/scripts/update-memory-log.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { execSync } from 'child_process';
-import { repoRoot, memPath, readMemoryLines, atomicWrite } from './memory-utils';
+import { repoRoot, memPath, readMemoryLines, atomicWrite, withFileLock } from './memory-utils';
 
 let entries = readMemoryLines();
 let lastHash = '';
@@ -39,5 +39,7 @@ if (current) {
   entries.push(`${current.h} | ${current.s} | ${current.f.join(', ')} | ${current.d}`);
 }
 
-atomicWrite(memPath, entries.join('\n') + '\n');
+withFileLock(memPath, () => {
+  atomicWrite(memPath, entries.join('\n') + '\n');
+});
 console.log('memory.log updated');

--- a/src/__tests__/file-lock.test.ts
+++ b/src/__tests__/file-lock.test.ts
@@ -1,0 +1,46 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawn } from 'child_process';
+import { repoRoot } from '../../scripts/memory-utils';
+
+function run(file: string, char: string, delay: string) {
+  const script = `
+    const fs = require('fs');
+    const { withFileLock, atomicWrite } = require('${path
+      .join(repoRoot, 'scripts/memory-utils.ts')
+      .replace(/\\/g, '\\\\')}');
+    const file = process.argv[2];
+    const ch = process.argv[3];
+    const d = parseInt(process.argv[4] || '0', 10);
+    withFileLock(file, () => {
+      let cur = fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : '';
+      if (d) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, d);
+      atomicWrite(file, cur + ch);
+    });
+  `;
+  const scriptPath = path.join(os.tmpdir(), `lock-${char}.js`);
+  fs.writeFileSync(scriptPath, script);
+  return spawn('node', ['-r', 'ts-node/register', scriptPath, file, char, delay], {
+    cwd: repoRoot,
+  });
+}
+
+describe('withFileLock', () => {
+  it('serializes concurrent writes', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'locktest-'));
+    const file = path.join(dir, 'mem.txt');
+    const p1 = run(file, 'A', '100');
+    const p2 = run(file, 'B', '0');
+
+    await Promise.all([
+      new Promise((res) => p1.on('exit', res)),
+      new Promise((res) => p2.on('exit', res)),
+    ]);
+
+    const out = fs.readFileSync(file, 'utf8');
+    const sorted = out.split('').sort().join('');
+    expect(sorted).toBe('AB');
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/src/__tests__/mem-rotate.test.ts
+++ b/src/__tests__/mem-rotate.test.ts
@@ -13,12 +13,16 @@ function withFsMocks(paths: Record<string, string>, fn: () => void) {
     const tmpK = path.join(path.dirname(k), `.${path.basename(k)}.tmp`);
     const tmpV = path.join(path.dirname(v), `.${path.basename(v)}.tmp`);
     expanded[tmpK] = tmpV;
+    expanded[`${k}.lock`] = `${v}.lock`;
   }
 
   const origExists = fs.existsSync;
   const origRead = fs.readFileSync;
   const origWrite = fs.writeFileSync;
   const origRename = fs.renameSync;
+  const origOpen = fs.openSync;
+  const origClose = fs.closeSync;
+  const origUnlink = fs.unlinkSync;
   const existsMock = jest
     .spyOn(fs, "existsSync")
     .mockImplementation((p: any) => {
@@ -50,6 +54,21 @@ function withFsMocks(paths: Record<string, string>, fn: () => void) {
       if (expanded[b as string]) b = expanded[b as string];
       return origRename.call(fs, a, b);
     });
+  const openMock = jest
+    .spyOn(fs, "openSync")
+    .mockImplementation((p: any, flag: any) => {
+      if (expanded[p as string]) p = expanded[p as string];
+      return origOpen.call(fs, p, flag);
+    });
+  const closeMock = jest
+    .spyOn(fs, "closeSync")
+    .mockImplementation((fd: any) => origClose.call(fs, fd));
+  const unlinkMock = jest
+    .spyOn(fs, "unlinkSync")
+    .mockImplementation((p: any) => {
+      if (expanded[p as string]) p = expanded[p as string];
+      return origUnlink.call(fs, p);
+    });
   try {
     fn();
   } finally {
@@ -57,6 +76,9 @@ function withFsMocks(paths: Record<string, string>, fn: () => void) {
     readMock.mockRestore();
     writeMock.mockRestore();
     renameMock.mockRestore();
+    openMock.mockRestore();
+    closeMock.mockRestore();
+    unlinkMock.mockRestore();
   }
 }
 

--- a/task_queue.json
+++ b/task_queue.json
@@ -373,5 +373,10 @@
     "id": 91,
     "description": "extend README with persistent memory section",
     "status": "done"
+  },
+  {
+    "id": 92,
+    "description": "add file locking for memory writes",
+    "status": "done"
   }
 ]


### PR DESCRIPTION
## Summary
- add `withFileLock` helper for exclusive writes
- use file locks in append-memory, update-memory-log and mem-rotate
- extend file mocks in tests
- test concurrent write serialization
- record new memory log entry

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_68402d2a61e88323b112b489c976f7c5