### PR TITLE
chore(env): enforce Node 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Personal dashboard for tracking Bitcoin and SPX/SPY price action and technical i
 
 ## Getting Started
 
+Ensure **Node.js 18** is installed before continuing.
+
 1. Clone the repository:
 
    ```bash

--- a/scripts/check-env.sh
+++ b/scripts/check-env.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 set -e
+
+# ensure Node.js 18
+NODE_VERSION=$(node --version 2>/dev/null || echo "")
+if [[ $NODE_VERSION != v18* ]]; then
+  echo "❌ Node.js 18 required" && exit 1
+fi
 for bin in next jest ts-node; do
   if ! npx --no-install $bin --version >/dev/null 2>&1; then
     echo "❌ $bin missing – run 'npm ci'" && exit 1


### PR DESCRIPTION
## Summary
- mention Node 18 requirement in the Getting Started section
- check Node 18 in `check-env.sh`

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run test` *(fails: 23 failed, 4 passed)*
- `npm run backtest` *(fails: Unknown file extension)*

------
https://chatgpt.com/codex/tasks/task_b_6841ce2f60b483238e3a47b2c306fe63