### PR TITLE
Update AGENTS workflow for new ChatGPT tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,16 +60,17 @@ These roles operate sequentially within the `DevAgent` to keep automation predic
 
 1. **Single Commit (bootstrap, task or fix)**
    a. Validate & patch this file (`AGENTS.md`) and helper files so automation rules exist.
-   b. When working on a task, load `task_queue.json` and `TASKS.md` to choose the first entry with `status: "pending"`.
-   c. Implement that task or fix.
-   d. Ensure package scripts `lint`, `test`, `backtest` run. Run `npm ci` if `node_modules` are missing, then `npm run lint && npm run test && npm run backtest`.
-   e. Commit using **Conventional Commits** (`feat|fix|chore|docs|test(scope): …`).
-   f. Body = 333‑token summary → part A “What I did”, part B “What’s next”.
-   g. Append the same summary with metadata to `memory.log`.
-   h. Append a memory block to `context.snapshot.md` detailing the commit hash,
+   b. If the user supplies a new task in ChatGPT, append it to `TASKS.md` and `task_queue.json` with the next ID **before** starting work. Run `npm run validate-tasks` to keep both files in sync. The standard automation loop still applies—lint, test, backtest, commit and update memory files.
+   c. When working on a task, load `task_queue.json` and `TASKS.md` to choose the first entry with `status: "pending"`.
+   d. Implement that task or fix.
+   e. Ensure package scripts `lint`, `test`, `backtest` run. Run `npm ci` if `node_modules` are missing, then `npm run lint && npm run test && npm run backtest`.
+   f. Commit using **Conventional Commits** (`feat|fix|chore|docs|test(scope): …`).
+   g. Body = 333‑token summary → part A “What I did”, part B “What’s next”.
+   h. Append the same summary with metadata to `memory.log`.
+   i. Append a memory block to `context.snapshot.md` detailing the commit hash,
       timestamp and next goal.
-   i. Mark the task `done` in `task_queue.json` and check the box in `TASKS.md`.
-   j. Rebase → merge → delete branch.
+   j. Mark the task `done` in `task_queue.json` and check the box in `TASKS.md`.
+   k. Rebase → merge → delete branch.
 2. **HALT** – await next prompt.
 
 **Self‑Healing:** If lint/test/backtest fails, attempt one `fix(scope)` commit within the single session; if still red, write `/logs/block-<task>.txt` and stop.

--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -200,3 +200,13 @@
 - Commit SHA: 9b43879
 - Summary: introduced memory validation step in AutoTaskRunner and updated docs with test coverage.
 - Next Goal: run npm ci only once in AutoTaskRunner
+### 2025-06-10 12:23 UTC | mem-050
+- Commit SHA: 912dcc9
+- Summary: clarified AGENTS workflow for adding chat-generated tasks to TASKS.md and task_queue.json before starting work and to validate with validate-tasks. Mentioned that lint, test, backtest, commit and memory updates still apply. Logged failing scripts.
+- Next Goal: run npm ci only once in AutoTaskRunner
+
+### 2025-06-10 12:24 UTC | mem-051
+- Commit SHA: 0cf7d78
+- Summary: recorded mem-050 entry in memory files to keep history consistent.
+- Next Goal: run npm ci only once in AutoTaskRunner
+

--- a/logs/block-docs-tasks-sync.txt
+++ b/logs/block-docs-tasks-sync.txt
@@ -1,0 +1,126 @@
+
+> bitdash-firestudio@1.0.0 lint
+> ESLINT_USE_FLAT_CONFIG=false eslint -c .eslintrc.json "src/**/*.{ts,tsx,js,jsx}"
+
+
+/workspace/bitdashfirestudio/src/__tests__/autoTaskRunner.state.test.ts
+   80:11  error  'spawnMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+   81:11  error  'execMock' is assigned a value but never used    @typescript-eslint/no-unused-vars
+  111:11  error  'atomicMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  112:11  error  'lockMock' is assigned a value but never used    @typescript-eslint/no-unused-vars
+  114:11  error  'spawnMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  120:11  error  'execMock' is assigned a value but never used    @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/__tests__/memory-check.test.ts
+   46:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+   81:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  115:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  121:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  122:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  155:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  161:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  162:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  188:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  194:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  195:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  221:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  227:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  228:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  258:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  264:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  265:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  296:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  302:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  303:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  334:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  340:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  341:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/app/api/economic-events/route.ts
+  5:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/funding-schedule/route.ts
+  5:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/higher-candles/route.ts
+  9:19  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  9:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/open-interest/route.ts
+  5:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/prev-day/route.ts
+  19:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/page.tsx
+   45:15  error  'ComputedIndicators' is defined but never used  @typescript-eslint/no-unused-vars
+   46:15  error  'TradeSignal' is defined but never used         @typescript-eslint/no-unused-vars
+   73:25  error  '_t' is assigned a value but never used         @typescript-eslint/no-unused-vars
+   73:40  error  '_f' is assigned a value but never used         @typescript-eslint/no-unused-vars
+   73:49  error  '_s1' is assigned a value but never used        @typescript-eslint/no-unused-vars
+   73:59  error  '_s2' is assigned a value but never used        @typescript-eslint/no-unused-vars
+   73:69  error  '_d' is assigned a value but never used         @typescript-eslint/no-unused-vars
+   73:80  error  '_u' is assigned a value but never used         @typescript-eslint/no-unused-vars
+  279:41  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
+  280:41  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
+  652:11  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/agents/IndicatorEngine.ts
+  3:29  error  'IndicatorSet' is defined but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/lib/agents/TestingAgent.ts
+  16:10  error  '_msg' is defined but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/lib/agents/UIRenderer.ts
+  4:10  error  '_msg' is defined but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/lib/data/binanceCandles.ts
+  20:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/bybitOpenInterest.ts
+  11:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  13:37  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/coingecko.ts
+  20:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  36:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/economicEvents.ts
+   1:23  error  'FetchImportance' is defined but never used  @typescript-eslint/no-unused-vars
+  16:34  error  Unexpected any. Specify a different type     @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/fmp.ts
+  18:12  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  34:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  47:14  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  65:14  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/fundingSchedule.ts
+  11:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  13:37  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/fetchCache.ts
+  10:9  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/signals.ts
+  38:9  error  'now' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/scripts/autoTaskRunner.ts
+  29:10  error  Unexpected constant condition                    no-constant-condition
+  39:88  error  Unexpected any. Specify a different type         @typescript-eslint/no-explicit-any
+  58:5   error  Move function declaration to function body root  no-inner-declarations
+  80:5   error  Move function declaration to function body root  no-inner-declarations
+
+/workspace/bitdashfirestudio/src/types/agent.ts
+  1:35  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+✖ 69 problems (69 errors, 0 warnings)
+
+
+> bitdash-firestudio@1.0.0 test
+> jest
+
+
+> bitdash-firestudio@1.0.0 backtest
+> node --loader ts-node/esm scripts/backtest.ts
+

--- a/memory.log
+++ b/memory.log
@@ -216,3 +216,5 @@ ea781f6 | feat(ci): enforce TASKS queue validation | .github/workflows/ci.yml,.h
 aeedee3 | chore(memory): record mem-047 | context.snapshot.md,memory.log | 2025-06-09T19:39:01+00:00
 0ec34a1 | chore(memory): record mem-048 | context.snapshot.md,memory.log | 2025-06-09T19:39:43+00:00
 9b43879 | feat(auto): validate memory after task commit | README.md, src/scripts/autoTaskRunner.ts, src/__tests__/autoTaskRunner.state.test.ts | 2025-06-09T20:12:24Z
+912dcc9 | Task 0 | clarified AGENTS instructions to sync new ChatGPT tasks to TASKS.md and task_queue.json using validate-tasks; noted standard automation loop applies; logged failing lint/test/backtest. | AGENTS.md,logs/block-docs-tasks-sync.txt | 2025-06-10T12:23:36Z
+0cf7d78 | Task 0 | record mem-050 entry | context.snapshot.md,memory.log | 2025-06-10T12:24:14Z


### PR DESCRIPTION
## Summary
- clarify that new ChatGPT tasks must be added to `TASKS.md` and `task_queue.json` with the next ID
- note validate-tasks usage and that the normal automation loop still applies
- record memory entries for these docs updates

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*
- `npm run test` *(fails: multiple Jest failures)*
- `npm run backtest` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_b_68482263ea9483238cdac12a44bfc82b