### PR TITLE
Fix duplicate mem-status script

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "mem-status": "ts-node scripts/mem-status.ts",
     "snap-rotate": "ts-node scripts/snapshot-rotate.ts",
     "mem-check": "ts-node scripts/memory-check.ts",
-    "mem-status": "ts-node scripts/mem-status.ts",
     "memory": "ts-node scripts/memory-cli.ts",
     "memgrep": "ts-node scripts/memgrep.ts",
     "clean-locks": "ts-node scripts/clean-locks.ts",


### PR DESCRIPTION
## Summary
- remove duplicate `mem-status` npm script in package.json

## Testing
- `npm run lint` *(fails: 65 errors)*
- `npm run test` *(fails: 45 failed, 41 passed)*

------
https://chatgpt.com/codex/tasks/task_b_68473323384c8323bde0d85b7c9c9e16