### PR TITLE
Add memory log order checks

### DIFF
--- a/scripts/memory-check.ts
+++ b/scripts/memory-check.ts
@@ -8,19 +8,46 @@ const snapshot = fs.existsSync(snapshotPath)
   : '';
 
 const errors: string[] = [];
+let lastTs = 0;
+const seenHashes = new Set<string>();
+const seenMemIds = new Set<string>();
 
 for (const line of lines) {
-  const hash = line.split('|')[0].trim();
-  if (!hash) continue;
+  const parts = line.split('|').map((p) => p.trim());
+  const hash = parts[0];
+  const tsStr = parts[parts.length - 1];
+
+  if (seenHashes.has(hash)) {
+    errors.push(`duplicate commit ${hash}`);
+  }
+  seenHashes.add(hash);
+
+  const ts = Date.parse(tsStr);
+  if (!Number.isNaN(ts)) {
+    if (ts <= lastTs) {
+      const prev = new Date(lastTs).toISOString();
+      errors.push(`timestamp out of order for ${hash}: ${tsStr} <= ${prev}`);
+    }
+    lastTs = ts;
+  }
+
   try {
     execSync(`git cat-file -e ${hash}`, { cwd: repoRoot, stdio: 'ignore' });
   } catch {
     errors.push(`unknown commit ${hash}`);
     continue;
   }
-  const pattern = new RegExp(`mem-\\d+[\\s\\S]*?Commit SHA: ${hash}\\b`);
-  if (!pattern.test(snapshot)) {
-    errors.push(`snapshot missing block for ${hash}`);
+
+  const pattern = new RegExp(`(mem-\\d+)[\\s\\S]*?Commit SHA: ${hash}\\b`);
+  const match = snapshot.match(pattern);
+  if (!match) {
+    errors.push(`snapshot missing mem-id for ${hash}`);
+  } else {
+    const id = match[1];
+    if (seenMemIds.has(id)) {
+      errors.push(`duplicate mem-id ${id}`);
+    }
+    seenMemIds.add(id);
   }
 }
 

--- a/src/__tests__/memory-check.test.ts
+++ b/src/__tests__/memory-check.test.ts
@@ -1,0 +1,95 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import * as cp from 'child_process';
+import * as utils from '../../scripts/memory-utils';
+
+const { memPath, snapshotPath } = utils;
+
+function withFsMocks(paths: Record<string, string>, fn: () => void) {
+  const existsMock = jest.spyOn(fs, 'existsSync').mockImplementation((p: any) => {
+    if (paths[p as string]) return fs.existsSync(paths[p as string]);
+    return fs.existsSync(p);
+  });
+  const readMock = jest.spyOn(fs, 'readFileSync').mockImplementation((p: any, o?: any) => {
+    if (paths[p as string]) p = paths[p as string];
+    return fs.readFileSync(p, o);
+  });
+  try {
+    fn();
+  } finally {
+    existsMock.mockRestore();
+    readMock.mockRestore();
+  }
+}
+
+describe('memory-check', () => {
+  it('passes for ordered log', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memchk-'));
+    const tmpMem = path.join(tmpDir, 'memory.log');
+    const tmpSnap = path.join(tmpDir, 'context.snapshot.md');
+    fs.writeFileSync(
+      tmpMem,
+      'a1b2c3 | test | file | 2025-01-01T00:00:00Z\n' +
+        'b2c3d4 | test | file | 2025-01-01T01:00:00Z\n'
+    );
+    fs.writeFileSync(
+      tmpSnap,
+      '### 2025-01-01 00:00 UTC | mem-001\n' +
+        '- Commit SHA: a1b2c3\n' +
+        '### 2025-01-01 01:00 UTC | mem-002\n' +
+        '- Commit SHA: b2c3d4\n'
+    );
+    const execMock = jest.spyOn(cp, 'execSync').mockReturnValue(Buffer.from(''));
+    const logMock = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    withFsMocks({ [memPath]: tmpMem, [snapshotPath]: tmpSnap }, () => {
+      jest.isolateModules(() => {
+        require('../../scripts/memory-check.ts');
+      });
+    });
+
+    expect(logMock).toHaveBeenCalledWith('Memory check passed');
+    execMock.mockRestore();
+    logMock.mockRestore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('fails for unordered log', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memchk-'));
+    const tmpMem = path.join(tmpDir, 'memory.log');
+    const tmpSnap = path.join(tmpDir, 'context.snapshot.md');
+    fs.writeFileSync(
+      tmpMem,
+      'a1b2c3 | test | file | 2025-01-01T01:00:00Z\n' +
+        'b2c3d4 | test | file | 2025-01-01T00:00:00Z\n'
+    );
+    fs.writeFileSync(
+      tmpSnap,
+      '### 2025-01-01 00:00 UTC | mem-001\n' +
+        '- Commit SHA: a1b2c3\n' +
+        '### 2025-01-01 01:00 UTC | mem-002\n' +
+        '- Commit SHA: b2c3d4\n'
+    );
+    const execMock = jest.spyOn(cp, 'execSync').mockReturnValue(Buffer.from(''));
+    const errMock = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const exitMock = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(String(code));
+      }) as any);
+
+    expect(() => {
+      withFsMocks({ [memPath]: tmpMem, [snapshotPath]: tmpSnap }, () => {
+        jest.isolateModules(() => {
+          require('../../scripts/memory-check.ts');
+        });
+      });
+    }).toThrow('1');
+
+    execMock.mockRestore();
+    errMock.mockRestore();
+    exitMock.mockRestore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- enhance memory-check script to validate commit order
- detect duplicates and missing mem IDs
- test ordered vs unordered memory logs

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_6840317c84c08323afac3bc0700e8cfa