### PR TITLE
Add mem-diff utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ npm run commitlog
 | `npm run commitlog` | Generate `logs/commit.log` from the last entries in `memory.log` |
 | `npm run mem-rotate` | Trim `memory.log` to a set number of entries and refresh `logs/commit.log` |
 | `npm run mem-check` | Verify memory hashes and snapshot blocks (auto after `mem-rotate`) |
+| `npm run mem-diff` | List commit hashes missing from `memory.log` |
 | `ts-node scripts/update-snapshot.ts` | Append commit summary and next task to `context.snapshot.md` |
 | `ts-node scripts/rebuild-memory.ts [path]` | Rebuild `memory.log` and `context.snapshot.md` from git history |
 | `npm run setup` | Install the post-commit hook for automatic memlog updates |

--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
     "mem-rotate": "ts-node scripts/mem-rotate.ts",
     "snap-rotate": "ts-node scripts/snapshot-rotate.ts",
     "mem-check": "ts-node scripts/memory-check.ts",
-  "memgrep": "ts-node scripts/memgrep.ts",
-  "clean-locks": "ts-node scripts/clean-locks.ts",
-  "codex": "bash scripts/codex_context.sh",
+    "mem-diff": "ts-node scripts/mem-diff.ts",
+    "memgrep": "ts-node scripts/memgrep.ts",
+    "clean-locks": "ts-node scripts/clean-locks.ts",
+    "codex": "bash scripts/codex_context.sh",
     "setup": "bash scripts/setup-hooks.sh",
     "bootstrap": "npm ci && npm run lint && npm run test && npm run backtest",
     "postinstall": "npm run setup"

--- a/scripts/mem-diff.ts
+++ b/scripts/mem-diff.ts
@@ -1,0 +1,22 @@
+import { execSync } from 'child_process';
+import { readMemoryLines, repoRoot } from './memory-utils';
+
+const memHashes = new Set(
+  readMemoryLines().map((line) => line.split('|')[0].trim())
+);
+
+const gitHashes = execSync('git log --pretty=%h --no-merges', {
+  cwd: repoRoot,
+})
+  .toString()
+  .trim()
+  .split('\n')
+  .filter(Boolean);
+
+const missing = gitHashes.filter((h) => !memHashes.has(h));
+
+if (missing.length) {
+  console.log(missing.join('\n'));
+} else {
+  console.log('All commits present in memory.log');
+}


### PR DESCRIPTION
## Summary
- show hashes in git history missing from memory.log
- document usage and add npm script

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_684060c424b0832380f93f198f3f96f8