### PR TITLE
Add mem-status helper script

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "snap-rotate": "ts-node scripts/snapshot-rotate.ts",
     "mem-check": "ts-node scripts/memory-check.ts",
     "memgrep": "ts-node scripts/memgrep.ts",
+    "mem-status": "ts-node scripts/mem-status.ts",
     "codex": "bash scripts/codex_context.sh",
     "setup": "bash scripts/setup-hooks.sh",
     "bootstrap": "npm ci && npm run lint && npm run test && npm run backtest",

--- a/scripts/mem-status.ts
+++ b/scripts/mem-status.ts
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+import { readMemoryLines, nextMemId, memPath, repoRoot } from './memory-utils';
+
+const tasksPath = path.join(repoRoot, 'TASKS.md');
+
+const lines = readMemoryLines();
+const last = lines.length ? lines[lines.length - 1] : 'none';
+
+let task = 'none';
+if (fs.existsSync(tasksPath)) {
+  const tLines = fs.readFileSync(tasksPath, 'utf8').split('\n');
+  const pending = tLines.find((l) => l.startsWith('- [ ] '));
+  if (pending) task = pending.replace(/^- \[ \] /, '').trim();
+}
+
+const id = nextMemId();
+
+console.log(`${last}\nmem-${id}\n${task}`);
+

--- a/src/__tests__/mem-status.test.ts
+++ b/src/__tests__/mem-status.test.ts
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import * as utils from '../../scripts/memory-utils';
+
+const { memPath, snapshotPath, repoRoot } = utils;
+
+function withFsMocks(paths: Record<string, string>, fn: () => void) {
+  const existsMock = jest.spyOn(fs, 'existsSync').mockImplementation((p: any) => {
+    if (paths[p as string]) return fs.existsSync(paths[p as string]);
+    return fs.existsSync(p);
+  });
+  const readMock = jest
+    .spyOn(fs, 'readFileSync')
+    .mockImplementation((p: any, opt?: any) => {
+      if (paths[p as string]) p = paths[p as string];
+      return fs.readFileSync(p, opt);
+    });
+  try {
+    fn();
+  } finally {
+    existsMock.mockRestore();
+    readMock.mockRestore();
+  }
+}
+
+describe('mem-status', () => {
+  it('prints last memory line, next mem-id and next task', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'memstat-'));
+    const memFile = path.join(dir, 'memory.log');
+    const tasksFile = path.join(dir, 'TASKS.md');
+    const snapFile = path.join(dir, 'context.snapshot.md');
+    fs.writeFileSync(memFile, 'abc123 | test commit | file | 2025-01-01T00:00:00Z\n');
+    fs.writeFileSync(tasksFile, '- [ ] Task 1: do something\n');
+    fs.writeFileSync(snapFile, '');
+    const logMock = jest.spyOn(console, 'log').mockImplementation(() => {});
+    withFsMocks(
+      {
+        [memPath]: memFile,
+        [path.join(repoRoot, 'TASKS.md')]: tasksFile,
+        [snapshotPath]: snapFile,
+      },
+      () => {
+        jest.isolateModules(() => {
+          require('../../scripts/mem-status.ts');
+        });
+      }
+    );
+    expect(logMock).toHaveBeenCalledWith(
+      'abc123 | test commit | file | 2025-01-01T00:00:00Z\nmem-001\nTask 1: do something'
+    );
+    logMock.mockRestore();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- expose `mem-status` script to show last memory line, next mem-id and next task
- register `npm run mem-status`
- test script output with mocked files

## Testing
- `npm run lint`
- `npm run test` *(fails: Command jest missing)*
- `npm run backtest` *(fails: Command ts-node missing)*

------
https://chatgpt.com/codex/tasks/task_b_68403f1a3a808323a335d1e0a80b4dd0