### PR TITLE
Docs: Node 18 setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ Ensure **Node.js 18** is installed before continuing.
    cd bitdash-firestudio
    ```
 
-2. Install dependencies:
+2. Install Node 18 and dependencies:
 
    ```bash
-   npm install
+   nvm install 18
+   nvm use 18
+   npm ci
    ```
 
 3. Install dev tools:

--- a/TASKS.md
+++ b/TASKS.md
@@ -81,6 +81,7 @@ All tasks live in `task_queue.json` as `{ "id": number, "description": string, "
 - [ ] Task 112: update jest tests to restore cp mocks after each run preventing execSync redefinition
 - [ ] Task 113: handle unequal array lengths in correlation test to avoid NaN values
 - [ ] Task 114: refactor backtest.ts to use dynamic import with ts-node to break require cycle
+- [ ] Task 115: clarify Node 18 nvm usage in README Getting Started
 
 
 ### Bitcoin Dashboard

--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -143,3 +143,7 @@
 - Commit SHA: e8934ed
 - Summary: added .eslintrc.json from setup snippet and updated lint script to load it; documented interplay with eslint.config.js in README.
 - Next Goal: create memory CLI with rotate, snapshot-rotate, status, grep and update-log
+### $(date -u '+%Y-%m-%d %H:%M UTC') | mem-036
+- Commit SHA: b29338f
+- Summary: clarified Node 18 nvm usage in README, updated env check error and setup script to use npm ci, added Task 115 entry
+- Next Goal: create memory CLI with rotate, snapshot-rotate, status, grep and update-log

--- a/logs/block-115.txt
+++ b/logs/block-115.txt
@@ -1,0 +1,1 @@
+lint, test or backtest failed for Task 115

--- a/memory.log
+++ b/memory.log
@@ -201,3 +201,4 @@ b5bf1eb | test(memory): concurrent append-memory writes | src/__tests__/append-m
 92c3269 | Task 94 | clarify memory rotation env vars in README | README.md,TASKS.md,task_queue.json | 2025-06-04T22:07:27Z
 4c3d3df | Task <unknown> | revamped codex_context.sh to match bitdash-setup snippet and print commit/task blocks, patched eslint.config.js to compute __dirname for ESM so lint succeeds | scripts/codex_context.sh,eslint.config.js | 2025-06-05T15:58:25Z
 e8934ed | chore(lint): add eslintrc config | .eslintrc.json, README.md, package.json | 2025-06-05T16:09:58+00:00
+b29338f | Task 115 | clarify Node 18 instructions and nvm hint; updated setup script; logged failure | README.md, scripts/check-env.sh, scripts/setup_dev.sh, TASKS.md, task_queue.json, logs/block-115.txt | 2025-06-05T18:24:57+00:00

--- a/scripts/check-env.sh
+++ b/scripts/check-env.sh
@@ -4,7 +4,7 @@ set -e
 # ensure Node.js 18
 NODE_VERSION=$(node --version 2>/dev/null || echo "")
 if [[ $NODE_VERSION != v18* ]]; then
-  echo "❌ Node.js 18 required" && exit 1
+  echo "❌ Node.js 18 required – run 'nvm use 18'" && exit 1
 fi
 for bin in next jest ts-node; do
   if ! npx --no-install $bin --version >/dev/null 2>&1; then

--- a/scripts/setup_dev.sh
+++ b/scripts/setup_dev.sh
@@ -2,11 +2,8 @@
 # Run once: installs all dev-tools locally so Codex finds them.
 
 set -e
-echo "▶ Installing dev-dependencies…"
-npm install --save-dev \
-  eslint @typescript-eslint/parser @typescript-eslint/eslint-plugin \
-  jest ts-jest @types/jest \
-  ts-node typescript @types/node
+echo "▶ Installing dev-dependencies via npm ci…"
+npm ci
 
 echo "▶ Done.  You can now run:"
 echo "   npm run lint   # ESLint"

--- a/task_queue.json
+++ b/task_queue.json
@@ -488,5 +488,10 @@
     "id": 114,
     "description": "refactor backtest.ts to use dynamic import with ts-node to break require cycle",
     "status": "pending"
+  },
+  {
+    "id": 115,
+    "description": "clarify Node 18 nvm usage in README Getting Started",
+    "status": "pending"
   }
 ]


### PR DESCRIPTION
## Summary
- clarify nvm usage before npm ci in README
- mention `nvm use 18` in env check
- switch setup_dev.sh to use `npm ci`
- track Task 115 for the doc fix

## Testing
- `bash scripts/check-env.sh`
- `npm run lint` *(fails: 66 errors)*
- `npm run test` *(fails: 42 failing tests)*
- `npm run backtest` *(fails to load ES module)*

------
https://chatgpt.com/codex/tasks/task_b_6841dff1e83c8323a6f1b26294c496c8