### PR TITLE
Improve memory log ordering checks

### DIFF
--- a/src/__tests__/memory-check.test.ts
+++ b/src/__tests__/memory-check.test.ts
@@ -60,6 +60,43 @@ describe('memory-check', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it('allows commit after task with earlier timestamp', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memchk-'));
+    const tmpMem = path.join(tmpDir, 'memory.log');
+    const tmpSnap = path.join(tmpDir, 'context.snapshot.md');
+    fs.writeFileSync(
+      tmpMem,
+      'c1c1c1 | commit one | f1 | 2025-01-01T00:00:00Z\n' +
+        'd2d2d2 | Task 1 | do stuff | g1 | 2025-01-01T01:00:00Z\n' +
+        'e3e3e3 | commit two | f2 | 2025-01-01T00:30:00Z\n',
+    );
+    fs.writeFileSync(
+      tmpSnap,
+      '### 2025-01-01 00:00 UTC | mem-001\n' +
+        '- Commit SHA: c1c1c1\n' +
+        '### 2025-01-01 00:30 UTC | mem-002\n' +
+        '- Commit SHA: e3e3e3\n',
+    );
+    const execMock = jest
+      .spyOn(cp, 'execSync')
+      .mockImplementation((cmd: string) => {
+        if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('msg');
+        return Buffer.from('');
+      });
+    const logMock = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    withFsMocks({ [memPath]: tmpMem, [snapshotPath]: tmpSnap }, () => {
+      jest.isolateModules(() => {
+        require('../../scripts/memory-check.ts');
+      });
+    });
+
+    expect(logMock).toHaveBeenCalledWith('Memory check passed');
+    execMock.mockRestore();
+    logMock.mockRestore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
   it('fails for unordered log', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memchk-'));
     const tmpMem = path.join(tmpDir, 'memory.log');
@@ -216,5 +253,127 @@ describe('memory-check', () => {
     errMock.mockRestore();
     exitMock.mockRestore();
     fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('fails when commit hashes repeat', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'memchk-'));
+    const mem = path.join(dir, 'memory.log');
+    const snap = path.join(dir, 'context.snapshot.md');
+    fs.writeFileSync(
+      mem,
+      'aaaaaa | commit a | f.ts | 2025-01-01T00:00:00Z\n' +
+        'aaaaaa | commit a again | f.ts | 2025-01-01T01:00:00Z\n',
+    );
+    fs.writeFileSync(
+      snap,
+      '### 2025-01-01 00:00 UTC | mem-001\n- Commit SHA: aaaaaa\n',
+    );
+    const execMock = jest
+      .spyOn(cp, 'execSync')
+      .mockImplementation((cmd: string) => {
+        if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('c');
+        return Buffer.from('');
+      });
+    const errMock = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const exitMock = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(String(code));
+      }) as any);
+
+    expect(() => {
+      withFsMocks({ [memPath]: mem, [snapshotPath]: snap }, () => {
+        jest.isolateModules(() => {
+          require('../../scripts/memory-check.ts');
+        });
+      });
+    }).toThrow('1');
+
+    execMock.mockRestore();
+    errMock.mockRestore();
+    exitMock.mockRestore();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('fails when tasks timestamps decrease', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'memchk-'));
+    const mem = path.join(dir, 'memory.log');
+    const snap = path.join(dir, 'context.snapshot.md');
+    fs.writeFileSync(
+      mem,
+      'abc111 | Task 1 | a | f.ts | 2025-01-01T01:00:00Z\n' +
+        'def222 | Task 2 | b | g.ts | 2025-01-01T00:30:00Z\n',
+    );
+    fs.writeFileSync(
+      snap,
+      '### 2025-01-01 01:00 UTC | mem-001\n- Commit SHA: abc111\n' +
+        '### 2025-01-01 01:30 UTC | mem-002\n- Commit SHA: def222\n',
+    );
+    const execMock = jest
+      .spyOn(cp, 'execSync')
+      .mockImplementation((cmd: string) => {
+        if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('t');
+        return Buffer.from('');
+      });
+    const errMock = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const exitMock = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(String(code));
+      }) as any);
+
+    expect(() => {
+      withFsMocks({ [memPath]: mem, [snapshotPath]: snap }, () => {
+        jest.isolateModules(() => {
+          require('../../scripts/memory-check.ts');
+        });
+      });
+    }).toThrow('1');
+
+    execMock.mockRestore();
+    errMock.mockRestore();
+    exitMock.mockRestore();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('fails when commit timestamps decrease', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'memchk-'));
+    const mem = path.join(dir, 'memory.log');
+    const snap = path.join(dir, 'context.snapshot.md');
+    fs.writeFileSync(
+      mem,
+      'aaa111 | commit A | f.ts | 2025-01-01T01:00:00Z\n' +
+        'bbb222 | commit B | g.ts | 2025-01-01T00:00:00Z\n',
+    );
+    fs.writeFileSync(
+      snap,
+      '### 2025-01-01 01:00 UTC | mem-001\n- Commit SHA: aaa111\n' +
+        '### 2025-01-01 02:00 UTC | mem-002\n- Commit SHA: bbb222\n',
+    );
+    const execMock = jest
+      .spyOn(cp, 'execSync')
+      .mockImplementation((cmd: string) => {
+        if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('m');
+        return Buffer.from('');
+      });
+    const errMock = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const exitMock = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(String(code));
+      }) as any);
+
+    expect(() => {
+      withFsMocks({ [memPath]: mem, [snapshotPath]: snap }, () => {
+        jest.isolateModules(() => {
+          require('../../scripts/memory-check.ts');
+        });
+      });
+    }).toThrow('1');
+
+    execMock.mockRestore();
+    errMock.mockRestore();
+    exitMock.mockRestore();
+    fs.rmSync(dir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary
- refine ordering and dedupe logic in `memory-check.ts`
- verify interleaved commit/task timestamps
- ensure duplicate commit detection

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_684081a2318083239730014c1eed8120