### PR TITLE
Implement Node fallback for caching

### DIFF
--- a/logs/backtest.log
+++ b/logs/backtest.log
@@ -1,4 +1,4 @@
 
 > bitdash-firestudio@1.0.0 backtest
-> ts-node scripts/backtest.ts
+> node --loader ts-node/esm scripts/backtest.ts
 

--- a/logs/lint.log
+++ b/logs/lint.log
@@ -1,4 +1,114 @@
 
 > bitdash-firestudio@1.0.0 lint
-> bash scripts/check-env.sh && eslint . --ext .ts,.tsx
+> ESLINT_USE_FLAT_CONFIG=false eslint -c .eslintrc.json "src/**/*.{ts,tsx,js,jsx}"
+
+
+/workspace/bitdashfirestudio/src/__tests__/autoTaskRunner.state.test.ts
+  80:11  error  'spawnMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  81:11  error  'execMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/__tests__/memory-check.test.ts
+   46:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+   81:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  115:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  121:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  122:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  155:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  161:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  162:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  188:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  194:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  195:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  221:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  227:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  228:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  258:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  264:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  265:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  296:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  302:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  303:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  334:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  340:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  341:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/app/api/economic-events/route.ts
+  4:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/funding-schedule/route.ts
+  4:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/higher-candles/route.ts
+  8:19  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  8:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/open-interest/route.ts
+  4:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/prev-day/route.ts
+  19:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/page.tsx
+   45:15  error  'ComputedIndicators' is defined but never used  @typescript-eslint/no-unused-vars
+   46:15  error  'TradeSignal' is defined but never used         @typescript-eslint/no-unused-vars
+   73:25  error  '_t' is assigned a value but never used         @typescript-eslint/no-unused-vars
+   73:40  error  '_f' is assigned a value but never used         @typescript-eslint/no-unused-vars
+   73:49  error  '_s1' is assigned a value but never used        @typescript-eslint/no-unused-vars
+   73:59  error  '_s2' is assigned a value but never used        @typescript-eslint/no-unused-vars
+   73:69  error  '_d' is assigned a value but never used         @typescript-eslint/no-unused-vars
+   73:80  error  '_u' is assigned a value but never used         @typescript-eslint/no-unused-vars
+  279:41  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
+  280:41  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
+  652:11  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/agents/IndicatorEngine.ts
+  3:29  error  'IndicatorSet' is defined but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/lib/agents/TestingAgent.ts
+  16:10  error  '_msg' is defined but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/lib/agents/UIRenderer.ts
+  4:10  error  '_msg' is defined but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/lib/data/binanceCandles.ts
+  20:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/bybitOpenInterest.ts
+  11:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  13:37  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/coingecko.ts
+  20:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  36:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/economicEvents.ts
+   1:23  error  'FetchImportance' is defined but never used  @typescript-eslint/no-unused-vars
+  16:34  error  Unexpected any. Specify a different type     @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/fmp.ts
+  18:12  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  34:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  47:14  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  65:14  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/fundingSchedule.ts
+  11:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  13:37  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/fetchCache.ts
+  10:9  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/signals.ts
+  38:9  error  'now' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/scripts/autoTaskRunner.ts
+  29:10  error  Unexpected constant condition                    no-constant-condition
+  39:88  error  Unexpected any. Specify a different type         @typescript-eslint/no-explicit-any
+  58:5   error  Move function declaration to function body root  no-inner-declarations
+  80:5   error  Move function declaration to function body root  no-inner-declarations
+
+/workspace/bitdashfirestudio/src/types/agent.ts
+  1:35  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+✖ 65 problems (65 errors, 0 warnings)
 

--- a/src/__tests__/cache.test.ts
+++ b/src/__tests__/cache.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals'
+
+const CACHE_DURATION = 30 * 60 * 1000
+
+afterEach(() => {
+  jest.useRealTimers()
+  delete (global as any).window
+})
+
+describe('cache module', () => {
+  it('uses Map fallback when localStorage missing', () => {
+    jest.useFakeTimers()
+    jest.isolateModules(() => {
+      const cache = require('../lib/cache')
+      expect(cache.getCachedData('x')).toBeNull()
+      cache.setCachedData('x', 1)
+      expect(cache.getCachedData('x')).toBe(1)
+      jest.advanceTimersByTime(CACHE_DURATION + 1)
+      expect(cache.getCachedData('x')).toBeNull()
+    })
+  })
+
+  it('uses browser localStorage when available', () => {
+    const store = new Map<string, string>()
+    ;(global as any).window = {
+      localStorage: {
+        getItem: (k: string) => (store.has(k) ? store.get(k) : null),
+        setItem: (k: string, v: string) => {
+          store.set(k, v)
+        },
+        removeItem: (k: string) => {
+          store.delete(k)
+        },
+      },
+    }
+    jest.useFakeTimers()
+    jest.isolateModules(() => {
+      const cache = require('../lib/cache')
+      expect(cache.getCachedData('y')).toBeNull()
+      cache.setCachedData('y', 2)
+      expect(cache.getCachedData('y')).toBe(2)
+      jest.advanceTimersByTime(CACHE_DURATION + 1)
+      expect(cache.getCachedData('y')).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add runtime detection of `localStorage` in `cache.ts` with in-memory Map fallback
- support clearing and setting cache across environments
- create unit tests for browser and server cache usage
- update lint, test and backtest logs

## Testing
- `npm run lint` *(fails: 65 errors)*
- `npm run test` *(fails to complete with 20 failing suites)*
- `npm run backtest` *(fails to run due to ESM require cycle)*

------
https://chatgpt.com/codex/tasks/task_b_6846e41b89cc83238d1da78d1917673f