### PR TITLE
Add new persistent memory tasks

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -56,6 +56,17 @@ All tasks live in `task_queue.json` as `{ "id": number, "description": string, "
 - [x] Task 91: extend README with persistent memory section
 - [x] Task 92: add file locking for memory writes
 
+### Upcoming Enhancements
+
+- [ ] Task 93: fix codex helper command by running ts-node scripts/codex-context.ts
+- [ ] Task 94: document MEM_PATH and SNAPSHOT_PATH in README with rotation env vars
+- [ ] Task 95: create memory CLI with rotate, snapshot-rotate, status, grep, update-log
+- [ ] Task 96: add jest tests verifying codex-context output with mocked git log
+- [ ] Task 97: export memory.log lines to memory.json using readMemoryLines helper
+- [ ] Task 98: add weekly workflow running mem-rotate and commitlog to push updates
+- [ ] Task 99: extend memgrep to filter by --since and --until timestamps
+- [ ] Task 100: update README rotation section showing mem-rotate and snapshot-rotate usage
+
 
 ### Bitcoin Dashboard
 

--- a/logs/commit.log
+++ b/logs/commit.log
@@ -19,3 +19,4 @@ d2623d5 | chore(memory): update logs after docs cleanup | logs/commit.log, memor
 9cfb60c | chore(memory): update logs | logs/commit.log, memory.log, scripts/append-memory.sh, scripts/autoTaskRunner.js, scripts/update-memory-log.js | 2025-06-03T20:18:45-04:00
 b2a16c3 | feat(memory): add helpers and node append script | scripts/append-memory.js, scripts/append-memory.sh, scripts/memory-utils.js | 2025-06-04T00:27:47+00:00
 bd46999 | feat(memory): add file locking | TASKS.md, scripts/append-memory.ts, scripts/mem-rotate.ts, scripts/memory-utils.ts, scripts/update-memory-log.ts, src/__tests__/file-lock.test.ts, src/__tests__/mem-rotate.test.ts, src/__tests__/memory-utils.test.ts, task_queue.json | 2025-06-04T11:29:47+00:00
+cdc44db | docs(memory): add pending automation tasks | TASKS.md, task_queue.json | 2025-06-04T13:21:01+00:00

--- a/memory.log
+++ b/memory.log
@@ -568,3 +568,4 @@ b2a16c3 | feat(memory): add helpers and node append script | scripts/append-memo
 bd46999 | feat(memory): add file locking | TASKS.md, scripts/append-memory.ts, scripts/mem-rotate.ts, scripts/memory-utils.ts, scripts/update-memory-log.ts, src/__tests__/file-lock.test.ts, src/__tests__/mem-rotate.test.ts, src/__tests__/memory-utils.test.ts, task_queue.json | 2025-06-04T11:29:47+00:00
 0d51487 | fix(memory): fsync temp file before rename | scripts/memory-utils.ts, src/__tests__/memory-utils.test.ts | 2025-06-04T12:34:42Z
 0fbe5ef | test(memory): add update-snapshot tests | src/__tests__/update-snapshot.test.ts | 2025-06-04T12:45:11Z
+cdc44db | docs(memory): add pending automation tasks | TASKS.md, task_queue.json | 2025-06-04T13:21:01+00:00

--- a/task_queue.json
+++ b/task_queue.json
@@ -378,5 +378,45 @@
     "id": 92,
     "description": "add file locking for memory writes",
     "status": "done"
+  },
+  {
+    "id": 93,
+    "description": "fix codex helper command by running ts-node scripts/codex-context.ts",
+    "status": "pending"
+  },
+  {
+    "id": 94,
+    "description": "document MEM_PATH and SNAPSHOT_PATH in README with rotation env vars",
+    "status": "pending"
+  },
+  {
+    "id": 95,
+    "description": "create memory CLI with rotate, snapshot-rotate, status, grep, update-log",
+    "status": "pending"
+  },
+  {
+    "id": 96,
+    "description": "add jest tests verifying codex-context output with mocked git log",
+    "status": "pending"
+  },
+  {
+    "id": 97,
+    "description": "export memory.log lines to memory.json using readMemoryLines helper",
+    "status": "pending"
+  },
+  {
+    "id": 98,
+    "description": "add weekly workflow running mem-rotate and commitlog to push updates",
+    "status": "pending"
+  },
+  {
+    "id": 99,
+    "description": "extend memgrep to filter by --since and --until timestamps",
+    "status": "pending"
+  },
+  {
+    "id": 100,
+    "description": "update README rotation section showing mem-rotate and snapshot-rotate usage",
+    "status": "pending"
   }
 ]


### PR DESCRIPTION
## Summary
- list upcoming memory automation tasks in TASKS.md
- sync task_queue.json with the new tasks
- log the update in persistent memory files

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`
- `npm run commitlog` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_b_684044526b7083239d58326138c691ea