### PR TITLE
docs(start): mention dev-deps in kickoff guide

### DIFF
--- a/CODEX_START.md
+++ b/CODEX_START.md
@@ -28,8 +28,9 @@ Limit commit summaries in both the commit body and context snapshot to about **3
 ## Recap
 
 1. Run `npm run codex` and paste the output block into ChatGPT.
-2. Confirm AGENTS.md, memory.log and context.snapshot.md are loaded.
-3. Execute the next task from TASKS.md, committing with a clear message.
-4. Append the commit info to memory.log and context.snapshot.md.
+2. Run `npm run dev-deps` if `node_modules` is missing before starting.
+3. Confirm AGENTS.md, memory.log and context.snapshot.md are loaded.
+4. Execute the next task from TASKS.md, committing with a clear message.
+5. Append the commit info to memory.log and context.snapshot.md.
 
 Following these steps preserves context between sessions and keeps token usage manageable.

--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -168,3 +168,7 @@
 - Commit SHA: fe24dba
 - Summary: unified API caching TTL via shared constant and updated docs
 - Next Goal: run npm ci only once in AutoTaskRunner
+### 2025-06-09 14:42 UTC | mem-042
+- Commit SHA: 2d90883
+- Summary: added kickoff guide bullet reminding to run dev-deps when node_modules is missing.
+- Next Goal: run npm ci only once in AutoTaskRunner

--- a/memory.log
+++ b/memory.log
@@ -207,3 +207,4 @@ b29338f | Task 115 | clarify Node 18 instructions and nvm hint; updated setup sc
 d56d7c0 | Task 96 | remove commitlog | multiple files | 2025-06-06T14:59:15+00:00
 a2c5495 | Task 95 | refactored memory-cli to use yargs; added dependency and updated lockfile; recorded failing lint/test/backtest logs | TASKS.md,logs/block-95.txt,package-lock.json,package.json,scripts/memory-cli.ts,task_queue.json | 2025-06-06T17:26:36+00:00
 fe24dba | Task <unknown> | unified cache TTL constant across API routes; added constants.ts and updated README. Tests failing due to prior issues | README.md src/lib/constants.ts src/app/api/bb-width/route.ts src/app/api/economic-events/route.ts src/app/api/ema-trend/route.ts src/app/api/funding-schedule/route.ts src/app/api/higher-candles/route.ts src/app/api/memory/route.ts src/app/api/open-interest/route.ts | 2025-06-09T14:29:59Z
+2d90883 | docs(start): mention dev-deps in kickoff guide | CODEX_START.md | 2025-06-09T14:42:33Z


### PR DESCRIPTION
## Summary
- highlight running `dev-deps` when `node_modules` is missing in the Codex kickoff instructions
- record mem-042

## Testing
- `npm run lint` *(fails: npm not found)*
- `npm run test` *(fails: npm not found)*
- `npm run backtest` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846f1b1b55083238854c93ebe15df2e