### PR TITLE
fix(backtest): run via ts-node esm loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint -c .eslintrc.json \"src/**/*.{ts,tsx,js,jsx}\"",
     "typecheck": "tsc --noEmit",
     "test": "jest",
-    "backtest": "ts-node scripts/backtest.ts",
+    "backtest": "node --loader ts-node/esm scripts/backtest.ts",
     "dev-deps": "bash scripts/dev-deps.sh",
     "auto": "node scripts/try-cmd.js ts-node src/scripts/autoTaskRunner.ts",
     "commitlog": "ts-node scripts/commitlog.ts",

--- a/scripts/backtest.ts
+++ b/scripts/backtest.ts
@@ -1,2 +1,4 @@
-import '../src/scripts/backtest'
+import backtest from '../src/scripts/backtest';
+
+backtest().catch(err => console.error(err));
 

--- a/src/scripts/backtest.ts
+++ b/src/scripts/backtest.ts
@@ -2,7 +2,7 @@ import { fetchBackfill } from '@/lib/data/coingecko';
 import { computeIndicators, evaluateSignal, type ComputedIndicators } from '@/lib/signals';
 import type { TradeSignal } from '@/types';
 
-async function run() {
+export async function runBacktest() {
   const candles = await fetchBackfill();
   const closes: number[] = [];
   const volumes: number[] = [];
@@ -23,4 +23,10 @@ async function run() {
   console.log('Signals generated', signals.length);
 }
 
-run().catch(e => console.error(e));
+export default async function cli() {
+  try {
+    await runBacktest();
+  } catch (e) {
+    console.error(e);
+  }
+}


### PR DESCRIPTION
## Summary
- update backtest npm script to use ts-node/esm loader
- adapt backtest entry to call the exported function
- expose backtest runner for cli use

## Testing
- `node --loader ts-node/esm scripts/backtest.ts` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_b_6841d70494ec83239770f2b8ba6ddacc