### PR TITLE
feat(ci): enforce TASKS queue validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           node-version: '18'
           cache: 'npm'
       - run: npm run dev-deps
+      - run: npm run validate-tasks
       - run: npm run lint
       - run: npm run test
       - run: npm run backtest

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,6 @@
 #!/bin/sh
 MEM_ROTATE_LIMIT=300 npm run mem-rotate >/dev/null 2>&1
+npm run validate-tasks || true
 npm run lint || true
 npm run test || true
 npm run mem-check || true

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Task 95: create memory CLI with rotate, snapshot-rotate, status, grep, update-lo
 | `npm run mem-diff` | List commit hashes missing from `memory.log` |
 | `npm run memgrep` | Search `memory.log` and `context.snapshot.md` for a pattern |
 | `npm run mem-status` | Show last memory entry, next mem id and pending task |
+| `npm run validate-tasks` | Ensure TASKS.md matches task_queue.json |
 | `npm run clean-locks` | Remove stale `.lock` files across the repository |
 | `ts-node scripts/update-snapshot.ts` | Append commit summary and next task to `context.snapshot.md` |
 | `ts-node scripts/rebuild-memory.ts [path]` | Rebuild `memory.log` and `context.snapshot.md` from git history |

--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -184,3 +184,15 @@
 - Commit SHA: db90cd3
 - Summary: added PR memory status workflow that installs dev deps, runs mem-status and comments output on pull requests; exposed mem-status npm script. Lint, test and backtest failing so logged in block-pr-memory-status.txt.
 - Next Goal: run npm ci only once in AutoTaskRunner
+### 2025-06-09 19:36 UTC | mem-046
+- Commit SHA: ea781f6
+- Summary: added validate-tasks script, integrated into pre-commit and CI, documented in README, created unit test; lint, test, backtest failing.
+- Next Goal: run npm ci only once in AutoTaskRunner
+### 2025-06-09 19:38 UTC | mem-047
+- Commit SHA: 9b5b4fc
+- Summary: corrected mem-046 entry after commit to keep memory files in sync.
+- Next Goal: run npm ci only once in AutoTaskRunner
+### 2025-06-09 19:39 UTC | mem-048
+- Commit SHA: aeedee3
+- Summary: recorded mem-047 entry for fix commit to keep history consistent.
+- Next Goal: run npm ci only once in AutoTaskRunner

--- a/memory.log
+++ b/memory.log
@@ -211,3 +211,7 @@ fe24dba | Task <unknown> | unified cache TTL constant across API routes; added c
 77c16db | docs(policy): emphasize minimal compute | AGENTS.md, docs/CODEX_WORKFLOW.md, logs/block-docs-minimal-compute.txt | 2025-06-09T17:00:27+00:00
 0f00a3e | docs(memory): correct mem-036 timestamp | context.snapshot.md | 2025-06-09T17:09:29+00:00
 db90cd3 | feat(ci): add PR memory status workflow | .github/workflows/pr-memory-status.yml logs/block-pr-memory-status.txt package.json | 2025-06-09T17:44:09Z
+ea781f6 | feat(ci): enforce TASKS queue validation | .github/workflows/ci.yml,.husky/pre-commit,README.md,package.json,src/__tests__/validate-tasks.test.ts | 2025-06-09T19:36:24+00:00
+9b5b4fc | fix(memory): correct mem-046 hash | context.snapshot.md,memory.log | 2025-06-09T19:38:22+00:00
+aeedee3 | chore(memory): record mem-047 | context.snapshot.md,memory.log | 2025-06-09T19:39:01+00:00
+0ec34a1 | chore(memory): record mem-048 | context.snapshot.md,memory.log | 2025-06-09T19:39:43+00:00

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "memlog": "ts-node scripts/update-memory-log.ts",
     "mem-rotate": "ts-node scripts/mem-rotate.ts",
     "mem-status": "ts-node scripts/mem-status.ts",
+    "validate-tasks": "ts-node scripts/validate-tasks.ts",
     "snap-rotate": "ts-node scripts/snapshot-rotate.ts",
     "mem-check": "ts-node scripts/memory-check.ts",
     "memory": "ts-node scripts/memory-cli.ts",

--- a/src/__tests__/validate-tasks.test.ts
+++ b/src/__tests__/validate-tasks.test.ts
@@ -1,0 +1,58 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { repoRoot } from '../../scripts/memory-utils';
+
+function withFsMocks(paths: Record<string, string>, fn: () => void) {
+  const origExists = fs.existsSync;
+  const origRead = fs.readFileSync;
+  const existsMock = jest.spyOn(fs, 'existsSync').mockImplementation((p: any) => {
+    if (paths[p as string]) return origExists.call(fs, paths[p as string]);
+    return origExists.call(fs, p);
+  });
+  const readMock = jest
+    .spyOn(fs, 'readFileSync')
+    .mockImplementation((p: any, opt?: any) => {
+      if (paths[p as string]) p = paths[p as string];
+      return origRead.call(fs, p, opt);
+    });
+  try {
+    fn();
+  } finally {
+    existsMock.mockRestore();
+    readMock.mockRestore();
+  }
+}
+
+describe('validate-tasks', () => {
+  it('exits non-zero when statuses mismatch', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'valt-'));
+    const md = path.join(dir, 'TASKS.md');
+    const queue = path.join(dir, 'task_queue.json');
+    fs.writeFileSync(md, '- [ ] Task 1: test\n');
+    fs.writeFileSync(queue, JSON.stringify([{ id: 1, description: 'test', status: 'done' }], null, 2));
+
+    const exitMock = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => { throw new Error(String(code)); }) as any);
+    const errMock = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => {
+      withFsMocks(
+        {
+          [path.join(repoRoot, 'TASKS.md')]: md,
+          [path.join(repoRoot, 'task_queue.json')]: queue,
+        },
+        () => {
+          jest.isolateModules(() => {
+            require('../../scripts/validate-tasks.ts');
+          });
+        }
+      );
+    }).toThrow('1');
+
+    fs.rmSync(dir, { recursive: true, force: true });
+    errMock.mockRestore();
+    exitMock.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add validate-tasks npm script
- run validate-tasks in pre-commit and CI workflows
- document script in README
- test mismatch exit code
- record mem entries

## Testing
- `npm run lint` *(fails: eslint errors)*
- `npm run test` *(fails: jest failures)*
- `npm run backtest` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_b_6847362e34a88323b91e0fb6ead2fd72