### PR TITLE
Add concurrency test for append-memory

### DIFF
--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -112,3 +112,7 @@
 - Commit SHA: 2d8d715
 - Summary: Replaced bash codex script with ts-node version and marked Task 93 done.
 - Next Goal: document MEM_PATH and SNAPSHOT_PATH in README with rotation env vars
+### 2025-06-04 16:48 UTC | mem-029
+- Commit SHA: b5bf1eb
+- Summary: Implemented new Jest test verifying concurrent append-memory writes
+- Next Goal: flag upcoming high-impact economic events

--- a/memory.log
+++ b/memory.log
@@ -571,3 +571,4 @@ bd46999 | feat(memory): add file locking | TASKS.md, scripts/append-memory.ts, s
 cdc44db | docs(memory): add pending automation tasks | TASKS.md, task_queue.json | 2025-06-04T13:21:01+00:00
 c1e5a28 | Task bootstrap | validate automation rules and ran lint, test, backtest | AGENTS.md | 2025-06-04T14:44:44+00:00
 2d8d715 | fix(scripts): Task 93 use ts-node for codex | package.json,TASKS.md,task_queue.json | 2025-06-04T15:08:56Z
+b5bf1eb | test(memory): concurrent append-memory writes | src/__tests__/append-memory.concurrent.test.ts | 2025-06-04T16:47:52Z

--- a/src/__tests__/append-memory.concurrent.test.ts
+++ b/src/__tests__/append-memory.concurrent.test.ts
@@ -1,0 +1,38 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawn } from 'child_process';
+import { repoRoot } from '../../scripts/memory-utils';
+
+function run(snapshot: string, summary: string, delay: string) {
+  const script = `
+    const { spawnSync } = require('child_process');
+    const path = require('path');
+    const delay = parseInt(process.argv[4] || '0', 10);
+    const env = { ...process.env, SNAPSHOT_PATH: process.argv[2] };
+    if (delay) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delay);
+    spawnSync('node', ['-r', 'ts-node/register', path.join('${repoRoot.replace(/\\/g, '\\\\')}', 'scripts/append-memory.ts'), process.argv[3], 'next'], { env, cwd: '${repoRoot}', stdio: 'inherit' });
+  `;
+  const tmpScript = path.join(os.tmpdir(), `append-${summary}.js`);
+  fs.writeFileSync(tmpScript, script);
+  return spawn('node', [tmpScript, snapshot, summary, delay], { cwd: repoRoot });
+}
+
+describe('append-memory concurrency', () => {
+  it('serializes concurrent snapshot writes', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'append-'));
+    const snap = path.join(dir, 'context.snapshot.md');
+    const p1 = run(snap, 'A', '100');
+    const p2 = run(snap, 'B', '0');
+
+    await Promise.all([
+      new Promise((res) => p1.on('exit', res)),
+      new Promise((res) => p2.on('exit', res)),
+    ]);
+
+    const out = fs.readFileSync(snap, 'utf8');
+    const sections = out.match(/mem-\d+/g) || [];
+    expect(sections.length).toBe(2);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- test concurrent snapshot updates using append-memory
- record memory entry for the new test

## Testing
- `npm run test` *(fails: Command jest missing)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run backtest` *(fails: Command ts-node missing)*

------
https://chatgpt.com/codex/tasks/task_b_6840777494b48323929017a2a73713c3