### PR TITLE
Add memory log parser and refactor scripts

### DIFF
--- a/scripts/commit-log.ts
+++ b/scripts/commit-log.ts
@@ -1,8 +1,17 @@
 import fs from 'fs';
 import path from 'path';
-import { memPath, readMemoryLines, atomicWrite, withFileLock } from './memory-utils';
+import {
+  memPath,
+  readMemoryLines,
+  atomicWrite,
+  withFileLock,
+  parseMemoryLines,
+} from './memory-utils';
 
-const log = readMemoryLines().slice(-20).join('\n');
+const log = parseMemoryLines(readMemoryLines())
+  .slice(-20)
+  .map((e) => e.raw)
+  .join('\n');
 const outPath = path.join(__dirname, '../logs/commit.log');
 withFileLock(outPath, () => {
   atomicWrite(outPath, `${log}\n`);

--- a/scripts/mem-status.ts
+++ b/scripts/mem-status.ts
@@ -1,11 +1,18 @@
 import fs from 'fs';
 import path from 'path';
-import { readMemoryLines, nextMemId, memPath, repoRoot } from './memory-utils';
+import {
+  readMemoryLines,
+  nextMemId,
+  memPath,
+  repoRoot,
+  parseMemoryLines,
+} from './memory-utils';
 
 const tasksPath = path.join(repoRoot, 'TASKS.md');
 
 const lines = readMemoryLines();
-const last = lines.length ? lines[lines.length - 1] : 'none';
+const entries = parseMemoryLines(lines);
+const last = entries.length ? entries[entries.length - 1].raw : 'none';
 
 let task = 'none';
 if (fs.existsSync(tasksPath)) {

--- a/scripts/memory-utils.ts
+++ b/scripts/memory-utils.ts
@@ -77,3 +77,40 @@ export function withFileLock(
     fs.unlinkSync(lock);
   }
 }
+
+export interface MemoryEntry {
+  hash: string;
+  task?: string;
+  summary: string;
+  files: string;
+  timestamp: string;
+  raw: string;
+}
+
+export function parseMemoryLines(lines: string[]): MemoryEntry[] {
+  return lines
+    .filter(Boolean)
+    .map((raw) => {
+      const parts = raw.split('|').map((p) => p.trim());
+      const [hash, p2 = '', p3 = '', p4 = '', p5 = ''] = parts;
+      let task: string | undefined;
+      let summary = '';
+      let files = '';
+      let timestamp = '';
+      if (parts.length >= 5) {
+        task = p2;
+        summary = p3;
+        files = p4;
+        timestamp = p5;
+      } else if (parts.length === 4) {
+        summary = p2;
+        files = p3;
+        timestamp = p4;
+      } else if (parts.length === 3) {
+        summary = p2;
+        files = '';
+        timestamp = p3;
+      }
+      return { hash, task, summary, files, timestamp, raw };
+    });
+}

--- a/src/__tests__/memory-utils.test.ts
+++ b/src/__tests__/memory-utils.test.ts
@@ -230,3 +230,33 @@ describe('path overrides', () => {
   });
 });
 
+describe('parseMemoryLines', () => {
+  it('parses lines with task prefix', () => {
+    const line =
+      'abc123 | Task 10 | add feature | a.ts, b.ts | 2025-01-01T00:00:00Z';
+    const out = utils.parseMemoryLines([line]);
+    expect(out).toEqual([
+      {
+        hash: 'abc123',
+        task: 'Task 10',
+        summary: 'add feature',
+        files: 'a.ts, b.ts',
+        timestamp: '2025-01-01T00:00:00Z',
+        raw: line,
+      },
+    ]);
+  });
+
+  it('parses simple lines', () => {
+    const line = 'def456 | fix bug | c.ts | 2025-01-02T00:00:00Z';
+    const out = utils.parseMemoryLines([line]);
+    expect(out[0]).toEqual({
+      hash: 'def456',
+      summary: 'fix bug',
+      files: 'c.ts',
+      timestamp: '2025-01-02T00:00:00Z',
+      raw: line,
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `parseMemoryLines` util to normalize memory log entries
- refactor `commit-log.ts` and `mem-status.ts` to use the parser
- cover new parser with unit tests

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_684060c2bf4883238bdf600240b060e9