### PR TITLE
Update CI to run mem-check after backtests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,4 @@ jobs:
       - run: npm run lint
       - run: npm run test
       - run: npm run backtest
+      - run: npm run mem-check


### PR DESCRIPTION
## Summary
- ensure GitHub workflow runs `npm run mem-check`

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`
- `npm run mem-check` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_b_684069012a988323a39536a182125468