### PR TITLE
Add memory API endpoint

### DIFF
--- a/src/__tests__/memory-api.test.ts
+++ b/src/__tests__/memory-api.test.ts
@@ -1,0 +1,41 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { parseMemoryLines } from '../../scripts/memory-utils'
+
+describe('memory api route', () => {
+  it('returns parsed memory entries', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'memapi-'))
+    const mem = path.join(dir, 'memory.log')
+    const lines = [
+      'abc123 | first commit | a.ts | 2025-01-01T00:00:00Z',
+      'def456 | Task 2 | desc | b.ts | 2025-01-02T00:00:00Z',
+    ]
+    fs.writeFileSync(mem, lines.join('\n'))
+    process.env.MEM_PATH = mem
+    let mod: any
+    jest.isolateModules(() => {
+      mod = require('../app/api/memory/route')
+    })
+    const res = await mod.GET()
+    const json = await res.json()
+    expect(json).toEqual(parseMemoryLines(lines))
+    delete process.env.MEM_PATH
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('returns empty array when file missing', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'memapi-'))
+    const mem = path.join(dir, 'missing.log')
+    process.env.MEM_PATH = mem
+    let mod: any
+    jest.isolateModules(() => {
+      mod = require('../app/api/memory/route')
+    })
+    const res = await mod.GET()
+    const json = await res.json()
+    expect(json).toEqual([])
+    delete process.env.MEM_PATH
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+})

--- a/src/app/api/memory/route.ts
+++ b/src/app/api/memory/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server'
+import {
+  readMemoryLines,
+  parseMemoryLines,
+  MemoryEntry,
+} from '../../../../scripts/memory-utils'
+
+let cache: { ts: number; data: MemoryEntry[] } | null = null
+const TTL = 15 * 1000
+
+export async function GET() {
+  if (cache && Date.now() - cache.ts < TTL) {
+    return NextResponse.json(cache.data)
+  }
+  const lines = readMemoryLines()
+  const entries = parseMemoryLines(lines)
+  cache = { ts: Date.now(), data: entries }
+  return NextResponse.json(entries)
+}


### PR DESCRIPTION
## Summary
- add `/api/memory` route returning parsed memory log
- test API route output with mocked memory files

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`

------
https://chatgpt.com/codex/tasks/task_b_6840849cfba0832380ce915bcf0986b8