### PR TITLE
Add memory rebuild script

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ npm run commitlog
 | `npm run mem-rotate` | Trim `memory.log` to a set number of entries and refresh `logs/commit.log` |
 | `npm run mem-check` | Verify memory.log hashes exist and snapshot blocks are present |
 | `ts-node scripts/update-snapshot.ts` | Append commit summary and next task to `context.snapshot.md` |
+| `ts-node scripts/rebuild-memory.ts [path]` | Rebuild `memory.log` and `context.snapshot.md` from git history |
 | `npm run setup` | Install the post-commit hook for automatic memlog updates |
 | `npm run dev-deps` | Install dev dependencies if `node_modules` is missing |
 | `bash scripts/check-env.sh` | Verify required CLIs (`next`, `jest`, `ts-node`) are installed |

--- a/scripts/rebuild-memory.ts
+++ b/scripts/rebuild-memory.ts
@@ -1,0 +1,58 @@
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+import { atomicWrite, withFileLock, repoRoot as defaultRoot } from './memory-utils';
+
+function parseLog(repo: string) {
+  const raw = execSync(
+    'git log --reverse --pretty=format:%h|%s|%cI --name-only',
+    { cwd: repo, encoding: 'utf8' }
+  );
+  const lines = raw.trim().split('\n');
+  const entries: { h: string; s: string; d: string; f: string[] }[] = [];
+  let cur: { h: string; s: string; d: string; f: string[] } | undefined;
+  for (const line of lines) {
+    if (!line) continue;
+    if (line.includes('|')) {
+      if (cur) entries.push(cur);
+      const [h, s, d] = line.split('|');
+      cur = { h: h.trim(), s: s.trim(), d: d.trim(), f: [] };
+    } else if (cur) {
+      cur.f.push(line.trim());
+    }
+  }
+  if (cur) entries.push(cur);
+  return entries;
+}
+
+function rebuildMemory(repo: string) {
+  const memFile = path.join(repo, 'memory.log');
+  const snapFile = path.join(repo, 'context.snapshot.md');
+  if (fs.existsSync(memFile)) fs.unlinkSync(memFile);
+  if (fs.existsSync(snapFile)) fs.unlinkSync(snapFile);
+
+  const entries = parseLog(repo);
+
+  const original = execSync('git rev-parse --abbrev-ref HEAD || git rev-parse HEAD', {
+    cwd: repo,
+    encoding: 'utf8',
+    shell: '/bin/bash',
+  }).trim();
+
+  const append = path.join(__dirname, 'append-memory.ts');
+  for (const e of entries) {
+    execSync(`git checkout ${e.h} --quiet`, { cwd: repo, stdio: 'ignore' });
+    execSync(`ts-node ${append} ${JSON.stringify(e.s)} ${JSON.stringify('rebuild')}`,
+      { cwd: repo, stdio: 'ignore', shell: '/bin/bash' });
+  }
+  execSync(`git checkout ${original} --quiet`, { cwd: repo, stdio: 'ignore' });
+
+  const lines = entries.map((e) => `${e.h} | ${e.s} | ${e.f.join(', ')} | ${e.d}`);
+  withFileLock(memFile, () => {
+    atomicWrite(memFile, lines.join('\n') + '\n');
+  });
+  console.log('memory.log and context.snapshot.md rebuilt');
+}
+
+const repo = process.argv[2] ? path.resolve(process.argv[2]) : defaultRoot;
+rebuildMemory(repo);

--- a/src/__tests__/rebuild-memory.test.ts
+++ b/src/__tests__/rebuild-memory.test.ts
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import * as cp from 'child_process';
+
+const script = path.join(__dirname, '../../scripts/rebuild-memory.ts');
+
+describe('rebuild-memory', () => {
+  it('writes commit history to memory.log', () => {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'rebuild-'));
+    cp.execSync('git init', { cwd: repo });
+    fs.writeFileSync(path.join(repo, 'a.txt'), 'a');
+    cp.execSync('git add a.txt', { cwd: repo });
+    cp.execSync('git commit -m "first"', { cwd: repo });
+    fs.writeFileSync(path.join(repo, 'b.txt'), 'b');
+    cp.execSync('git add b.txt', { cwd: repo });
+    cp.execSync('git commit -m "second"', { cwd: repo });
+
+    const origExec = cp.execSync;
+    const execMock = jest.spyOn(cp, 'execSync').mockImplementation((cmd: string, opts?: any) => {
+      if (cmd.startsWith('ts-node') && cmd.includes('append-memory.ts')) {
+        return Buffer.from('');
+      }
+      return origExec(cmd, opts);
+    });
+
+    jest.isolateModules(() => {
+      process.argv = ['node', script, repo];
+      require('../../scripts/rebuild-memory.ts');
+    });
+
+    execMock.mockRestore();
+    const out = fs.readFileSync(path.join(repo, 'memory.log'), 'utf8').trim().split('\n');
+    expect(out.length).toBe(2);
+    expect(out[0]).toMatch(/first/);
+    expect(out[1]).toMatch(/second/);
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- introduce `rebuild-memory.ts` for reconstructing memory log and snapshot
- document new script in README
- cover memory rebuild with basic Jest test

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_6840354bd75c83238de47be5aef6a960