### PR TITLE
Fix withFsMocks recursion

### DIFF
--- a/src/__tests__/mem-locate.test.ts
+++ b/src/__tests__/mem-locate.test.ts
@@ -4,15 +4,17 @@ import path from 'path';
 import { memPath, snapshotPath } from '../../scripts/memory-utils';
 
 function withFsMocks(paths: Record<string, string>, fn: () => void) {
+  const origExists = fs.existsSync;
+  const origRead = fs.readFileSync;
   const existsMock = jest.spyOn(fs, 'existsSync').mockImplementation((p: any) => {
-    if (paths[p as string]) return fs.existsSync(paths[p as string]);
-    return fs.existsSync(p as string);
+    if (paths[p as string]) return origExists.call(fs, paths[p as string]);
+    return origExists.call(fs, p as string);
   });
   const readMock = jest
     .spyOn(fs, 'readFileSync')
     .mockImplementation((p: any, opt?: any) => {
       if (paths[p as string]) p = paths[p as string];
-      return fs.readFileSync(p as string, opt);
+      return origRead.call(fs, p as string, opt);
     });
   try {
     fn();

--- a/src/__tests__/mem-status.test.ts
+++ b/src/__tests__/mem-status.test.ts
@@ -6,15 +6,17 @@ import * as utils from '../../scripts/memory-utils';
 const { memPath, snapshotPath, repoRoot } = utils;
 
 function withFsMocks(paths: Record<string, string>, fn: () => void) {
+  const origExists = fs.existsSync;
+  const origRead = fs.readFileSync;
   const existsMock = jest.spyOn(fs, 'existsSync').mockImplementation((p: any) => {
-    if (paths[p as string]) return fs.existsSync(paths[p as string]);
-    return fs.existsSync(p);
+    if (paths[p as string]) return origExists.call(fs, paths[p as string]);
+    return origExists.call(fs, p);
   });
   const readMock = jest
     .spyOn(fs, 'readFileSync')
     .mockImplementation((p: any, opt?: any) => {
       if (paths[p as string]) p = paths[p as string];
-      return fs.readFileSync(p, opt);
+      return origRead.call(fs, p, opt);
     });
   try {
     fn();

--- a/src/__tests__/memgrep.test.ts
+++ b/src/__tests__/memgrep.test.ts
@@ -4,15 +4,17 @@ import path from 'path';
 import { memPath, snapshotPath } from '../../scripts/memory-utils';
 
 function withFsMocks(paths: Record<string, string>, fn: () => void) {
+  const origExists = fs.existsSync;
+  const origRead = fs.readFileSync;
   const existsMock = jest.spyOn(fs, 'existsSync').mockImplementation((p: any) => {
-    if (paths[p as string]) return fs.existsSync(paths[p as string]);
-    return fs.existsSync(p as string);
+    if (paths[p as string]) return origExists.call(fs, paths[p as string]);
+    return origExists.call(fs, p as string);
   });
   const readMock = jest
     .spyOn(fs, 'readFileSync')
     .mockImplementation((p: any, opt?: any) => {
       if (paths[p as string]) p = paths[p as string];
-      return fs.readFileSync(p as string, opt);
+      return origRead.call(fs, p as string, opt);
     });
   try {
     fn();

--- a/src/__tests__/memory-check.test.ts
+++ b/src/__tests__/memory-check.test.ts
@@ -7,13 +7,15 @@ import * as utils from '../../scripts/memory-utils';
 const { memPath, snapshotPath } = utils;
 
 function withFsMocks(paths: Record<string, string>, fn: () => void) {
+  const origExists = fs.existsSync;
+  const origRead = fs.readFileSync;
   const existsMock = jest.spyOn(fs, 'existsSync').mockImplementation((p: any) => {
-    if (paths[p as string]) return fs.existsSync(paths[p as string]);
-    return fs.existsSync(p);
+    if (paths[p as string]) return origExists.call(fs, paths[p as string]);
+    return origExists.call(fs, p);
   });
   const readMock = jest.spyOn(fs, 'readFileSync').mockImplementation((p: any, o?: any) => {
     if (paths[p as string]) p = paths[p as string];
-    return fs.readFileSync(p, o);
+    return origRead.call(fs, p, o);
   });
   try {
     fn();


### PR DESCRIPTION
## Summary
- ensure withFsMocks helpers use original fs methods

## Testing
- `npm run lint` *(fails: unexpected any)*
- `npm run test` *(fails to execute tests)*
- `npm run backtest` *(fails to run backtest script)*

------
https://chatgpt.com/codex/tasks/task_b_6841d1d2aa688323b1dd916051a89aca