### PR TITLE
Update CODEX_START for ad-hoc task workflow

### DIFF
--- a/CODEX_START.md
+++ b/CODEX_START.md
@@ -28,10 +28,11 @@ Limit commit summaries in both the commit body and context snapshot to about **3
 ## Recap
 
 1. Run `npm run codex` and paste the output block into ChatGPT.
-2. Run `npm run dev-deps` if `node_modules` is missing before starting.
-3. Confirm AGENTS.md, memory.log and context.snapshot.md are loaded.
-4. Execute the next task from TASKS.md, committing with a clear message.
-5. End the session after that single commit unless you are explicitly told to continue.
-6. Append the commit info to memory.log and context.snapshot.md.
+2. If you receive a new ad-hoc request, add it to `TASKS.md` and `task_queue.json` then run `npm run codex` again to print the refreshed context.
+3. Run `npm run dev-deps` if `node_modules` is missing before starting.
+4. Confirm AGENTS.md, memory.log and context.snapshot.md are loaded.
+5. Execute the next task from TASKS.md, committing with a clear message.
+6. End the session after that single commit unless you are explicitly told to continue.
+7. Append the commit info to memory.log and context.snapshot.md.
 
 Following these steps preserves context between sessions and keeps token usage manageable.

--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -210,3 +210,7 @@
 - Summary: recorded mem-050 entry in memory files to keep history consistent.
 - Next Goal: run npm ci only once in AutoTaskRunner
 
+### 2025-06-10 12:32 UTC | mem-052
+- Commit SHA: cb9cea9
+- Summary: updated kickoff guide to cover ad-hoc tasks workflow and logged failing lint/test/backtest results.
+- Next Goal: run npm ci only once in AutoTaskRunner

--- a/logs/block-docs-ad-hoc-tasks.txt
+++ b/logs/block-docs-ad-hoc-tasks.txt
@@ -1,0 +1,126 @@
+
+> bitdash-firestudio@1.0.0 lint
+> ESLINT_USE_FLAT_CONFIG=false eslint -c .eslintrc.json "src/**/*.{ts,tsx,js,jsx}"
+
+
+/workspace/bitdashfirestudio/src/__tests__/autoTaskRunner.state.test.ts
+   80:11  error  'spawnMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+   81:11  error  'execMock' is assigned a value but never used    @typescript-eslint/no-unused-vars
+  111:11  error  'atomicMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  112:11  error  'lockMock' is assigned a value but never used    @typescript-eslint/no-unused-vars
+  114:11  error  'spawnMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  120:11  error  'execMock' is assigned a value but never used    @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/__tests__/memory-check.test.ts
+   46:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+   81:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  115:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  121:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  122:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  155:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  161:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  162:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  188:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  194:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  195:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  221:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  227:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  228:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  258:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  264:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  265:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  296:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  302:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  303:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  334:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  340:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  341:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/app/api/economic-events/route.ts
+  5:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/funding-schedule/route.ts
+  5:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/higher-candles/route.ts
+  9:19  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  9:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/open-interest/route.ts
+  5:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/prev-day/route.ts
+  19:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/page.tsx
+   45:15  error  'ComputedIndicators' is defined but never used  @typescript-eslint/no-unused-vars
+   46:15  error  'TradeSignal' is defined but never used         @typescript-eslint/no-unused-vars
+   73:25  error  '_t' is assigned a value but never used         @typescript-eslint/no-unused-vars
+   73:40  error  '_f' is assigned a value but never used         @typescript-eslint/no-unused-vars
+   73:49  error  '_s1' is assigned a value but never used        @typescript-eslint/no-unused-vars
+   73:59  error  '_s2' is assigned a value but never used        @typescript-eslint/no-unused-vars
+   73:69  error  '_d' is assigned a value but never used         @typescript-eslint/no-unused-vars
+   73:80  error  '_u' is assigned a value but never used         @typescript-eslint/no-unused-vars
+  279:41  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
+  280:41  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
+  652:11  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/agents/IndicatorEngine.ts
+  3:29  error  'IndicatorSet' is defined but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/lib/agents/TestingAgent.ts
+  16:10  error  '_msg' is defined but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/lib/agents/UIRenderer.ts
+  4:10  error  '_msg' is defined but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/lib/data/binanceCandles.ts
+  20:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/bybitOpenInterest.ts
+  11:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  13:37  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/coingecko.ts
+  20:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  36:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/economicEvents.ts
+   1:23  error  'FetchImportance' is defined but never used  @typescript-eslint/no-unused-vars
+  16:34  error  Unexpected any. Specify a different type     @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/fmp.ts
+  18:12  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  34:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  47:14  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  65:14  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/fundingSchedule.ts
+  11:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  13:37  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/fetchCache.ts
+  10:9  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/signals.ts
+  38:9  error  'now' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/scripts/autoTaskRunner.ts
+  29:10  error  Unexpected constant condition                    no-constant-condition
+  39:88  error  Unexpected any. Specify a different type         @typescript-eslint/no-explicit-any
+  58:5   error  Move function declaration to function body root  no-inner-declarations
+  80:5   error  Move function declaration to function body root  no-inner-declarations
+
+/workspace/bitdashfirestudio/src/types/agent.ts
+  1:35  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+✖ 69 problems (69 errors, 0 warnings)
+
+
+> bitdash-firestudio@1.0.0 test
+> jest
+
+
+> bitdash-firestudio@1.0.0 backtest
+> node --loader ts-node/esm scripts/backtest.ts
+

--- a/memory.log
+++ b/memory.log
@@ -218,3 +218,6 @@ aeedee3 | chore(memory): record mem-047 | context.snapshot.md,memory.log | 2025-
 9b43879 | feat(auto): validate memory after task commit | README.md, src/scripts/autoTaskRunner.ts, src/__tests__/autoTaskRunner.state.test.ts | 2025-06-09T20:12:24Z
 912dcc9 | Task 0 | clarified AGENTS instructions to sync new ChatGPT tasks to TASKS.md and task_queue.json using validate-tasks; noted standard automation loop applies; logged failing lint/test/backtest. | AGENTS.md,logs/block-docs-tasks-sync.txt | 2025-06-10T12:23:36Z
 0cf7d78 | Task 0 | record mem-050 entry | context.snapshot.md,memory.log | 2025-06-10T12:24:14Z
+cb9cea9 | docs(start): document ad-hoc task workflow | CODEX_START.md,logs/block-docs-ad-hoc-tasks.txt | 2025-06-10T12:31:59Z
+f3dfe22 | chore(memory): record mem-052 | context.snapshot.md,memory.log | 2025-06-10T12:32:26Z
+11f9b02 | chore(memory): append mem-052 entry | memory.log | 2025-06-10T12:33:01Z


### PR DESCRIPTION
## Summary
- document how to process ad-hoc tasks in CODEX_START
- record mem-052 entry for the documentation update
- update memory log
- logs for failing lint/test/backtest

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars, etc.)*
- `npm run test` *(fails: TypeError: Cannot redefine property: execSync, etc.)*
- `npm run backtest` *(fails: Error [ERR_REQUIRE_CYCLE_MODULE]: Cannot require() ES Module)*

------
https://chatgpt.com/codex/tasks/task_b_684824bdb4fc83239739ab811d53aa55