### PR TITLE
Task 94: add timeout & logging for withFileLock

### DIFF
--- a/src/__tests__/file-lock.test.ts
+++ b/src/__tests__/file-lock.test.ts
@@ -74,6 +74,18 @@ describe('withFileLock', () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it('throws after timeout', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'locktest-'));
+    const file = path.join(dir, 'mem.txt');
+    const lock = `${file}.lock`;
+    fs.writeFileSync(lock, '');
+    const { withFileLock, LockAcquisitionTimeoutError } = require('../../scripts/memory-utils');
+    expect(() => {
+      withFileLock(file, () => {}, { acquireTimeoutMs: 50, maxRetries: 1 });
+    }).toThrow(LockAcquisitionTimeoutError);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it('handles many concurrent writers', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'locktest-'));
     const file = path.join(dir, 'mem.txt');


### PR DESCRIPTION
## Summary
- support passing options to `withFileLock`
- implement timeout handling with `LockAcquisitionTimeoutError`
- add verbose contention logging controlled by `DEBUG_FILE_LOCK`
- test timeout behaviour

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest`
- `npx tsc --noEmit` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_b_6840abf159a08323994a211b4ad5141b