### PR TITLE
Add Rotating Memory Files section

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,19 @@ npm run commitlog
 
 Use `MEM_ROTATE_LIMIT` or a numeric argument to `npm run mem-rotate` to change the number of retained lines.
 
+## Rotating Memory Files
+
+Keep `memory.log` and `context.snapshot.md` trimmed so the agent loads quickly:
+
+```bash
+npm run mem-rotate   # prune memory.log
+npm run snap-rotate  # prune context.snapshot.md
+```
+
+A weekly GitHub workflow automatically runs `mem-rotate` and `commitlog` to push the
+latest trimmed logs. Adjust `MEM_ROTATE_LIMIT` and `SNAP_ROTATE_LIMIT` to control the
+number of retained entries.
+
 ## Using Codex with Persistent Memory
 
 See [CODEX_START.md](CODEX_START.md) for full instructions on launching Codex with persistent memory.


### PR DESCRIPTION
## Summary
- document `npm run mem-rotate` and `npm run snap-rotate`
- describe weekly workflow that rotates logs automatically

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`
- `npm run commitlog` *(fails: ts-node missing)*

------
https://chatgpt.com/codex/tasks/task_b_684060c1fbf8832391872e28393f7b98