### PR TITLE
Add log archive script

### DIFF
--- a/scripts/compress-memory-logs.ts
+++ b/scripts/compress-memory-logs.ts
@@ -1,0 +1,30 @@
+import fs from 'fs';
+import path from 'path';
+import zlib from 'zlib';
+import { repoRoot } from './memory-utils';
+
+const remove = process.argv.includes('--remove');
+const days = parseInt(process.env.MEM_ARCHIVE_DAYS || '7', 10);
+const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+
+const logsDir = path.join(repoRoot, 'logs');
+const patterns = [/^memory\.log\..*\.bak$/, /^context\.snapshot\..*\.bak$/];
+
+if (fs.existsSync(logsDir)) {
+  for (const entry of fs.readdirSync(logsDir)) {
+    if (!patterns.some((p) => p.test(entry))) continue;
+    const file = path.join(logsDir, entry);
+    try {
+      const stat = fs.statSync(file);
+      if (stat.mtimeMs >= cutoff) continue;
+      const out = `${file}.gz`;
+      if (fs.existsSync(out)) continue;
+      const data = fs.readFileSync(file);
+      fs.writeFileSync(out, zlib.gzipSync(data));
+      if (remove) fs.unlinkSync(file);
+      console.log(`compressed ${entry}`);
+    } catch (err: any) {
+      console.error(`Failed to compress ${entry}: ${err.message}`);
+    }
+  }
+}

--- a/scripts/memory-cli.ts
+++ b/scripts/memory-cli.ts
@@ -28,6 +28,7 @@ Commands:
   diff                             List commits missing from memory.log
   json                             Export memory.log to memory.json
   clean-locks                      Delete stale .lock files
+  archive [--remove]               Gzip old memory backups
   check                            Verify memory files
   rebuild [path]                   Rebuild memory files from git history
   snapshot-update                  Append last commit summary to snapshot
@@ -66,6 +67,9 @@ switch (cmd) {
     break;
   case 'clean-locks':
     run('clean-locks.ts', rest);
+    break;
+  case 'archive':
+    run('compress-memory-logs.ts', rest);
     break;
   case 'check':
     run('memory-check.ts', rest);

--- a/src/__tests__/compress-memory-logs.test.ts
+++ b/src/__tests__/compress-memory-logs.test.ts
@@ -1,0 +1,60 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+function run(dir: string, args: string[] = []) {
+  jest.doMock('../../scripts/memory-utils', () => {
+    const actual = jest.requireActual('../../scripts/memory-utils');
+    return { ...actual, repoRoot: dir };
+  });
+  jest.isolateModules(() => {
+    const orig = process.argv;
+    process.argv = ['node', 'compress-memory-logs.ts', ...args];
+    require('../../scripts/compress-memory-logs.ts');
+    process.argv = orig;
+  });
+  jest.dontMock('../../scripts/memory-utils');
+}
+
+describe('compress-memory-logs', () => {
+  it('gzips old backups without removing originals', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arch-'));
+    const logs = path.join(dir, 'logs');
+    fs.mkdirSync(logs);
+    const old = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    const mem = path.join(logs, 'memory.log.old.bak');
+    const snap = path.join(logs, 'context.snapshot.old.bak');
+    fs.writeFileSync(mem, 'a');
+    fs.writeFileSync(snap, 'b');
+    const d = new Date(old);
+    fs.utimesSync(mem, d, d);
+    fs.utimesSync(snap, d, d);
+
+    run(dir);
+
+    expect(fs.existsSync(mem + '.gz')).toBe(true);
+    expect(fs.existsSync(snap + '.gz')).toBe(true);
+    expect(fs.existsSync(mem)).toBe(true);
+    expect(fs.existsSync(snap)).toBe(true);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('removes originals when --remove flag used', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arch-'));
+    const logs = path.join(dir, 'logs');
+    fs.mkdirSync(logs);
+    const old = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    const mem = path.join(logs, 'memory.log.old.bak');
+    fs.writeFileSync(mem, 'a');
+    const d = new Date(old);
+    fs.utimesSync(mem, d, d);
+
+    run(dir, ['--remove']);
+
+    expect(fs.existsSync(mem + '.gz')).toBe(true);
+    expect(fs.existsSync(mem)).toBe(false);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/src/__tests__/memory-cli.test.ts
+++ b/src/__tests__/memory-cli.test.ts
@@ -77,4 +77,13 @@ describe('memory-cli', () => {
       { stdio: 'inherit', cwd: repoRoot }
     );
   });
+
+  it('runs compress-memory-logs for archive command', () => {
+    run(['archive']);
+    expect(spy).toHaveBeenCalledWith(
+      'ts-node',
+      [path.join(scriptDir, 'compress-memory-logs.ts')],
+      { stdio: 'inherit', cwd: repoRoot }
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add `scripts/compress-memory-logs.ts` to gzip memory backups
- hook the script into `memory-cli.ts` via new `archive` command
- test CLI integration and compression behavior

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_6840849f048c8323b334826ddbbb5e45