### PR TITLE
Implement snapshot parser

### DIFF
--- a/scripts/memory-utils.ts
+++ b/scripts/memory-utils.ts
@@ -1,40 +1,40 @@
-import fs from 'fs';
-import path from 'path';
+import fs from "fs";
+import path from "path";
 
-export const repoRoot = path.resolve(__dirname, '..');
+export const repoRoot = path.resolve(__dirname, "..");
 export const memPath = process.env.MEM_PATH
   ? path.resolve(process.env.MEM_PATH)
-  : path.join(repoRoot, 'memory.log');
+  : path.join(repoRoot, "memory.log");
 export const snapshotPath = process.env.SNAPSHOT_PATH
   ? path.resolve(process.env.SNAPSHOT_PATH)
-  : path.join(repoRoot, 'context.snapshot.md');
+  : path.join(repoRoot, "context.snapshot.md");
 
 export function readMemoryLines(): string[] {
   if (!fs.existsSync(memPath)) return [];
-  return fs.readFileSync(memPath, 'utf8').trim().split('\n').filter(Boolean);
+  return fs.readFileSync(memPath, "utf8").trim().split("\n").filter(Boolean);
 }
 
 export function nextMemId(): string {
   let last = 0;
   if (fs.existsSync(snapshotPath)) {
-    const matches = fs.readFileSync(snapshotPath, 'utf8').match(/mem-(\d+)/g);
+    const matches = fs.readFileSync(snapshotPath, "utf8").match(/mem-(\d+)/g);
     if (matches && matches.length) {
       const lastMatch = matches[matches.length - 1];
-      last = parseInt(lastMatch.replace('mem-', ''), 10);
+      last = parseInt(lastMatch.replace("mem-", ""), 10);
     }
   }
-  return String(last + 1).padStart(3, '0');
+  return String(last + 1).padStart(3, "0");
 }
 
 export function atomicWrite(file: string, data: string): void {
   const dir = path.dirname(file);
   const tmp = path.join(dir, `.${path.basename(file)}.tmp`);
-  const fd = fs.openSync(tmp, 'w');
+  const fd = fs.openSync(tmp, "w");
   fs.writeFileSync(fd, data);
   fs.fsyncSync(fd);
   fs.closeSync(fd);
   fs.renameSync(tmp, file);
-  const dirFd = fs.openSync(dir, 'r');
+  const dirFd = fs.openSync(dir, "r");
   fs.fsyncSync(dirFd);
   fs.closeSync(dirFd);
 }
@@ -42,15 +42,15 @@ export function atomicWrite(file: string, data: string): void {
 export function withFileLock(
   target: string,
   fn: () => void,
-  staleMs = 60_000
+  staleMs = 60_000,
 ): void {
   const lock = `${target}.lock`;
   let fd: number | undefined;
   while (fd === undefined) {
     try {
-      fd = fs.openSync(lock, 'wx');
+      fd = fs.openSync(lock, "wx");
     } catch (err: any) {
-      if (err.code === 'EEXIST') {
+      if (err.code === "EEXIST") {
         let stale = false;
         try {
           const stat = fs.statSync(lock);
@@ -88,29 +88,88 @@ export interface MemoryEntry {
 }
 
 export function parseMemoryLines(lines: string[]): MemoryEntry[] {
-  return lines
-    .filter(Boolean)
-    .map((raw) => {
-      const parts = raw.split('|').map((p) => p.trim());
-      const [hash, p2 = '', p3 = '', p4 = '', p5 = ''] = parts;
-      let task: string | undefined;
-      let summary = '';
-      let files = '';
-      let timestamp = '';
-      if (parts.length >= 5) {
-        task = p2;
-        summary = p3;
-        files = p4;
-        timestamp = p5;
-      } else if (parts.length === 4) {
-        summary = p2;
-        files = p3;
-        timestamp = p4;
-      } else if (parts.length === 3) {
-        summary = p2;
-        files = '';
-        timestamp = p3;
-      }
-      return { hash, task, summary, files, timestamp, raw };
+  return lines.filter(Boolean).map((raw) => {
+    const parts = raw.split("|").map((p) => p.trim());
+    const [hash, p2 = "", p3 = "", p4 = "", p5 = ""] = parts;
+    let task: string | undefined;
+    let summary = "";
+    let files = "";
+    let timestamp = "";
+    if (parts.length >= 5) {
+      task = p2;
+      summary = p3;
+      files = p4;
+      timestamp = p5;
+    } else if (parts.length === 4) {
+      summary = p2;
+      files = p3;
+      timestamp = p4;
+    } else if (parts.length === 3) {
+      summary = p2;
+      files = "";
+      timestamp = p3;
+    }
+    return { hash, task, summary, files, timestamp, raw };
+  });
+}
+
+export interface SnapshotEntry {
+  id: string;
+  hash: string;
+  summary: string;
+  nextGoal: string;
+  timestamp: string;
+}
+
+export function parseSnapshotEntries(content: string): SnapshotEntry[] {
+  const lines = content.split("\n");
+  const entries: SnapshotEntry[] = [];
+  let cur: Partial<SnapshotEntry> | null = null;
+  for (const raw of lines) {
+    const header = raw.match(/^###\s+([^|]+)\s*\|\s*(mem-\d+)/);
+    if (header) {
+      if (cur)
+        entries.push({
+          id: cur.id || "",
+          hash: cur.hash || "",
+          summary: cur.summary || "",
+          nextGoal: cur.nextGoal || "",
+          timestamp: cur.timestamp || "",
+        });
+      cur = {
+        timestamp: header[1].trim(),
+        id: header[2],
+        hash: "",
+        summary: "",
+        nextGoal: "",
+      };
+      continue;
+    }
+    if (!cur) continue;
+    const commit = raw.match(/^-\s*Commit SHA:\s*(\S+)/);
+    if (commit) {
+      cur.hash = commit[1];
+      continue;
+    }
+    const summary = raw.match(/^-\s*Summary:\s*(.*)/);
+    if (summary) {
+      cur.summary = summary[1].trim();
+      continue;
+    }
+    const next = raw.match(/^-\s*Next Goal:\s*(.*)/);
+    if (next) {
+      cur.nextGoal = next[1].trim();
+      continue;
+    }
+  }
+  if (cur) {
+    entries.push({
+      id: cur.id || "",
+      hash: cur.hash || "",
+      summary: cur.summary || "",
+      nextGoal: cur.nextGoal || "",
+      timestamp: cur.timestamp || "",
     });
+  }
+  return entries;
 }

--- a/src/__tests__/memory-utils.test.ts
+++ b/src/__tests__/memory-utils.test.ts
@@ -1,8 +1,8 @@
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
-import * as cp from 'child_process';
-import * as utils from '../../scripts/memory-utils';
+import fs from "fs";
+import os from "os";
+import path from "path";
+import * as cp from "child_process";
+import * as utils from "../../scripts/memory-utils";
 
 const { snapshotPath, memPath } = utils;
 
@@ -23,40 +23,54 @@ function withFsMocks(paths: Record<string, string>, fn: () => void) {
   const origOpen = fs.openSync;
   const origClose = fs.closeSync;
   const origUnlink = fs.unlinkSync;
-  const existsMock = jest.spyOn(fs, 'existsSync').mockImplementation((p: any) => {
-    if (expanded[p as string]) {
-      return origExists.call(fs, expanded[p as string]);
-    }
-    return origExists.call(fs, p);
-  });
-  const readMock = jest.spyOn(fs, 'readFileSync').mockImplementation((p: any, opt?: any) => {
-    if (expanded[p as string]) {
-      p = expanded[p as string];
-    }
-    return origRead.call(fs, p, opt);
-  });
-  const writeMock = jest.spyOn(fs, 'writeFileSync').mockImplementation((p: any, data: any, opt?: any) => {
-    if (expanded[p as string]) {
-      p = expanded[p as string];
-    }
-    return origWrite.call(fs, p, data, opt as any);
-  });
-  const renameMock = jest.spyOn(fs, 'renameSync').mockImplementation((a: any, b: any) => {
-    if (expanded[a as string]) a = expanded[a as string];
-    if (expanded[b as string]) b = expanded[b as string];
-    return origRename.call(fs, a, b);
-  });
-  const openMock = jest.spyOn(fs, 'openSync').mockImplementation((p: any, flag: any) => {
-    if (expanded[p as string]) p = expanded[p as string];
-    return origOpen.call(fs, p, flag);
-  });
-  const closeMock = jest.spyOn(fs, 'closeSync').mockImplementation((fd: any) => {
-    return origClose.call(fs, fd);
-  });
-  const unlinkMock = jest.spyOn(fs, 'unlinkSync').mockImplementation((p: any) => {
-    if (expanded[p as string]) p = expanded[p as string];
-    return origUnlink.call(fs, p);
-  });
+  const existsMock = jest
+    .spyOn(fs, "existsSync")
+    .mockImplementation((p: any) => {
+      if (expanded[p as string]) {
+        return origExists.call(fs, expanded[p as string]);
+      }
+      return origExists.call(fs, p);
+    });
+  const readMock = jest
+    .spyOn(fs, "readFileSync")
+    .mockImplementation((p: any, opt?: any) => {
+      if (expanded[p as string]) {
+        p = expanded[p as string];
+      }
+      return origRead.call(fs, p, opt);
+    });
+  const writeMock = jest
+    .spyOn(fs, "writeFileSync")
+    .mockImplementation((p: any, data: any, opt?: any) => {
+      if (expanded[p as string]) {
+        p = expanded[p as string];
+      }
+      return origWrite.call(fs, p, data, opt as any);
+    });
+  const renameMock = jest
+    .spyOn(fs, "renameSync")
+    .mockImplementation((a: any, b: any) => {
+      if (expanded[a as string]) a = expanded[a as string];
+      if (expanded[b as string]) b = expanded[b as string];
+      return origRename.call(fs, a, b);
+    });
+  const openMock = jest
+    .spyOn(fs, "openSync")
+    .mockImplementation((p: any, flag: any) => {
+      if (expanded[p as string]) p = expanded[p as string];
+      return origOpen.call(fs, p, flag);
+    });
+  const closeMock = jest
+    .spyOn(fs, "closeSync")
+    .mockImplementation((fd: any) => {
+      return origClose.call(fs, fd);
+    });
+  const unlinkMock = jest
+    .spyOn(fs, "unlinkSync")
+    .mockImplementation((p: any) => {
+      if (expanded[p as string]) p = expanded[p as string];
+      return origUnlink.call(fs, p);
+    });
   try {
     fn();
   } finally {
@@ -70,91 +84,94 @@ function withFsMocks(paths: Record<string, string>, fn: () => void) {
   }
 }
 
-describe('nextMemId', () => {
-  it('returns 001 when snapshot missing', () => {
-    withFsMocks({ [snapshotPath]: path.join(os.tmpdir(), 'no-file') }, () => {
-      expect(utils.nextMemId()).toBe('001');
+describe("nextMemId", () => {
+  it("returns 001 when snapshot missing", () => {
+    withFsMocks({ [snapshotPath]: path.join(os.tmpdir(), "no-file") }, () => {
+      expect(utils.nextMemId()).toBe("001");
     });
   });
 
-  it('increments based on last mem entry', () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memtest-'));
-    const tmpSnap = path.join(tmpDir, 'context.snapshot.md');
+  it("increments based on last mem entry", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "memtest-"));
+    const tmpSnap = path.join(tmpDir, "context.snapshot.md");
     fs.writeFileSync(
       tmpSnap,
-      '### 2020-01-01 | mem-001\n' +
-        'some text\n' +
-        '### 2020-01-02 | mem-009\n'
+      "### 2020-01-01 | mem-001\n" +
+        "some text\n" +
+        "### 2020-01-02 | mem-009\n",
     );
     withFsMocks({ [snapshotPath]: tmpSnap }, () => {
-      expect(utils.nextMemId()).toBe('010');
+      expect(utils.nextMemId()).toBe("010");
     });
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 });
 
-describe('update-memory-log', () => {
-  it('appends new commit entries from git log', () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memlog-'));
-    const tmpMem = path.join(tmpDir, 'memory.log');
-    fs.writeFileSync(tmpMem, 'abc123 | old commit | file1 | 2025-06-01T00:00:00Z\n');
+describe("update-memory-log", () => {
+  it("appends new commit entries from git log", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "memlog-"));
+    const tmpMem = path.join(tmpDir, "memory.log");
+    fs.writeFileSync(
+      tmpMem,
+      "abc123 | old commit | file1 | 2025-06-01T00:00:00Z\n",
+    );
 
     const execMock = jest
-      .spyOn(cp, 'execSync')
+      .spyOn(cp, "execSync")
       .mockImplementation((cmd: string) => {
-        if (cmd.startsWith('git cat-file -e')) return Buffer.from('');
-        if (cmd.startsWith('git log')) {
+        if (cmd.startsWith("git cat-file -e")) return Buffer.from("");
+        if (cmd.startsWith("git log")) {
           return Buffer.from(
-            'def456|new commit|2025-06-02T00:00:00Z\n' +
-              'src/a.ts\n' +
-              'src/b.ts\n'
+            "def456|new commit|2025-06-02T00:00:00Z\n" +
+              "src/a.ts\n" +
+              "src/b.ts\n",
           );
         }
-        return Buffer.from('');
+        return Buffer.from("");
       });
 
     withFsMocks({ [memPath]: tmpMem }, () => {
       jest.isolateModules(() => {
-        require('../../scripts/update-memory-log.ts');
+        require("../../scripts/update-memory-log.ts");
       });
     });
 
     execMock.mockRestore();
-    const out = fs.readFileSync(tmpMem, 'utf8').trim().split('\n');
+    const out = fs.readFileSync(tmpMem, "utf8").trim().split("\n");
     expect(out).toEqual([
-      'abc123 | old commit | file1 | 2025-06-01T00:00:00Z',
-      'def456 | new commit | src/a.ts, src/b.ts | 2025-06-02T00:00:00Z',
+      "abc123 | old commit | file1 | 2025-06-01T00:00:00Z",
+      "def456 | new commit | src/a.ts, src/b.ts | 2025-06-02T00:00:00Z",
     ]);
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('runs memory-check when --verify flag passed', () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memlog-'));
-    const tmpMem = path.join(tmpDir, 'memory.log');
-    fs.writeFileSync(tmpMem, '');
+  it("runs memory-check when --verify flag passed", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "memlog-"));
+    const tmpMem = path.join(tmpDir, "memory.log");
+    fs.writeFileSync(tmpMem, "");
 
     const execMock = jest
-      .spyOn(cp, 'execSync')
+      .spyOn(cp, "execSync")
       .mockImplementation((cmd: string) => {
-        if (cmd.startsWith('git cat-file -e')) return Buffer.from('');
-        if (cmd.startsWith('git log')) {
-          return Buffer.from('abc123|a commit|2025-06-02T00:00:00Z\n');
+        if (cmd.startsWith("git cat-file -e")) return Buffer.from("");
+        if (cmd.startsWith("git log")) {
+          return Buffer.from("abc123|a commit|2025-06-02T00:00:00Z\n");
         }
-        return Buffer.from('');
+        return Buffer.from("");
       });
 
     withFsMocks({ [memPath]: tmpMem }, () => {
       jest.isolateModules(() => {
         const orig = process.argv;
-        process.argv = ['node', 'update-memory-log.ts', '--verify'];
-        require('../../scripts/update-memory-log.ts');
+        process.argv = ["node", "update-memory-log.ts", "--verify"];
+        require("../../scripts/update-memory-log.ts");
         process.argv = orig;
       });
     });
 
     expect(execMock).toHaveBeenCalledWith(
-      'ts-node scripts/memory-check.ts',
-      expect.objectContaining({ cwd: repoRoot, stdio: 'inherit' })
+      "ts-node scripts/memory-check.ts",
+      expect.objectContaining({ cwd: repoRoot, stdio: "inherit" }),
     );
 
     execMock.mockRestore();
@@ -162,54 +179,54 @@ describe('update-memory-log', () => {
   });
 });
 
-describe('atomicWrite', () => {
-  it('calls fsync before rename', () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'atomic-'));
-    const file = path.join(dir, 'out.txt');
-    const fsync = jest.spyOn(fs, 'fsyncSync').mockImplementation(() => {});
+describe("atomicWrite", () => {
+  it("calls fsync before rename", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "atomic-"));
+    const file = path.join(dir, "out.txt");
+    const fsync = jest.spyOn(fs, "fsyncSync").mockImplementation(() => {});
 
-    utils.atomicWrite(file, 'data');
+    utils.atomicWrite(file, "data");
 
     expect(fsync).toHaveBeenCalled();
 
     fsync.mockRestore();
-    const out = fs.readFileSync(file, 'utf8');
-    expect(out).toBe('data');
+    const out = fs.readFileSync(file, "utf8");
+    expect(out).toBe("data");
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it('fsyncs file and directory', () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'atomic-'));
-    const file = path.join(dir, 'out.txt');
+  it("fsyncs file and directory", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "atomic-"));
+    const file = path.join(dir, "out.txt");
     const origOpen = fs.openSync;
     const openSpy = jest
-      .spyOn(fs, 'openSync')
+      .spyOn(fs, "openSync")
       .mockImplementation((p: any, f: any) => origOpen.call(fs, p, f));
-    const fsync = jest.spyOn(fs, 'fsyncSync').mockImplementation(() => {});
+    const fsync = jest.spyOn(fs, "fsyncSync").mockImplementation(() => {});
 
-    utils.atomicWrite(file, 'data');
+    utils.atomicWrite(file, "data");
 
     expect(openSpy).toHaveBeenCalledTimes(2);
     expect(openSpy.mock.calls[1][0]).toBe(dir);
-    expect(openSpy.mock.calls[1][1]).toBe('r');
+    expect(openSpy.mock.calls[1][1]).toBe("r");
     expect(fsync).toHaveBeenCalledTimes(2);
 
     openSpy.mockRestore();
     fsync.mockRestore();
-    const out = fs.readFileSync(file, 'utf8');
-    expect(out).toBe('data');
+    const out = fs.readFileSync(file, "utf8");
+    expect(out).toBe("data");
     fs.rmSync(dir, { recursive: true, force: true });
   });
 });
 
-describe('path overrides', () => {
-  it('uses MEM_PATH and SNAPSHOT_PATH when set', () => {
-    const mem = path.join(os.tmpdir(), 'custom-mem.log');
-    const snap = path.join(os.tmpdir(), 'custom-snap.md');
+describe("path overrides", () => {
+  it("uses MEM_PATH and SNAPSHOT_PATH when set", () => {
+    const mem = path.join(os.tmpdir(), "custom-mem.log");
+    const snap = path.join(os.tmpdir(), "custom-snap.md");
     jest.isolateModules(() => {
       process.env.MEM_PATH = mem;
       process.env.SNAPSHOT_PATH = snap;
-      const mod = require('../../scripts/memory-utils');
+      const mod = require("../../scripts/memory-utils");
       expect(mod.memPath).toBe(path.resolve(mem));
       expect(mod.snapshotPath).toBe(path.resolve(snap));
       delete process.env.MEM_PATH;
@@ -217,46 +234,102 @@ describe('path overrides', () => {
     });
   });
 
-  it('defaults to repo root when env vars absent', () => {
+  it("defaults to repo root when env vars absent", () => {
     jest.isolateModules(() => {
       delete process.env.MEM_PATH;
       delete process.env.SNAPSHOT_PATH;
-      const mod = require('../../scripts/memory-utils');
-      expect(mod.memPath).toBe(path.join(mod.repoRoot, 'memory.log'));
+      const mod = require("../../scripts/memory-utils");
+      expect(mod.memPath).toBe(path.join(mod.repoRoot, "memory.log"));
       expect(mod.snapshotPath).toBe(
-        path.join(mod.repoRoot, 'context.snapshot.md')
+        path.join(mod.repoRoot, "context.snapshot.md"),
       );
     });
   });
 });
 
-describe('parseMemoryLines', () => {
-  it('parses lines with task prefix', () => {
+describe("parseMemoryLines", () => {
+  it("parses lines with task prefix", () => {
     const line =
-      'abc123 | Task 10 | add feature | a.ts, b.ts | 2025-01-01T00:00:00Z';
+      "abc123 | Task 10 | add feature | a.ts, b.ts | 2025-01-01T00:00:00Z";
     const out = utils.parseMemoryLines([line]);
     expect(out).toEqual([
       {
-        hash: 'abc123',
-        task: 'Task 10',
-        summary: 'add feature',
-        files: 'a.ts, b.ts',
-        timestamp: '2025-01-01T00:00:00Z',
+        hash: "abc123",
+        task: "Task 10",
+        summary: "add feature",
+        files: "a.ts, b.ts",
+        timestamp: "2025-01-01T00:00:00Z",
         raw: line,
       },
     ]);
   });
 
-  it('parses simple lines', () => {
-    const line = 'def456 | fix bug | c.ts | 2025-01-02T00:00:00Z';
+  it("parses simple lines", () => {
+    const line = "def456 | fix bug | c.ts | 2025-01-02T00:00:00Z";
     const out = utils.parseMemoryLines([line]);
     expect(out[0]).toEqual({
-      hash: 'def456',
-      summary: 'fix bug',
-      files: 'c.ts',
-      timestamp: '2025-01-02T00:00:00Z',
+      hash: "def456",
+      summary: "fix bug",
+      files: "c.ts",
+      timestamp: "2025-01-02T00:00:00Z",
       raw: line,
     });
   });
 });
 
+describe("parseSnapshotEntries", () => {
+  it("parses well-formed sections", () => {
+    const data =
+      "### 2025-01-01 00:00 UTC | mem-001\n" +
+      "- Commit SHA: abc123\n" +
+      "- Summary: first entry\n" +
+      "- Next Goal: continue\n" +
+      "### 2025-01-01 01:00 UTC | mem-002\n" +
+      "- Commit SHA: def456\n" +
+      "- Summary: second entry\n" +
+      "- Next Goal: done\n";
+    const out = utils.parseSnapshotEntries(data);
+    expect(out).toEqual([
+      {
+        id: "mem-001",
+        hash: "abc123",
+        summary: "first entry",
+        nextGoal: "continue",
+        timestamp: "2025-01-01 00:00 UTC",
+      },
+      {
+        id: "mem-002",
+        hash: "def456",
+        summary: "second entry",
+        nextGoal: "done",
+        timestamp: "2025-01-01 01:00 UTC",
+      },
+    ]);
+  });
+
+  it("handles malformed entries", () => {
+    const data =
+      "### 2025-01-01 00:00 UTC | mem-001\n" +
+      "- Commit SHA: abc123\n" +
+      "- Summary: only summary\n" +
+      "### 2025-01-02 00:00 UTC | mem-002\n" +
+      "- Next Goal: todo\n";
+    const out = utils.parseSnapshotEntries(data);
+    expect(out).toEqual([
+      {
+        id: "mem-001",
+        hash: "abc123",
+        summary: "only summary",
+        nextGoal: "",
+        timestamp: "2025-01-01 00:00 UTC",
+      },
+      {
+        id: "mem-002",
+        hash: "",
+        summary: "",
+        nextGoal: "todo",
+        timestamp: "2025-01-02 00:00 UTC",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `parseSnapshotEntries` to parse context snapshot blocks
- export `SnapshotEntry` interface for reuse
- test snapshot parsing for normal and malformed entries

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_684069027ca483239c52359cce38dbec