### PR TITLE
Add ESLint and Prettier configs

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all",
+  "endOfLine": "lf"
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,24 @@
+import eslintPluginTs from '@typescript-eslint/eslint-plugin';
+import parserTs from '@typescript-eslint/parser';
+
+export default [
+  {
+    ignores: ['node_modules/**', '.next/**', 'logs/**'],
+  },
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    languageOptions: {
+      parser: parserTs,
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: __dirname,
+      },
+    },
+    plugins: {
+      '@typescript-eslint': eslintPluginTs,
+    },
+    rules: {
+      // place custom rules here
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -91,6 +91,10 @@
     "next": "15.2.3",
     "ts-node": "^10.9.1",
     "eslint": "^8",
+    "@typescript-eslint/eslint-plugin": "^6",
+    "@typescript-eslint/parser": "^6",
+    "eslint-config-prettier": "^9",
+    "prettier": "^3",
     "@types/jest": "^29"
   },
   "engines": {


### PR DESCRIPTION
## Summary
- add ESLint flat config and ignore pattern in repo
- add Prettier config for formatting
- include eslint and prettier plugins in package.json so linting works out of the box

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm run test` *(fails: Command jest missing)*
- `npm run backtest` *(fails: Command ts-node missing)*
- `npm run commitlog` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840c4b8286883238795576f5f48578c