### PR TITLE
Add codex context shell helper

### DIFF
--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -134,3 +134,8 @@
 - Commit SHA: 92c3269
 - Summary: Updated README rotation docs to mention MEM_PATH and SNAPSHOT_PATH and marked Task 94 done in TASKS.md and task_queue.json. Lint, test and backtest skipped due to missing modules.
 - Next Goal: create memory CLI with rotate, snapshot-rotate, status, grep and update-log
+
+### 2025-06-05 15:58 UTC | mem-034
+- Commit SHA: 4c3d3df
+- Summary: revamped codex_context.sh to mirror setup snippet and patched eslint.config.js for ESM compatibility. Lint succeeded but tests and backtest failed.
+- Next Goal: create memory CLI with rotate, snapshot-rotate, status, grep and update-log

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,9 @@
 import eslintPluginTs from '@typescript-eslint/eslint-plugin';
 import parserTs from '@typescript-eslint/parser';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default [
   {

--- a/memory.log
+++ b/memory.log
@@ -199,3 +199,4 @@ b5bf1eb | test(memory): concurrent append-memory writes | src/__tests__/append-m
 3469d34 | Task <unknown> | add tests for memory parsing edge cases and validation | scripts/memory-check.ts, scripts/memory-utils.ts, src/__tests__/memory-utils.test.ts, src/__tests__/memory-check.test.ts | 2025-06-04T16:53:32Z
 9a2853d | Task 32 | add economic events api with caching and tests | src/lib/data/economicEvents.ts,src/app/api/economic-events/route.ts,src/__tests__/economic-events-api.test.ts,TASKS.md,task_queue.json | 2025-06-04T19:57:23Z
 92c3269 | Task 94 | clarify memory rotation env vars in README | README.md,TASKS.md,task_queue.json | 2025-06-04T22:07:27Z
+4c3d3df | Task <unknown> | revamped codex_context.sh to match bitdash-setup snippet and print commit/task blocks, patched eslint.config.js to compute __dirname for ESM so lint succeeds | scripts/codex_context.sh,eslint.config.js | 2025-06-05T15:58:25Z

--- a/scripts/codex_context.sh
+++ b/scripts/codex_context.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# Prints 333-token commit memory + 333-token task block.
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
-cd "$REPO_ROOT"
+COMMITS=$(git log -n5 --pretty=format:'• %s – %b' | head -c 2000)     # ≈333 tokens
+TASKS=$(grep '^- \[ \]' TASKS.md | head -n15 | sed 's/^- \[ \] //' | head -c 2000)  # ≈333
 
-commits=$(git log -n 5 --pretty=format:'- %h %s')
+cat <<EOF
+[MEMORY PREAMBLE—DO NOT EDIT BELOW]
+Recent commits (333 tokens):
+$COMMITS
 
-next_task=$(grep -m 1 '^\- \[ \]' TASKS.md | sed -E 's/^\- \[ \] //')
+Pending tasks (333 tokens):
+$TASKS
+[END MEMORY PREAMBLE]
+EOF
 
-printf "Recent work:\n%s\nNext task: %s\n" "$commits" "$next_task"


### PR DESCRIPTION
## Summary
- rewrite scripts/codex_context.sh to match setup docs
- fix eslint.config.js so __dirname works in ESM
- record mem-034 in context files

## Testing
- `npm run lint`
- `npm run test` *(fails: Cannot redefine property: execSync)*
- `npm run backtest` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*

------
https://chatgpt.com/codex/tasks/task_b_6841bd7fac3c83239ed298bbb4295e9a