### PR TITLE
Add rebuild and snapshot-update memory commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ npm run commitlog
 | ------- | ------- |
 | `npm run auto` | Execute the AutoTaskRunner to process tasks in `task_queue.json` |
 | `npm run commitlog` | Generate `logs/commit.log` from the last entries in `memory.log` |
-| `npm run memory` | Manage memory files: rotate, snapshot-rotate, status, grep, update-log, diff, json, clean-locks, check, locate |
+| `npm run memory` | Manage memory files: rotate, snapshot-rotate, status, grep, update-log, diff, json, clean-locks, check, locate, rebuild, snapshot-update |
 | `npm run mem-rotate` | Trim `memory.log` to a set number of entries and refresh `logs/commit.log` |
 | `npm run mem-check` | Verify memory hashes and snapshot blocks (auto after `mem-rotate`) |
 | `npm run mem-diff` | List commit hashes missing from `memory.log` |

--- a/scripts/memory-cli.ts
+++ b/scripts/memory-cli.ts
@@ -29,6 +29,8 @@ Commands:
   json                             Export memory.log to memory.json
   clean-locks                      Delete stale .lock files
   check                            Verify memory files
+  rebuild [path]                   Rebuild memory files from git history
+  snapshot-update                  Append last commit summary to snapshot
 `);
 }
 
@@ -67,6 +69,12 @@ switch (cmd) {
     break;
   case 'check':
     run('memory-check.ts', rest);
+    break;
+  case 'rebuild':
+    run('rebuild-memory.ts', rest);
+    break;
+  case 'snapshot-update':
+    run('update-snapshot.ts', rest);
     break;
   default:
     console.error(`Unknown command: ${cmd}`);

--- a/src/__tests__/memory-cli.test.ts
+++ b/src/__tests__/memory-cli.test.ts
@@ -59,4 +59,22 @@ describe('memory-cli', () => {
       { stdio: 'inherit', cwd: repoRoot }
     );
   });
+
+  it('runs rebuild-memory for rebuild command', () => {
+    run(['rebuild']);
+    expect(spy).toHaveBeenCalledWith(
+      'ts-node',
+      [path.join(scriptDir, 'rebuild-memory.ts')],
+      { stdio: 'inherit', cwd: repoRoot }
+    );
+  });
+
+  it('runs update-snapshot for snapshot-update command', () => {
+    run(['snapshot-update']);
+    expect(spy).toHaveBeenCalledWith(
+      'ts-node',
+      [path.join(scriptDir, 'update-snapshot.ts')],
+      { stdio: 'inherit', cwd: repoRoot }
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- extend memory-cli with rebuild and snapshot-update commands
- test new subcommands
- mention additional subcommands in README

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_68407144773083238dc8c62f7b412b8e