### PR TITLE
Add tasks for Node 18 CI fixes

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -77,6 +77,10 @@ All tasks live in `task_queue.json` as `{ "id": number, "description": string, "
 - [ ] Task 108: update GitHub Pages workflow to publish snapshot.json
 - [ ] Task 109: create Jest test validating memory list -n 2 output
 - [ ] Task 110: implement /api/snapshot endpoint exposing snapshot data
+- [ ] Task 111: fix lint errors flagged under Node 18 by removing unused vars and typing any usage
+- [ ] Task 112: update jest tests to restore cp mocks after each run preventing execSync redefinition
+- [ ] Task 113: handle unequal array lengths in correlation test to avoid NaN values
+- [ ] Task 114: refactor backtest.ts to use dynamic import with ts-node to break require cycle
 
 
 ### Bitcoin Dashboard

--- a/task_queue.json
+++ b/task_queue.json
@@ -468,5 +468,25 @@
     "id": 110,
     "description": "implement /api/snapshot endpoint exposing snapshot data",
     "status": "pending"
+  },
+  {
+    "id": 111,
+    "description": "fix lint errors flagged under Node 18 by removing unused vars and typing any usage",
+    "status": "pending"
+  },
+  {
+    "id": 112,
+    "description": "update jest tests to restore cp mocks after each run preventing execSync redefinition",
+    "status": "pending"
+  },
+  {
+    "id": 113,
+    "description": "handle unequal array lengths in correlation test to avoid NaN values",
+    "status": "pending"
+  },
+  {
+    "id": 114,
+    "description": "refactor backtest.ts to use dynamic import with ts-node to break require cycle",
+    "status": "pending"
   }
 ]


### PR DESCRIPTION
## Summary
- queue new tasks for fixing Node 18 CI regressions

## Testing
- `npm run lint` *(fails: 66 errors)*
- `npm run test` *(fails to execute tests)*
- `npm run backtest` *(fails to run backtest)*

------
https://chatgpt.com/codex/tasks/task_b_6841d9c35f508323875e8481ceca8b46