### PR TITLE
Add Tasks 101-110

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -67,6 +67,17 @@ All tasks live in `task_queue.json` as `{ "id": number, "description": string, "
 - [ ] Task 99: extend memgrep to filter by --since and --until timestamps
 - [ ] Task 100: update README rotation section showing mem-rotate and snapshot-rotate usage
 
+- [ ] Task 101: make memory API TTL configurable via MEMORY_API_TTL env variable
+- [ ] Task 102: support since/until query params to filter memory API results by timestamp
+- [ ] Task 103: add snapshot-json script exporting context.snapshot.md to snapshot.json
+- [ ] Task 104: extend memory CLI with list command showing the last N entries
+- [ ] Task 105: build /memory Next.js page fetching /api/memory and rendering a table
+- [ ] Task 106: enforce max 300 lines for memory.log in pre-commit hook
+- [ ] Task 107: document memory CLI commands in README with examples
+- [ ] Task 108: update GitHub Pages workflow to publish snapshot.json
+- [ ] Task 109: create Jest test validating memory list -n 2 output
+- [ ] Task 110: implement /api/snapshot endpoint exposing snapshot data
+
 
 ### Bitcoin Dashboard
 

--- a/task_queue.json
+++ b/task_queue.json
@@ -418,5 +418,55 @@
     "id": 100,
     "description": "update README rotation section showing mem-rotate and snapshot-rotate usage",
     "status": "pending"
+  },
+  {
+    "id": 101,
+    "description": "make memory API TTL configurable via MEMORY_API_TTL env variable",
+    "status": "pending"
+  },
+  {
+    "id": 102,
+    "description": "support since/until query params to filter memory API results by timestamp",
+    "status": "pending"
+  },
+  {
+    "id": 103,
+    "description": "add snapshot-json script exporting context.snapshot.md to snapshot.json",
+    "status": "pending"
+  },
+  {
+    "id": 104,
+    "description": "extend memory CLI with list command showing the last N entries",
+    "status": "pending"
+  },
+  {
+    "id": 105,
+    "description": "build /memory Next.js page fetching /api/memory and rendering a table",
+    "status": "pending"
+  },
+  {
+    "id": 106,
+    "description": "enforce max 300 lines for memory.log in pre-commit hook",
+    "status": "pending"
+  },
+  {
+    "id": 107,
+    "description": "document memory CLI commands in README with examples",
+    "status": "pending"
+  },
+  {
+    "id": 108,
+    "description": "update GitHub Pages workflow to publish snapshot.json",
+    "status": "pending"
+  },
+  {
+    "id": 109,
+    "description": "create Jest test validating memory list -n 2 output",
+    "status": "pending"
+  },
+  {
+    "id": 110,
+    "description": "implement /api/snapshot endpoint exposing snapshot data",
+    "status": "pending"
   }
 ]


### PR DESCRIPTION
## Summary
- extend task checklist with tasks 101-110
- mirror new tasks in `task_queue.json`

## Testing
- `npm ci` *(fails: 403 Forbidden)*
- `npm run lint`
- `npm run test`
- `npm run backtest`


------
https://chatgpt.com/codex/tasks/task_b_684092b5e4ec83239e3c7b1f6d87aa21