### PR TITLE
Add mem-check to pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
 #!/bin/sh
-npm run lint && npm run test
+npm run lint && npm run test && npm run mem-check

--- a/src/__tests__/precommit.test.ts
+++ b/src/__tests__/precommit.test.ts
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import path from 'path';
+import * as cp from 'child_process';
+import { repoRoot } from '../../scripts/memory-utils';
+
+function runHook() {
+  const hookPath = path.join(repoRoot, '.husky/pre-commit');
+  const lines = fs.readFileSync(hookPath, 'utf8').split('\n');
+  const cmd = lines.find((l) => l.startsWith('npm'));
+  if (cmd) {
+    cp.spawnSync(cmd, { shell: true });
+  }
+}
+
+describe('pre-commit hook', () => {
+  it('invokes npm run mem-check', () => {
+    const spy = jest
+      .spyOn(cp, 'spawnSync')
+      .mockReturnValue({ status: 0 } as any);
+    runHook();
+    expect(spy).toHaveBeenCalled();
+    const joined = spy.mock.calls.map((c) => c[0]).join(' ');
+    expect(joined).toContain('npm run mem-check');
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- append `npm run mem-check` to the Husky pre-commit hook
- verify the hook via a new Jest test

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_68403f16629c8323ae0924b8b5bd873b