### PR TITLE
Implement memory entry validation tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,8 @@ Run `npm run commitlog` after each commit to keep `logs/commit.log` current.
 ```
 
 Use this single-line format inside `memory.log` so the history remains easy to parse.
+Each field must be present except the optional `Task <id>`; values are pipe-separated with
+an ISO-8601 timestamp at the end.
 
 ---
 

--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -116,3 +116,13 @@
 - Commit SHA: b5bf1eb
 - Summary: Implemented new Jest test verifying concurrent append-memory writes
 - Next Goal: flag upcoming high-impact economic events
+
+### 2025-06-04 16:52 UTC | mem-030
+- Commit SHA: 6bfddd4
+- Summary: clarified memory.log field requirements in AGENTS.md to aid automation rules
+- Next Goal: flag upcoming high-impact economic events
+
+### 2025-06-04 16:53 UTC | mem-031
+- Commit SHA: 3469d34
+- Summary: added validation function and tests covering malformed memory entries
+- Next Goal: flag upcoming high-impact economic events

--- a/memory.log
+++ b/memory.log
@@ -572,3 +572,5 @@ cdc44db | docs(memory): add pending automation tasks | TASKS.md, task_queue.json
 c1e5a28 | Task bootstrap | validate automation rules and ran lint, test, backtest | AGENTS.md | 2025-06-04T14:44:44+00:00
 2d8d715 | fix(scripts): Task 93 use ts-node for codex | package.json,TASKS.md,task_queue.json | 2025-06-04T15:08:56Z
 b5bf1eb | test(memory): concurrent append-memory writes | src/__tests__/append-memory.concurrent.test.ts | 2025-06-04T16:47:52Z
+6bfddd4 | Task bootstrap | clarified memory.log field requirements | AGENTS.md | 2025-06-04T16:52:12Z
+3469d34 | Task <unknown> | add tests for memory parsing edge cases and validation | scripts/memory-check.ts, scripts/memory-utils.ts, src/__tests__/memory-utils.test.ts, src/__tests__/memory-check.test.ts | 2025-06-04T16:53:32Z

--- a/scripts/memory-utils.ts
+++ b/scripts/memory-utils.ts
@@ -113,6 +113,20 @@ export function parseMemoryLines(lines: string[]): MemoryEntry[] {
   });
 }
 
+export function validateMemoryEntry(entry: MemoryEntry): string[] {
+  const errors: string[] = [];
+  if (!/^[0-9a-f]{7,40}$/i.test(entry.hash)) {
+    errors.push(`invalid hash: ${entry.hash}`);
+  }
+  if (!entry.summary) {
+    errors.push(`missing summary for ${entry.hash}`);
+  }
+  if (!entry.timestamp || Number.isNaN(Date.parse(entry.timestamp))) {
+    errors.push(`invalid timestamp for ${entry.hash}`);
+  }
+  return errors;
+}
+
 
 export interface SnapshotEntry {
   id: string;

--- a/src/__tests__/memory-utils.test.ts
+++ b/src/__tests__/memory-utils.test.ts
@@ -303,6 +303,36 @@ describe("parseMemoryLines", () => {
       raw: line,
     });
   });
+
+  it("ignores empty lines", () => {
+    const out = utils.parseMemoryLines(["", "abc123 | a | b | 2025-01-01T00:00:00Z"]);
+    expect(out.length).toBe(1);
+    expect(out[0].hash).toBe("abc123");
+  });
+
+  it("handles malformed entries", () => {
+    const line = "abc123 just text";
+    const [entry] = utils.parseMemoryLines([line]);
+    expect(entry.hash).toBe("abc123 just text");
+    expect(entry.summary).toBe("");
+    expect(entry.timestamp).toBe("");
+  });
+
+  it("handles extremely long lines", () => {
+    const long = "a".repeat(10000);
+    const line = `abcd123 | ${long} | file.ts | 2025-01-01T00:00:00Z`;
+    const [entry] = utils.parseMemoryLines([line]);
+    expect(entry.summary.length).toBe(10000);
+  });
+});
+
+describe("validateMemoryEntry", () => {
+  it("detects missing fields", () => {
+    const [entry] = utils.parseMemoryLines(["abcd123 | test"]);
+    const errs = utils.validateMemoryEntry(entry);
+    expect(errs).toContain("invalid timestamp for abcd123");
+    expect(errs).toContain("missing summary for abcd123");
+  });
 });
 
 describe('parseSnapshotEntries', () => {


### PR DESCRIPTION
## Summary
- note memory log field requirements in AGENTS.md
- validate memory entries and expose `validateMemoryEntry`
- enforce validation via `memory-check`
- add unit tests for malformed lines and invalid entries
- record mem-030 and mem-031

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`
- `npm run commitlog` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_b_68407466e1f08323a58b4f422d4a9470