### PR TITLE
Add memory summary validation

### DIFF
--- a/scripts/memory-check.ts
+++ b/scripts/memory-check.ts
@@ -39,6 +39,22 @@ for (const line of lines) {
     continue;
   }
 
+  let commitSummary = '';
+  try {
+    commitSummary = execSync(`git log -1 --pretty=%s ${hash}`, {
+      cwd: repoRoot,
+    })
+      .toString()
+      .trim();
+  } catch {
+    errors.push(`unable to read summary for ${hash}`);
+  }
+
+  const memSummary = parts.length === 5 ? parts[2] : parts[1];
+  if (commitSummary && memSummary && memSummary !== commitSummary) {
+    errors.push(`summary mismatch for ${hash}`);
+  }
+
   const pattern = new RegExp(`(mem-\\d+)[\\s\\S]*?Commit SHA: ${hash}\\b`);
   const match = snapshot.match(pattern);
   if (!match) {

--- a/src/__tests__/memory-check.test.ts
+++ b/src/__tests__/memory-check.test.ts
@@ -40,7 +40,12 @@ describe('memory-check', () => {
         '### 2025-01-01 01:00 UTC | mem-002\n' +
         '- Commit SHA: b2c3d4\n'
     );
-    const execMock = jest.spyOn(cp, 'execSync').mockReturnValue(Buffer.from(''));
+    const execMock = jest
+      .spyOn(cp, 'execSync')
+      .mockImplementation((cmd: string) => {
+        if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('test');
+        return Buffer.from('');
+      });
     const logMock = jest.spyOn(console, 'log').mockImplementation(() => {});
 
     withFsMocks({ [memPath]: tmpMem, [snapshotPath]: tmpSnap }, () => {
@@ -71,7 +76,12 @@ describe('memory-check', () => {
         '### 2025-01-01 01:00 UTC | mem-002\n' +
         '- Commit SHA: b2c3d4\n'
     );
-    const execMock = jest.spyOn(cp, 'execSync').mockReturnValue(Buffer.from(''));
+    const execMock = jest
+      .spyOn(cp, 'execSync')
+      .mockImplementation((cmd: string) => {
+        if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('test');
+        return Buffer.from('');
+      });
     const errMock = jest.spyOn(console, 'error').mockImplementation(() => {});
     const exitMock = jest
       .spyOn(process, 'exit')
@@ -109,7 +119,48 @@ describe('memory-check', () => {
         '### 2025-01-01 01:00 UTC | mem-003\n' +
         '- Commit SHA: b2c3d4\n'
     );
-    const execMock = jest.spyOn(cp, 'execSync').mockReturnValue(Buffer.from(''));
+    const execMock = jest
+      .spyOn(cp, 'execSync')
+      .mockImplementation((cmd: string) => {
+        if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('test');
+        return Buffer.from('');
+      });
+    const errMock = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const exitMock = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(String(code));
+      }) as any);
+
+    expect(() => {
+      withFsMocks({ [memPath]: tmpMem, [snapshotPath]: tmpSnap }, () => {
+        jest.isolateModules(() => {
+          require('../../scripts/memory-check.ts');
+        });
+      });
+    }).toThrow('1');
+
+    execMock.mockRestore();
+    errMock.mockRestore();
+    exitMock.mockRestore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('fails for mismatched summary', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memchk-'));
+    const tmpMem = path.join(tmpDir, 'memory.log');
+    const tmpSnap = path.join(tmpDir, 'context.snapshot.md');
+    fs.writeFileSync(tmpMem, 'a1b2c3 | wrong | file | 2025-01-01T00:00:00Z\n');
+    fs.writeFileSync(
+      tmpSnap,
+      '### 2025-01-01 00:00 UTC | mem-001\n' + '- Commit SHA: a1b2c3\n'
+    );
+    const execMock = jest
+      .spyOn(cp, 'execSync')
+      .mockImplementation((cmd: string) => {
+        if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('correct');
+        return Buffer.from('');
+      });
     const errMock = jest.spyOn(console, 'error').mockImplementation(() => {});
     const exitMock = jest
       .spyOn(process, 'exit')


### PR DESCRIPTION
## Summary
- extend `memory-check.ts` to verify commit summaries
- update unit tests for new git log call
- add failing case when memory summary differs from git history

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_6840390bf6e0832382fbfc2cf7dc93b5