### PR TITLE
test: reset mocks after each run

### DIFF
--- a/src/__tests__/autoTaskRunner.state.test.ts
+++ b/src/__tests__/autoTaskRunner.state.test.ts
@@ -62,6 +62,7 @@ function withFsMocks(paths: Record<string, string>, fn: () => void) {
 }
 
 describe('autoTaskRunner writes', () => {
+  afterEach(() => jest.restoreAllMocks());
   it('uses locks and atomic writes for tasks and signals', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'autorun-'));
     const tasks = path.join(dir, 'TASKS.md');
@@ -89,10 +90,6 @@ describe('autoTaskRunner writes', () => {
     expect(lockMock.mock.calls.map(c => c[0])).toEqual(expect.arrayContaining([tasks, signals]));
     expect(atomicMock.mock.calls.map(c => c[0])).toEqual(expect.arrayContaining([tasks, signals]));
 
-    spawnMock.mockRestore();
-    execMock.mockRestore();
-    atomicMock.mockRestore();
-    lockMock.mockRestore();
     fs.rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/src/__tests__/memory-check.test.ts
+++ b/src/__tests__/memory-check.test.ts
@@ -26,6 +26,7 @@ function withFsMocks(paths: Record<string, string>, fn: () => void) {
 }
 
 describe('memory-check', () => {
+  afterEach(() => jest.restoreAllMocks());
   it('passes for ordered log', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memchk-'));
     const tmpMem = path.join(tmpDir, 'memory.log');
@@ -57,8 +58,6 @@ describe('memory-check', () => {
     });
 
     expect(logMock).toHaveBeenCalledWith('Memory check passed');
-    execMock.mockRestore();
-    logMock.mockRestore();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -94,8 +93,6 @@ describe('memory-check', () => {
     });
 
     expect(logMock).toHaveBeenCalledWith('Memory check passed');
-    execMock.mockRestore();
-    logMock.mockRestore();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -136,9 +133,6 @@ describe('memory-check', () => {
       });
     }).toThrow('1');
 
-    execMock.mockRestore();
-    errMock.mockRestore();
-    exitMock.mockRestore();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -179,9 +173,6 @@ describe('memory-check', () => {
       });
     }).toThrow('1');
 
-    execMock.mockRestore();
-    errMock.mockRestore();
-    exitMock.mockRestore();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -215,9 +206,6 @@ describe('memory-check', () => {
       });
     }).toThrow('1');
 
-    execMock.mockRestore();
-    errMock.mockRestore();
-    exitMock.mockRestore();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -251,9 +239,6 @@ describe('memory-check', () => {
       });
     }).toThrow('1');
 
-    execMock.mockRestore();
-    errMock.mockRestore();
-    exitMock.mockRestore();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -291,9 +276,6 @@ describe('memory-check', () => {
       });
     }).toThrow('1');
 
-    execMock.mockRestore();
-    errMock.mockRestore();
-    exitMock.mockRestore();
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
@@ -332,9 +314,6 @@ describe('memory-check', () => {
       });
     }).toThrow('1');
 
-    execMock.mockRestore();
-    errMock.mockRestore();
-    exitMock.mockRestore();
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
@@ -373,9 +352,6 @@ describe('memory-check', () => {
       });
     }).toThrow('1');
 
-    execMock.mockRestore();
-    errMock.mockRestore();
-    exitMock.mockRestore();
     fs.rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/src/__tests__/memory-cli.test.ts
+++ b/src/__tests__/memory-cli.test.ts
@@ -20,9 +20,7 @@ describe('memory-cli', () => {
     spy = jest.spyOn(cp, 'spawnSync').mockReturnValue({ status: 0 } as any);
   });
 
-  afterEach(() => {
-    spy.mockRestore();
-  });
+  afterEach(() => jest.restoreAllMocks());
 
   it('runs mem-diff for diff command', () => {
     run(['diff']);


### PR DESCRIPTION
## Summary
- ensure test suites reset mocks between each test
- rely on jest.restoreAllMocks instead of individual calls

## Testing
- `npm run lint` *(fails: no-unused-vars, no-explicit-any, etc.)*
- `npm run test` *(fails: Cannot redefine property: execSync, missing modules, timeouts, etc.)*
- `npm run backtest` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*

------
https://chatgpt.com/codex/tasks/task_b_6841d3ef9c2483239c0939c8cc49114c