### PR TITLE
Update action versions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version: '18'
           cache: 'npm'
       - run: npm ci
       - run: npm run lint


### PR DESCRIPTION
## Summary
- update `actions/checkout` to v4
- update `actions/setup-node` to v4
- specify Node.js `18` in CI workflow

## Testing
- `npm run lint` *(fails: 161 errors)*
- `npm run test` *(fails to execute: many Jest errors)*
- `npm run backtest` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*

------
https://chatgpt.com/codex/tasks/task_b_6841caced8808323a88335058f31b7a5