### PR TITLE
Task 1: override memory paths via env

### DIFF
--- a/scripts/memory-utils.ts
+++ b/scripts/memory-utils.ts
@@ -2,8 +2,12 @@ import fs from 'fs';
 import path from 'path';
 
 export const repoRoot = path.resolve(__dirname, '..');
-export const memPath = path.join(repoRoot, 'memory.log');
-export const snapshotPath = path.join(repoRoot, 'context.snapshot.md');
+export const memPath = process.env.MEM_PATH
+  ? path.resolve(process.env.MEM_PATH)
+  : path.join(repoRoot, 'memory.log');
+export const snapshotPath = process.env.SNAPSHOT_PATH
+  ? path.resolve(process.env.SNAPSHOT_PATH)
+  : path.join(repoRoot, 'context.snapshot.md');
 
 export function readMemoryLines(): string[] {
   if (!fs.existsSync(memPath)) return [];

--- a/src/__tests__/memory-utils.test.ts
+++ b/src/__tests__/memory-utils.test.ts
@@ -179,3 +179,31 @@ describe('atomicWrite', () => {
   });
 });
 
+describe('path overrides', () => {
+  it('uses MEM_PATH and SNAPSHOT_PATH when set', () => {
+    const mem = path.join(os.tmpdir(), 'custom-mem.log');
+    const snap = path.join(os.tmpdir(), 'custom-snap.md');
+    jest.isolateModules(() => {
+      process.env.MEM_PATH = mem;
+      process.env.SNAPSHOT_PATH = snap;
+      const mod = require('../../scripts/memory-utils');
+      expect(mod.memPath).toBe(path.resolve(mem));
+      expect(mod.snapshotPath).toBe(path.resolve(snap));
+      delete process.env.MEM_PATH;
+      delete process.env.SNAPSHOT_PATH;
+    });
+  });
+
+  it('defaults to repo root when env vars absent', () => {
+    jest.isolateModules(() => {
+      delete process.env.MEM_PATH;
+      delete process.env.SNAPSHOT_PATH;
+      const mod = require('../../scripts/memory-utils');
+      expect(mod.memPath).toBe(path.join(mod.repoRoot, 'memory.log'));
+      expect(mod.snapshotPath).toBe(
+        path.join(mod.repoRoot, 'context.snapshot.md')
+      );
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- allow specifying memory.log and snapshot paths via `MEM_PATH` and `SNAPSHOT_PATH`
- test memory path overrides

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_68403f176c2c83239fc394aaeea6f8cd