### PR TITLE
Add sequential memory test

### DIFF
--- a/src/__tests__/rebuild-memory.test.ts
+++ b/src/__tests__/rebuild-memory.test.ts
@@ -36,4 +36,57 @@ describe('rebuild-memory', () => {
     expect(out[1]).toMatch(/second/);
     fs.rmSync(repo, { recursive: true, force: true });
   });
+
+  it('writes sequential mem-ids to snapshot', () => {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'rebuild-'));
+    cp.execSync('git init', { cwd: repo });
+    fs.writeFileSync(path.join(repo, 'a.txt'), 'a');
+    cp.execSync('git add a.txt', { cwd: repo });
+    cp.execSync('git commit -m "first"', { cwd: repo });
+    fs.writeFileSync(path.join(repo, 'b.txt'), 'b');
+    cp.execSync('git add b.txt', { cwd: repo });
+    cp.execSync('git commit -m "second"', { cwd: repo });
+
+    const snapshot = path.join(repo, 'context.snapshot.md');
+
+    const origExec = cp.execSync;
+    let count = 0;
+    const execMock = jest
+      .spyOn(cp, 'execSync')
+      .mockImplementation((cmd: string, opts?: any) => {
+        if (cmd.startsWith('ts-node') && cmd.includes('append-memory.ts')) {
+          const sha = origExec('git rev-parse --short HEAD', {
+            cwd: repo,
+            encoding: 'utf8',
+          })
+            .toString()
+            .trim();
+          count++;
+          const id = String(count).padStart(3, '0');
+          fs.appendFileSync(snapshot, `### 0 | mem-${id}\n- Commit SHA: ${sha}\n`);
+          return Buffer.from('');
+        }
+        return origExec(cmd, opts);
+      });
+
+    jest.isolateModules(() => {
+      process.argv = ['node', script, repo];
+      require('../../scripts/rebuild-memory.ts');
+    });
+
+    execMock.mockRestore();
+    const memLines = fs
+      .readFileSync(path.join(repo, 'memory.log'), 'utf8')
+      .trim()
+      .split('\n');
+    const snapContent = fs.readFileSync(snapshot, 'utf8');
+    const ids = memLines.map((line) => {
+      const hash = line.split('|')[0].trim();
+      const m = snapContent.match(new RegExp(`(mem-\\d+)[\\s\\S]*?Commit SHA: ${hash}`));
+      return m ? m[1] : '';
+    });
+    const expected = memLines.map((_, i) => `mem-${String(i + 1).padStart(3, '0')}`);
+    expect(ids).toEqual(expected);
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
 });


### PR DESCRIPTION
## Summary
- expand `rebuild-memory.test.ts` with a new case that verifies generated mem-IDs

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_68403ced3f2883239d33039e89bab8a5