### PR TITLE
Add Memory CLI usage docs

### DIFF
--- a/CODEX_START.md
+++ b/CODEX_START.md
@@ -20,6 +20,7 @@ Paste that block into the first message when launching Codex. The `npm run codex
 - **context.snapshot.md** – add a new `mem-XXX` section summarizing the commit (333 tokens max) and the next goal.
 
 Codex must read these files at the start of every run to rebuild context. Commit messages themselves serve as persistent memory, so keep them descriptive and follow the Conventional Commits format.
+For example `memory rotate` and other subcommands are documented in the [Memory CLI Usage](README.md#memory-cli-usage) section of the README.
 
 ## Token Guidance
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,28 @@ SNAP_ROTATE_LIMIT=150 \
 npm run mem-rotate && ts-node scripts/snapshot-rotate.ts
 ```
 
+## Memory CLI Usage
+
+The `memory` script consolidates all log-management commands.
+
+| Command | Example | Purpose |
+| ------- | ------- | ------- |
+| `rotate [limit]` | `npm run memory rotate 200` | Trim `memory.log` to the last N entries |
+| `snapshot-rotate [limit]` | `npm run memory snapshot-rotate 100` | Trim `context.snapshot.md` |
+| `status` | `npm run memory status` | Show the latest entry and next task |
+| `grep <pattern>` | `npm run memory grep "mem-042"` | Search memory files for a pattern |
+| `locate <hash|mem-id>` | `npm run memory locate 0f00a3e` | Display snapshot block for a commit |
+| `update-log` | `npm run memory update-log` | Refresh `memory.log` from git history |
+| `list [N]` | `npm run memory list 5` | Show the last N entries |
+| `diff` | `npm run memory diff` | List commits missing from `memory.log` |
+| `json` | `npm run memory json > memory.json` | Export `memory.log` to JSON |
+| `clean-locks` | `npm run memory clean-locks` | Remove stale `.lock` files |
+| `check` | `npm run memory check` | Verify memory file consistency |
+| `restore <backup> <memory|snapshot>` | `npm run memory restore backup.tar.gz memory` | Restore from backup |
+| `rebuild [path]` | `npm run memory rebuild` | Rebuild logs from git history |
+| `sync <branch>` | `npm run memory sync origin/main` | Merge memory log from another branch |
+| `snapshot-update` | `npm run memory snapshot-update` | Append last commit summary to snapshot |
+
 ## Using Codex with Persistent Memory
 
 See [CODEX_START.md](CODEX_START.md) for full instructions on launching Codex with persistent memory.

--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -180,3 +180,8 @@
 - Commit SHA: 0f00a3e
 - Summary: corrected mem-036 timestamp in context.snapshot.
 - Next Goal: run npm ci only once in AutoTaskRunner
+
+### 2025-06-09 17:46 UTC | mem-045
+- Commit SHA: 2dd7c5b
+- Summary: added Memory CLI Usage section in README with examples; cross-linked from CODEX_START.
+- Next Goal: run npm ci only once in AutoTaskRunner

--- a/memory.log
+++ b/memory.log
@@ -210,3 +210,4 @@ fe24dba | Task <unknown> | unified cache TTL constant across API routes; added c
 2d90883 | docs(start): mention dev-deps in kickoff guide | CODEX_START.md | 2025-06-09T14:42:33Z
 77c16db | docs(policy): emphasize minimal compute | AGENTS.md, docs/CODEX_WORKFLOW.md, logs/block-docs-minimal-compute.txt | 2025-06-09T17:00:27+00:00
 0f00a3e | docs(memory): correct mem-036 timestamp | context.snapshot.md | 2025-06-09T17:09:29+00:00
+2dd7c5b | docs(memory): add Memory CLI usage section | CODEX_START.md, README.md | 2025-06-09T17:46:56Z


### PR DESCRIPTION
## Summary
- document each memory CLI command in README with short examples
- link to the new section from CODEX_START.md
- record mem-045 for tracking

## Testing
- `npm run lint` *(fails: Unexpected any & other errors)*
- `npm run test` *(fails: cannot redefine property execSync, module resolution errors)*
- `npm run backtest` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_b_68471c0627308323b3079662b2003d6a