### PR TITLE
Add lock cleanup utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
     "mem-rotate": "ts-node scripts/mem-rotate.ts",
     "snap-rotate": "ts-node scripts/snapshot-rotate.ts",
     "mem-check": "ts-node scripts/memory-check.ts",
-    "memgrep": "ts-node scripts/memgrep.ts",
-    "codex": "bash scripts/codex_context.sh",
+  "memgrep": "ts-node scripts/memgrep.ts",
+  "clean-locks": "ts-node scripts/clean-locks.ts",
+  "codex": "bash scripts/codex_context.sh",
     "setup": "bash scripts/setup-hooks.sh",
     "bootstrap": "npm ci && npm run lint && npm run test && npm run backtest",
     "postinstall": "npm run setup"

--- a/scripts/clean-locks.ts
+++ b/scripts/clean-locks.ts
@@ -1,0 +1,35 @@
+import fs from 'fs';
+import path from 'path';
+import { repoRoot } from './memory-utils';
+
+export const LOCK_TTL_MS = parseInt(process.env.LOCK_TTL || '', 10) || 300_000;
+
+export function cleanLocks(root: string = repoRoot, ttl: number = LOCK_TTL_MS): void {
+  const stack = [root];
+  while (stack.length) {
+    const dir = stack.pop() as string;
+    let entries: fs.Dirent[] = [];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else if (entry.isFile() && entry.name.endsWith('.lock')) {
+        try {
+          const stat = fs.statSync(full);
+          if (Date.now() - stat.mtimeMs > ttl) {
+            fs.unlinkSync(full);
+          }
+        } catch {}
+      }
+    }
+  }
+}
+
+if (require.main === module) {
+  cleanLocks();
+}

--- a/src/__tests__/clean-locks.test.ts
+++ b/src/__tests__/clean-locks.test.ts
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { cleanLocks } from '../../scripts/clean-locks';
+
+const TTL = 300_000; // 5 minutes
+
+describe('cleanLocks', () => {
+  it('removes stale lock files', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'locks-'));
+    const oldLock = path.join(dir, 'old.lock');
+    const newLock = path.join(dir, 'new.lock');
+    fs.writeFileSync(oldLock, '');
+    fs.writeFileSync(newLock, '');
+
+    const past = new Date(Date.now() - TTL - 1000);
+    fs.utimesSync(oldLock, past, past);
+
+    cleanLocks(dir, TTL);
+
+    expect(fs.existsSync(oldLock)).toBe(false);
+    expect(fs.existsSync(newLock)).toBe(true);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- script to purge stale `.lock` files older than `LOCK_TTL`
- expose via `npm run clean-locks`
- test removal of outdated lock files

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`
- `npm run commitlog` *(failed: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_b_68403f15f9a48323b55a90a4305a7d86