### PR TITLE
fix(memory): compute next snapshot id safely

### DIFF
--- a/scripts/append-memory.ts
+++ b/scripts/append-memory.ts
@@ -26,20 +26,22 @@ try {
   const summary = process.argv[2] || 'No summary provided.';
   const nextGoal = process.argv[3] || 'TBD.';
   const ts = formatTimestamp();
-  const sha = execSync('git rev-parse --short HEAD', { cwd: repoRoot, encoding: 'utf8' }).trim();
-  const id = nextMemId();
-  const entry =
-    `### ${ts} | mem-${id}\n` +
-    `- Commit SHA: ${sha}\n` +
-    `- Summary: ${summary}\n` +
-    `- Next Goal: ${nextGoal}\n`;
-
-  let content = '';
-  if (fs.existsSync(snapshotPath)) {
-    content = fs.readFileSync(snapshotPath, 'utf8');
-    if (content.length && !content.endsWith('\n')) content += '\n';
-  }
+  const sha = execSync('git rev-parse --short HEAD', {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  }).trim();
   withFileLock(snapshotPath, () => {
+    let content = '';
+    if (fs.existsSync(snapshotPath)) {
+      content = fs.readFileSync(snapshotPath, 'utf8');
+      if (content.length && !content.endsWith('\n')) content += '\n';
+    }
+    const id = nextMemId(content);
+    const entry =
+      `### ${ts} | mem-${id}\n` +
+      `- Commit SHA: ${sha}\n` +
+      `- Summary: ${summary}\n` +
+      `- Next Goal: ${nextGoal}\n`;
     atomicWrite(snapshotPath, content + entry);
   });
 } catch (err) {

--- a/scripts/memory-utils.ts
+++ b/scripts/memory-utils.ts
@@ -14,14 +14,18 @@ export function readMemoryLines(): string[] {
   return fs.readFileSync(memPath, "utf8").trim().split("\n").filter(Boolean);
 }
 
-export function nextMemId(): string {
+export function nextMemId(content?: string): string {
+  let data = content;
+  if (data === undefined) {
+    if (!fs.existsSync(snapshotPath)) return "001";
+    data = fs.readFileSync(snapshotPath, "utf8");
+  }
+  const lines = data.split("\n");
+  const entries = parseSnapshotEntries(lines);
   let last = 0;
-  if (fs.existsSync(snapshotPath)) {
-    const matches = fs.readFileSync(snapshotPath, "utf8").match(/mem-(\d+)/g);
-    if (matches && matches.length) {
-      const lastMatch = matches[matches.length - 1];
-      last = parseInt(lastMatch.replace("mem-", ""), 10);
-    }
+  for (const e of entries) {
+    const num = parseInt(e.id.replace("mem-", ""), 10);
+    if (num > last) last = num;
   }
   return String(last + 1).padStart(3, "0");
 }

--- a/src/__tests__/memory-utils.test.ts
+++ b/src/__tests__/memory-utils.test.ts
@@ -105,6 +105,19 @@ describe("nextMemId", () => {
     });
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
+
+  it("computes id from provided content", () => {
+    const content = "### 2020-01-01 | mem-002\n";
+    expect(utils.nextMemId(content)).toBe("003");
+  });
+
+  it("ignores numbers that are not mem ids", () => {
+    const content =
+      "### 2020-01-01 | mem-005\n" +
+      "Summary with 999 number\n" +
+      "### 2020-01-02 | mem-006\n";
+    expect(utils.nextMemId(content)).toBe("007");
+  });
 });
 
 describe("update-memory-log", () => {


### PR DESCRIPTION
## Summary
- use snapshot parser within `nextMemId` to find latest ID
- verify concurrent appends for 2 and 3 processes
- add unit test ignoring random numbers

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_68407bf5c9b083239112558310de95a8