### PR TITLE
Add mem-status script alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Task 95: create memory CLI with rotate, snapshot-rotate, status, grep, update-lo
 | `npm run mem-check` | Verify memory hashes and snapshot blocks (auto after `mem-rotate`) |
 | `npm run mem-diff` | List commit hashes missing from `memory.log` |
 | `npm run memgrep` | Search `memory.log` and `context.snapshot.md` for a pattern |
+| `npm run mem-status` | Show last memory entry, next mem id and pending task |
 | `npm run clean-locks` | Remove stale `.lock` files across the repository |
 | `ts-node scripts/update-snapshot.ts` | Append commit summary and next task to `context.snapshot.md` |
 | `ts-node scripts/rebuild-memory.ts [path]` | Rebuild `memory.log` and `context.snapshot.md` from git history |

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "auto": "node scripts/try-cmd.js ts-node src/scripts/autoTaskRunner.ts",
     "memlog": "ts-node scripts/update-memory-log.ts",
     "mem-rotate": "ts-node scripts/mem-rotate.ts",
+    "mem-status": "ts-node scripts/mem-status.ts",
     "snap-rotate": "ts-node scripts/snapshot-rotate.ts",
     "mem-check": "ts-node scripts/memory-check.ts",
     "memory": "ts-node scripts/memory-cli.ts",


### PR DESCRIPTION
## Summary
- add mem-status npm script for memory file overview
- document the alias in the Automation Scripts table

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*
- `npm run test` *(fails: multiple Jest test failures)*
- `npm run backtest` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_b_68471c05df188323ad5d41f1dceeb77a