### PR TITLE
Update workflow docs with single-commit reminder

### DIFF
--- a/CODEX_START.md
+++ b/CODEX_START.md
@@ -31,6 +31,7 @@ Limit commit summaries in both the commit body and context snapshot to about **3
 2. Run `npm run dev-deps` if `node_modules` is missing before starting.
 3. Confirm AGENTS.md, memory.log and context.snapshot.md are loaded.
 4. Execute the next task from TASKS.md, committing with a clear message.
-5. Append the commit info to memory.log and context.snapshot.md.
+5. End the session after that single commit unless you are explicitly told to continue.
+6. Append the commit info to memory.log and context.snapshot.md.
 
 Following these steps preserves context between sessions and keeps token usage manageable.

--- a/docs/CODEX_WORKFLOW.md
+++ b/docs/CODEX_WORKFLOW.md
@@ -12,6 +12,8 @@ This document distills the key points from `CODEX-INSTRUCTIONS.txt` for working 
 - Keep `task_queue.json` synchronized with `TASKS.md` so automation can resume accurately.
 - Run `npm ci` once at the start of a session. Subsequent commits can reuse the installed `node_modules`.
 
+Each session ends after a single commit unless instructions explicitly allow more work. Start a new session to continue with the next commit.
+
 ## Keeping the Workspace Alive
 
 Codex runs in an ephemeral container. To avoid losing context:

--- a/logs/block-docs-memory-rule.txt
+++ b/logs/block-docs-memory-rule.txt
@@ -1,0 +1,1 @@
+Lint, test and backtest failed while documenting single-commit rule.


### PR DESCRIPTION
## Summary
- clarify one-commit rule in docs/CODEX_WORKFLOW.md
- mention single-commit rule near recap checklist in CODEX_START.md
- log failing tests for docs update

## Testing
- `npm run lint` *(fails: Unexpected any, no-unused-vars, etc.)*
- `npm run test` *(fails: many failing tests, unresolved modules, timeout)*
- `npm run backtest` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_b_68470f6daad88323a2a56aee2362e987