### PR TITLE
Add memory timeline component

### DIFF
--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -126,3 +126,7 @@
 - Commit SHA: 3469d34
 - Summary: added validation function and tests covering malformed memory entries
 - Next Goal: flag upcoming high-impact economic events
+### 2025-06-04 17:42 UTC | mem-032
+- Commit SHA: 2c55b05
+- Summary: added MemoryTimeline component and API route to display commit history with optional flag
+- Next Goal: flag upcoming high-impact economic events

--- a/memory.log
+++ b/memory.log
@@ -574,3 +574,4 @@ c1e5a28 | Task bootstrap | validate automation rules and ran lint, test, backtes
 b5bf1eb | test(memory): concurrent append-memory writes | src/__tests__/append-memory.concurrent.test.ts | 2025-06-04T16:47:52Z
 6bfddd4 | Task bootstrap | clarified memory.log field requirements | AGENTS.md | 2025-06-04T16:52:12Z
 3469d34 | Task <unknown> | add tests for memory parsing edge cases and validation | scripts/memory-check.ts, scripts/memory-utils.ts, src/__tests__/memory-utils.test.ts, src/__tests__/memory-check.test.ts | 2025-06-04T16:53:32Z
+2c55b05 | Task <unknown> | add memory timeline component and API | src/app/api/memory/route.ts, src/components/MemoryTimeline.tsx, src/app/page.tsx | 2025-06-04T17:42:14Z

--- a/src/app/api/memory/route.ts
+++ b/src/app/api/memory/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+
+interface MemoryEntry {
+  hash: string;
+  summary: string;
+  timestamp: string;
+}
+
+let cache: { data: MemoryEntry[]; ts: number } | null = null;
+const CACHE_DURATION = 15 * 1000;
+
+export async function GET() {
+  if (cache && Date.now() - cache.ts < CACHE_DURATION) {
+    return NextResponse.json({ entries: cache.data, status: 'cached' });
+  }
+  try {
+    const memPath = process.env.MEM_PATH
+      ? path.resolve(process.env.MEM_PATH)
+      : path.join(process.cwd(), 'memory.log');
+    const content = fs.existsSync(memPath)
+      ? fs.readFileSync(memPath, 'utf8').trim()
+      : '';
+    const lines = content ? content.split('\n') : [];
+    const entries: MemoryEntry[] = lines.map((line) => {
+      const parts = line.split('|').map((p) => p.trim());
+      const hash = parts[0];
+      const summary = parts.length === 5 ? parts[2] : parts[1];
+      const timestamp = parts[parts.length - 1];
+      return { hash, summary, timestamp };
+    });
+    entries.sort(
+      (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+    );
+    cache = { data: entries, ts: Date.now() };
+    return NextResponse.json({ entries, status: 'fresh' });
+  } catch (e) {
+    console.error('Memory API error', e);
+    if (cache)
+      return NextResponse.json({ entries: cache.data, status: 'cached_error' });
+    return NextResponse.json({ entries: [], status: 'error' });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,6 +38,7 @@ import TxnCountWidget from "@/components/TxnCountWidget";
 import SessionTimerWidget from "@/components/SessionTimerWidget";
 import EmaCrossoverWidget from "@/components/EmaCrossoverWidget";
 import EmaTrendWidget from "@/components/EmaTrendWidget";
+import MemoryTimeline from "@/components/MemoryTimeline";
 import { Orchestrator } from "@/lib/agents/Orchestrator";
 import { DataCollector } from "@/lib/agents/DataCollector";
 import { IndicatorEngine } from "@/lib/agents/IndicatorEngine";
@@ -763,6 +764,9 @@ const CryptoDashboardPage: FC = () => {
           <AtrWidget />
           <SessionTimerWidget />
           <BbWidthAlert />
+          {process.env.NEXT_PUBLIC_MEMORY_TIMELINE === 'true' && (
+            <MemoryTimeline />
+          )}
 
 
         </div>

--- a/src/components/MemoryTimeline.tsx
+++ b/src/components/MemoryTimeline.tsx
@@ -1,0 +1,60 @@
+'use client'
+import { useEffect, useState } from 'react'
+import DataCard from '@/components/DataCard'
+
+interface MemoryEntry {
+  hash: string
+  summary: string
+  timestamp: string
+}
+
+export default function MemoryTimeline() {
+  const [entries, setEntries] = useState<MemoryEntry[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/api/memory')
+        if (!res.ok) throw new Error('API error')
+        const json = await res.json()
+        if (Array.isArray(json.entries)) {
+          json.entries.sort(
+            (a: MemoryEntry, b: MemoryEntry) =>
+              new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+          )
+          setEntries(json.entries)
+        }
+      } catch (e) {
+        console.error('Memory fetch failed', e)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [])
+
+  return (
+    <DataCard title="Commit History" className="sm:col-span-2 lg:col-span-2">
+      {loading ? (
+        <p className="text-center p-4">Loading...</p>
+      ) : (
+        <ul className="space-y-2 text-sm">
+          {entries.map((e) => (
+            <li key={`${e.hash}-${e.timestamp}`} className="border-b last:border-b-0 pb-1">
+              <div className="flex justify-between">
+                <span className="font-mono bg-muted px-1 rounded text-xs">
+                  {e.hash.slice(0, 7)}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {new Date(e.timestamp).toLocaleString()}
+                </span>
+              </div>
+              <p>{e.summary}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </DataCard>
+  )
+}


### PR DESCRIPTION
## Summary
- expose `/api/memory` to return commit entries
- create `MemoryTimeline` component to list commit history
- show timeline when `NEXT_PUBLIC_MEMORY_TIMELINE` env var is `true`
- document update in memory log

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`
- `npm run commitlog` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840849bdfe883238a37ff4bb59db6dd