### PR TITLE
Task 94: run memory check after rotate

### DIFF
--- a/.github/workflows/mem-maintenance.yml
+++ b/.github/workflows/mem-maintenance.yml
@@ -16,6 +16,7 @@ jobs:
       - run: npm ci
       - run: npm run mem-rotate
       - run: npm run commitlog
+      - run: ts-node scripts/memory-check.ts
       # clean up old lock files before committing
       - run: ts-node scripts/clean-locks.ts
       - name: Push changes

--- a/scripts/mem-rotate.ts
+++ b/scripts/mem-rotate.ts
@@ -41,4 +41,12 @@ if (dryRun) {
   console.log('[dry-run] Skipping commit-log update');
 } else {
   execSync('ts-node scripts/commit-log.ts', { cwd: repoRoot, stdio: 'inherit' });
+  try {
+    execSync('ts-node scripts/memory-check.ts', {
+      cwd: repoRoot,
+      stdio: 'inherit',
+    });
+  } catch (err: any) {
+    process.exit(err.status || 1);
+  }
 }

--- a/src/__tests__/mem-rotate.test.ts
+++ b/src/__tests__/mem-rotate.test.ts
@@ -118,6 +118,10 @@ describe("mem-rotate", () => {
       });
       jest.useRealTimers();
     });
+    expect(execMock).toHaveBeenCalledWith(
+      "ts-node scripts/memory-check.ts",
+      expect.objectContaining({ cwd: repoRoot, stdio: "inherit" })
+    );
 
     execMock.mockRestore();
     const memOut = fs.readFileSync(tmpMem, "utf8");


### PR DESCRIPTION
## Summary
- run `memory-check` in `mem-rotate.ts` unless dry-run
- test that `mem-rotate` invokes `memory-check`
- call `memory-check` in the weekly `mem-maintenance` workflow

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`

------
https://chatgpt.com/codex/tasks/task_b_6840714572c08323944a8714bbf2eed5