### PR TITLE
docs(memory): correct mem-036 timestamp

### DIFF
--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -143,7 +143,7 @@
 - Commit SHA: e8934ed
 - Summary: added .eslintrc.json from setup snippet and updated lint script to load it; documented interplay with eslint.config.js in README.
 - Next Goal: create memory CLI with rotate, snapshot-rotate, status, grep and update-log
-### $(date -u '+%Y-%m-%d %H:%M UTC') | mem-036
+### 2025-06-05 18:24 UTC | mem-036
 - Commit SHA: b29338f
 - Summary: clarified Node 18 nvm usage in README, updated env check error and setup script to use npm ci, added Task 115 entry
 - Next Goal: create memory CLI with rotate, snapshot-rotate, status, grep and update-log
@@ -175,4 +175,8 @@
 ### 2025-06-09 17:00 UTC | mem-043
 - Commit SHA: 77c16db
 - Summary: emphasized minimal compute usage in AGENTS and CODEX_WORKFLOW; logged failing checks.
+- Next Goal: run npm ci only once in AutoTaskRunner
+### 2025-06-09 17:09 UTC | mem-044
+- Commit SHA: 0f00a3e
+- Summary: corrected mem-036 timestamp in context.snapshot.
 - Next Goal: run npm ci only once in AutoTaskRunner

--- a/memory.log
+++ b/memory.log
@@ -209,3 +209,4 @@ a2c5495 | Task 95 | refactored memory-cli to use yargs; added dependency and upd
 fe24dba | Task <unknown> | unified cache TTL constant across API routes; added constants.ts and updated README. Tests failing due to prior issues | README.md src/lib/constants.ts src/app/api/bb-width/route.ts src/app/api/economic-events/route.ts src/app/api/ema-trend/route.ts src/app/api/funding-schedule/route.ts src/app/api/higher-candles/route.ts src/app/api/memory/route.ts src/app/api/open-interest/route.ts | 2025-06-09T14:29:59Z
 2d90883 | docs(start): mention dev-deps in kickoff guide | CODEX_START.md | 2025-06-09T14:42:33Z
 77c16db | docs(policy): emphasize minimal compute | AGENTS.md, docs/CODEX_WORKFLOW.md, logs/block-docs-minimal-compute.txt | 2025-06-09T17:00:27+00:00
+0f00a3e | docs(memory): correct mem-036 timestamp | context.snapshot.md | 2025-06-09T17:09:29+00:00


### PR DESCRIPTION
## Summary
- fill in mem-036 timestamp with 2025-06-05 18:24 UTC
- record mem-044 entry

## Testing
- `npm run lint` *(fails: '@typescript-eslint/no-unused-vars', 'no-explicit-any', etc.)*
- `npm run test` *(fails to redefine property execSync, module errors)*
- `npm run backtest` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_b_684713ed9cb08323b7c7d6a41f6a97b0