### PR TITLE
Add memory log JSON export script

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ npm run commitlog
 | `npm run mem-check` | Verify memory hashes and snapshot blocks (auto after `mem-rotate`) |
 | `ts-node scripts/update-snapshot.ts` | Append commit summary and next task to `context.snapshot.md` |
 | `ts-node scripts/rebuild-memory.ts [path]` | Rebuild `memory.log` and `context.snapshot.md` from git history |
+| `ts-node scripts/memory-json.ts` | Export `memory.log` lines to `memory.json` |
 | `npm run setup` | Install the post-commit hook for automatic memlog updates |
 | `npm run dev-deps` | Install dev dependencies if `node_modules` is missing |
 | `bash scripts/check-env.sh` | Verify required CLIs (`next`, `jest`, `ts-node`) are installed |

--- a/scripts/memory-json.ts
+++ b/scripts/memory-json.ts
@@ -1,0 +1,19 @@
+import path from 'path';
+import { repoRoot, readMemoryLines, atomicWrite, withFileLock } from './memory-utils';
+
+const lines = readMemoryLines();
+const entries = lines.map((line) => {
+  const parts = line.split('|').map((p) => p.trim());
+  const hash = parts[0];
+  const summary = parts.length === 5 ? parts[2] : parts[1];
+  const filesPart = parts.length === 5 ? parts[3] : parts[2];
+  const timestamp = parts[parts.length - 1];
+  const files = filesPart.split(',').map((f) => f.trim()).filter(Boolean);
+  return { hash, summary, files, timestamp };
+});
+
+const outPath = path.join(repoRoot, 'memory.json');
+withFileLock(outPath, () => {
+  atomicWrite(outPath, JSON.stringify(entries, null, 2) + '\n');
+});
+console.log(`memory.json written to ${outPath}`);


### PR DESCRIPTION
## Summary
- add script to convert memory.log into memory.json
- document script in README

## Testing
- `npm run dev-deps` *(fails: 403 Forbidden)*
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_684060bf1d30832384587dca5b049589