### PR TITLE
Implement economic events API

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -98,7 +98,7 @@ All tasks live in `task_queue.json` as `{ "id": number, "description": string, "
 - [x] Task 29: show distance to nearest volume peak
 - [x] Task 30: fetch 1 h and 4 h candles
 - [x] Task 31: compare 5 m EMA trend with higher timeframes
-- [ ] Task 32: flag upcoming high-impact economic events
+- [x] Task 32: flag upcoming high-impact economic events
 - [ ] Task 33: notify on daily Google Trends spike
 - [ ] Task 34: integrate mempool fee pressure gauge
 - [ ] Task 35: implement risk/position-size calculator logic

--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -126,3 +126,7 @@
 - Commit SHA: 3469d34
 - Summary: added validation function and tests covering malformed memory entries
 - Next Goal: flag upcoming high-impact economic events
+### 2025-06-04 19:57 UTC | mem-032
+- Commit SHA: 9a2853d
+- Summary: implemented economic events fetcher and API route with caching and test; updated tasks to mark Task 32 done.
+- Next Goal: notify on daily Google Trends spike

--- a/memory.log
+++ b/memory.log
@@ -574,3 +574,4 @@ c1e5a28 | Task bootstrap | validate automation rules and ran lint, test, backtes
 b5bf1eb | test(memory): concurrent append-memory writes | src/__tests__/append-memory.concurrent.test.ts | 2025-06-04T16:47:52Z
 6bfddd4 | Task bootstrap | clarified memory.log field requirements | AGENTS.md | 2025-06-04T16:52:12Z
 3469d34 | Task <unknown> | add tests for memory parsing edge cases and validation | scripts/memory-check.ts, scripts/memory-utils.ts, src/__tests__/memory-utils.test.ts, src/__tests__/memory-check.test.ts | 2025-06-04T16:53:32Z
+9a2853d | Task 32 | add economic events api with caching and tests | src/lib/data/economicEvents.ts,src/app/api/economic-events/route.ts,src/__tests__/economic-events-api.test.ts,TASKS.md,task_queue.json | 2025-06-04T19:57:23Z

--- a/src/__tests__/economic-events-api.test.ts
+++ b/src/__tests__/economic-events-api.test.ts
@@ -1,0 +1,20 @@
+
+describe('economic events api', () => {
+  it('returns high impact events', async () => {
+    const mock = [
+      { date: '2025-06-05', event: 'CPI', impact: 'High', country: 'US' },
+      { date: '2025-06-05', event: 'Other', impact: 'Medium', country: 'US' },
+    ]
+    const fetchSpy = jest
+      .spyOn(global, 'fetch' as any)
+      .mockResolvedValue({ ok: true, json: async () => mock } as any)
+    let mod: any
+    jest.isolateModules(() => {
+      mod = require('../app/api/economic-events/route')
+    })
+    const res = await mod.GET()
+    const json = await res.json()
+    expect(json.events).toEqual([mock[0]])
+    fetchSpy.mockRestore()
+  })
+})

--- a/src/app/api/economic-events/route.ts
+++ b/src/app/api/economic-events/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server'
+import { fetchHighImpactEvents } from '@/lib/data/economicEvents'
+
+let cache: { ts: number; data: any } | null = null
+const TTL = 60 * 1000
+
+export async function GET() {
+  if (cache && Date.now() - cache.ts < TTL) {
+    return NextResponse.json({ events: cache.data, status: 'cached' })
+  }
+  const events = await fetchHighImpactEvents()
+  cache = { ts: Date.now(), data: events }
+  return NextResponse.json({ events, status: 'fresh' })
+}

--- a/src/lib/data/economicEvents.ts
+++ b/src/lib/data/economicEvents.ts
@@ -1,0 +1,32 @@
+import { cachedFetch, FetchImportance } from '@/lib/fetchCache'
+
+export interface EconomicEvent {
+  date: string
+  event: string
+  impact: string
+  country?: string
+}
+
+const API_BASE = 'https://financialmodelingprep.com/api/v3'
+
+export async function fetchEconomicCalendar(from: string, to: string): Promise<EconomicEvent[]> {
+  const key = process.env.NEXT_PUBLIC_FMP_API_KEY
+  if (!key) throw new Error('FMP API key not set')
+  const url = `${API_BASE}/economic_calendar?from=${from}&to=${to}&apikey=${key}`
+  const data = await cachedFetch<any[]>(url, 'context')
+  if (!Array.isArray(data)) return []
+  return data.map(d => ({
+    date: d.date,
+    event: d.event || d.title || '',
+    impact: d.impact || d.importance || 'Low',
+    country: d.country,
+  }))
+}
+
+export async function fetchHighImpactEvents(daysAhead = 2): Promise<EconomicEvent[]> {
+  const now = new Date()
+  const from = now.toISOString().slice(0, 10)
+  const to = new Date(now.getTime() + daysAhead * 86400000).toISOString().slice(0, 10)
+  const events = await fetchEconomicCalendar(from, to)
+  return events.filter(e => /high/i.test(e.impact))
+}

--- a/task_queue.json
+++ b/task_queue.json
@@ -77,7 +77,7 @@
   {
     "id": 32,
     "description": "flag upcoming high-impact economic events",
-    "status": "pending"
+    "status": "done"
   },
   {
     "id": 33,


### PR DESCRIPTION
## Summary
- flag upcoming high-impact economic events
- add route to fetch from FinancialModelingPrep
- cache results for one minute
- test the route
- update task queue and memory

## Testing
- `npm run dev-deps` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: ESLint config missing)*
- `npm run test` *(skipped: jest missing)*
- `npm run backtest` *(skipped: ts-node missing)*

------
https://chatgpt.com/codex/tasks/task_b_684096af62488323a527229db5f69bf9