### PR TITLE
Add pre-commit mem-check hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Personal dashboard for tracking Bitcoin and SPX/SPY price action and technical i
    npm install
    ```
 
-3. Set up git hooks:
+3. Set up git hooks (pre-commit and post-commit):
    ```bash
    npm run setup
    ```
@@ -144,7 +144,7 @@ npm run commitlog
 | `ts-node scripts/update-snapshot.ts` | Append commit summary and next task to `context.snapshot.md` |
 | `ts-node scripts/rebuild-memory.ts [path]` | Rebuild `memory.log` and `context.snapshot.md` from git history |
 | `ts-node scripts/memory-json.ts` | Export `memory.log` lines to `memory.json` |
-| `npm run setup` | Install the post-commit hook for automatic memlog updates |
+| `npm run setup` | Install pre-commit and post-commit hooks for automatic memlog checks |
 | `npm run dev-deps` | Install dev dependencies if `node_modules` is missing |
 | `bash scripts/check-env.sh` | Verify required CLIs (`next`, `jest`, `ts-node`) are installed |
 | `node scripts/try-cmd.js <cmd>` | Run a command only if the binary exists |

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-HOOK_PATH="$REPO_ROOT/.git/hooks/post-commit"
+POST_HOOK_PATH="$REPO_ROOT/.git/hooks/post-commit"
+PRE_HOOK_PATH="$REPO_ROOT/.git/hooks/pre-commit"
 
-cat > "$HOOK_PATH" <<'HOOK'
+cat > "$POST_HOOK_PATH" <<'HOOK'
 #!/usr/bin/env bash
 npm run memlog >/dev/null 2>&1
 npm run mem-rotate >/dev/null 2>&1
@@ -11,6 +12,14 @@ npm run mem-check >/dev/null 2>&1
 ts-node scripts/update-snapshot.ts >/dev/null 2>&1
 HOOK
 
-chmod +x "$HOOK_PATH"
-echo "post-commit hook installed at $HOOK_PATH"
+chmod +x "$POST_HOOK_PATH"
+echo "post-commit hook installed at $POST_HOOK_PATH"
+
+cat > "$PRE_HOOK_PATH" <<'HOOK'
+#!/usr/bin/env bash
+npm run mem-check >/dev/null 2>&1
+HOOK
+
+chmod +x "$PRE_HOOK_PATH"
+echo "pre-commit hook installed at $PRE_HOOK_PATH"
 


### PR DESCRIPTION
## Summary
- install pre-commit hook via `setup-hooks.sh` to run memory checks
- document the new pre-commit hook in setup instructions

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`
- `npm run commitlog` *(failed: ts-node not found)*
- `npm ci` *(failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6840849e251c8323be55c73a33a03c06