### PR TITLE
Add mem-summary range utility

### DIFF
--- a/scripts/mem-summary.ts
+++ b/scripts/mem-summary.ts
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import {
+  readMemoryLines,
+  parseMemoryLines,
+  snapshotPath,
+  parseSnapshotEntries,
+} from './memory-utils';
+
+const [fromId, toId] = process.argv.slice(2);
+
+if (!fromId || !toId) {
+  console.error('Usage: ts-node scripts/mem-summary.ts <from> <to>');
+  process.exit(1);
+}
+
+const snapLines = fs.existsSync(snapshotPath)
+  ? fs.readFileSync(snapshotPath, 'utf8').split('\n')
+  : [];
+const snapEntries = parseSnapshotEntries(snapLines);
+
+const fromIdx = snapEntries.findIndex((e) => e.id === fromId);
+const toIdx = snapEntries.findIndex((e) => e.id === toId);
+
+if (fromIdx === -1 || toIdx === -1) {
+  console.error('mem-id not found in snapshot');
+  process.exit(1);
+}
+
+const start = Math.min(fromIdx, toIdx);
+const end = Math.max(fromIdx, toIdx);
+
+const memMap = new Map(
+  parseMemoryLines(readMemoryLines()).map((e) => [e.hash, e.summary])
+);
+
+for (const entry of snapEntries.slice(start, end + 1)) {
+  const summary = memMap.get(entry.commit) || entry.summary;
+  console.log(`${entry.id}: ${summary}`);
+}

--- a/scripts/memory-cli.ts
+++ b/scripts/memory-cli.ts
@@ -28,6 +28,7 @@ Commands:
   diff                             List commits missing from memory.log
   json                             Export memory.log to memory.json
   clean-locks                      Delete stale .lock files
+  summary <from> <to>              Summaries between mem-ids
   check                            Verify memory files
   rebuild [path]                   Rebuild memory files from git history
   snapshot-update                  Append last commit summary to snapshot
@@ -69,6 +70,9 @@ switch (cmd) {
     break;
   case 'check':
     run('memory-check.ts', rest);
+    break;
+  case 'summary':
+    run('mem-summary.ts', rest);
     break;
   case 'rebuild':
     run('rebuild-memory.ts', rest);


### PR DESCRIPTION
## Summary
- add `scripts/mem-summary.ts` to print summaries between two mem-ids
- expose `summary` command from `memory-cli.ts`

## Testing
- `npm run dev-deps` *(fails: 403 Forbidden)*
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_6840849cddf48323afdabc0184b9bc73