### PR TITLE
Task 94: document MEM_PATH in rotation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ npm run snap-rotate  # prune context.snapshot.md
 ```
 
 A weekly GitHub workflow automatically runs `mem-rotate`, `clean-locks` and `commitlog` to push the
-latest trimmed logs. Adjust `MEM_ROTATE_LIMIT` and `SNAP_ROTATE_LIMIT` to control the
-number of retained entries. `LOCK_TTL` defines how old `.lock` files must be before
-`clean-locks` deletes them.
+latest trimmed logs. Set `MEM_PATH` and `SNAPSHOT_PATH` if your memory files live elsewhere and
+adjust `MEM_ROTATE_LIMIT` and `SNAP_ROTATE_LIMIT` to control the number of retained entries.
+`LOCK_TTL` defines how old `.lock` files must be before `clean-locks` deletes them.
 
 The memory scripts honor several environment variables:
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -59,7 +59,7 @@ All tasks live in `task_queue.json` as `{ "id": number, "description": string, "
 ### Upcoming Enhancements
 
  - [x] Task 93: fix codex helper command by running ts-node scripts/codex-context.ts
-- [ ] Task 94: document MEM_PATH and SNAPSHOT_PATH in README with rotation env vars
+ - [x] Task 94: document MEM_PATH and SNAPSHOT_PATH in README with rotation env vars
 - [ ] Task 95: create memory CLI with rotate, snapshot-rotate, status, grep, update-log
 - [x] Task 96: add jest tests verifying codex-context output with mocked git log
 - [ ] Task 97: export memory.log lines to memory.json using readMemoryLines helper

--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -130,3 +130,7 @@
 - Commit SHA: 9a2853d
 - Summary: implemented economic events fetcher and API route with caching and test; updated tasks to mark Task 32 done.
 - Next Goal: notify on daily Google Trends spike
+### 2025-06-04 22:07 UTC | mem-033
+- Commit SHA: 92c3269
+- Summary: Updated README rotation docs to mention MEM_PATH and SNAPSHOT_PATH and marked Task 94 done in TASKS.md and task_queue.json. Lint, test and backtest skipped due to missing modules.
+- Next Goal: create memory CLI with rotate, snapshot-rotate, status, grep and update-log

--- a/memory.log
+++ b/memory.log
@@ -198,3 +198,4 @@ b5bf1eb | test(memory): concurrent append-memory writes | src/__tests__/append-m
 6bfddd4 | Task bootstrap | clarified memory.log field requirements | AGENTS.md | 2025-06-04T16:52:12Z
 3469d34 | Task <unknown> | add tests for memory parsing edge cases and validation | scripts/memory-check.ts, scripts/memory-utils.ts, src/__tests__/memory-utils.test.ts, src/__tests__/memory-check.test.ts | 2025-06-04T16:53:32Z
 9a2853d | Task 32 | add economic events api with caching and tests | src/lib/data/economicEvents.ts,src/app/api/economic-events/route.ts,src/__tests__/economic-events-api.test.ts,TASKS.md,task_queue.json | 2025-06-04T19:57:23Z
+92c3269 | Task 94 | clarify memory rotation env vars in README | README.md,TASKS.md,task_queue.json | 2025-06-04T22:07:27Z

--- a/task_queue.json
+++ b/task_queue.json
@@ -387,7 +387,7 @@
   {
     "id": 94,
     "description": "document MEM_PATH and SNAPSHOT_PATH in README with rotation env vars",
-    "status": "pending"
+    "status": "done"
   },
   {
     "id": 95,


### PR DESCRIPTION
## Summary
- clarify memory rotation docs mentioning `MEM_PATH` and `SNAPSHOT_PATH`
- mark Task 94 done in TASKS.md and task_queue.json
- log mem-033 entry in context snapshot

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run test` *(skipped: jest missing)*
- `npm run backtest` *(skipped: ts-node missing)*
- `npm run commitlog` *(failed: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840c3152a4c8323b5bb7622341eaebe