### PR TITLE
fix(memory): ensure unique snapshot ids

### DIFF
--- a/scripts/append-memory.ts
+++ b/scripts/append-memory.ts
@@ -26,20 +26,22 @@ try {
   const summary = process.argv[2] || 'No summary provided.';
   const nextGoal = process.argv[3] || 'TBD.';
   const ts = formatTimestamp();
-  const sha = execSync('git rev-parse --short HEAD', { cwd: repoRoot, encoding: 'utf8' }).trim();
-  const id = nextMemId();
-  const entry =
-    `### ${ts} | mem-${id}\n` +
-    `- Commit SHA: ${sha}\n` +
-    `- Summary: ${summary}\n` +
-    `- Next Goal: ${nextGoal}\n`;
-
-  let content = '';
-  if (fs.existsSync(snapshotPath)) {
-    content = fs.readFileSync(snapshotPath, 'utf8');
-    if (content.length && !content.endsWith('\n')) content += '\n';
-  }
+  const sha = execSync('git rev-parse --short HEAD', {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  }).trim();
   withFileLock(snapshotPath, () => {
+    let content = '';
+    if (fs.existsSync(snapshotPath)) {
+      content = fs.readFileSync(snapshotPath, 'utf8');
+      if (content.length && !content.endsWith('\n')) content += '\n';
+    }
+    const id = nextMemId(content);
+    const entry =
+      `### ${ts} | mem-${id}\n` +
+      `- Commit SHA: ${sha}\n` +
+      `- Summary: ${summary}\n` +
+      `- Next Goal: ${nextGoal}\n`;
     atomicWrite(snapshotPath, content + entry);
   });
 } catch (err) {

--- a/scripts/memory-utils.ts
+++ b/scripts/memory-utils.ts
@@ -14,15 +14,16 @@ export function readMemoryLines(): string[] {
   return fs.readFileSync(memPath, "utf8").trim().split("\n").filter(Boolean);
 }
 
-export function nextMemId(): string {
-  let last = 0;
-  if (fs.existsSync(snapshotPath)) {
-    const matches = fs.readFileSync(snapshotPath, "utf8").match(/mem-(\d+)/g);
-    if (matches && matches.length) {
-      const lastMatch = matches[matches.length - 1];
-      last = parseInt(lastMatch.replace("mem-", ""), 10);
-    }
+export function nextMemId(content?: string): string {
+  let data = content;
+  if (data === undefined) {
+    if (!fs.existsSync(snapshotPath)) return "001";
+    data = fs.readFileSync(snapshotPath, "utf8");
   }
+  const matches = data.match(/mem-(\d+)/g);
+  const last = matches && matches.length
+    ? parseInt(matches[matches.length - 1].replace("mem-", ""), 10)
+    : 0;
   return String(last + 1).padStart(3, "0");
 }
 

--- a/src/__tests__/append-memory.concurrent.test.ts
+++ b/src/__tests__/append-memory.concurrent.test.ts
@@ -33,6 +33,8 @@ describe('append-memory concurrency', () => {
     const out = fs.readFileSync(snap, 'utf8');
     const sections = out.match(/mem-\d+/g) || [];
     expect(sections.length).toBe(2);
+    const sorted = [...new Set(sections)].sort();
+    expect(sorted).toEqual(['mem-001', 'mem-002']);
     fs.rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/src/__tests__/memory-utils.test.ts
+++ b/src/__tests__/memory-utils.test.ts
@@ -105,6 +105,11 @@ describe("nextMemId", () => {
     });
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
+
+  it("computes id from provided content", () => {
+    const content = "### 2020-01-01 | mem-002\n";
+    expect(utils.nextMemId(content)).toBe("003");
+  });
 });
 
 describe("update-memory-log", () => {


### PR DESCRIPTION
## Summary
- refactor `nextMemId` to accept optional snapshot content
- compute memory IDs inside snapshot file lock
- verify concurrent processes generate unique IDs

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_68407bf5c9b083239112558310de95a8