### PR TITLE
Update memory api tests

### DIFF
--- a/src/__tests__/economic-events-api.test.ts
+++ b/src/__tests__/economic-events-api.test.ts
@@ -12,7 +12,7 @@ describe('economic events api', () => {
     jest.isolateModules(() => {
       mod = require('../app/api/economic-events/route')
     })
-    const res = await mod.GET()
+    const res = await mod.GET(new Request('http://x'))
     const json = await res.json()
     expect(json.events).toEqual([mock[0]])
     fetchSpy.mockRestore()

--- a/src/__tests__/memory-api.test.ts
+++ b/src/__tests__/memory-api.test.ts
@@ -17,7 +17,7 @@ describe('memory api route', () => {
     jest.isolateModules(() => {
       mod = require('../app/api/memory/route')
     })
-    const res = await mod.GET()
+    const res = await mod.GET(new Request('http://x'))
     const json = await res.json()
     expect(json).toEqual(parseMemoryLines(lines))
     delete process.env.MEM_PATH
@@ -32,7 +32,7 @@ describe('memory api route', () => {
     jest.isolateModules(() => {
       mod = require('../app/api/memory/route')
     })
-    const res = await mod.GET()
+    const res = await mod.GET(new Request('http://x'))
     const json = await res.json()
     expect(json).toEqual([])
     delete process.env.MEM_PATH


### PR DESCRIPTION
## Summary
- pass a Request object when invoking `GET` in memory-api tests

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run test` *(fails: TypeError: Cannot redefine property: execSync)*
- `npm run backtest` *(fails: Unknown file extension .ts)*

------
https://chatgpt.com/codex/tasks/task_b_6841d5de7a2c8323b869a1df07fb9de4