### PR TITLE
Task 105: add archive-memory docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,14 @@ npm run mem-rotate   # prune memory.log
 npm run snap-rotate  # prune context.snapshot.md
 ```
 
+### Manual Archival
+
+Use this command to stash the current memory files before resetting them:
+
+```bash
+npm run archive-memory  # moves memory.log and snapshot to ./logs/archive/
+```
+
 A weekly GitHub workflow automatically runs `mem-rotate` and `clean-locks` to push the
 latest trimmed logs. Set `MEM_PATH` and `SNAPSHOT_PATH` if your memory files live elsewhere and
 adjust `MEM_ROTATE_LIMIT` and `SNAP_ROTATE_LIMIT` to control the number of retained entries.

--- a/TASKS.md
+++ b/TASKS.md
@@ -69,6 +69,7 @@ All tasks live in `task_queue.json` as `{ "id": number, "description": string, "
 - [x] Task 102: rewrite codex_context.sh with concise git/sed/jq and add test
 - [x] Task 103: check COMMIT_EDITMSG for '^Task [0-9]+:' in pre-commit and abort if missing
 - [x] Task 104: merge memory scripts into update-memory.ts with mem-update command and tests
+- [x] Task 105: add archive-memory script and docs
 
 
 ### Bitcoin Dashboard

--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -245,3 +245,7 @@
 - Commit SHA: d01d08f
 - Summary: chore(tasks): mark Task 104 done
 - Next Goal: run npm ci only once in autoTaskRunner loop
+### 2025-06-10 14:01 UTC | mem-060
+- Commit SHA: 9f15b1a510e50d19983f9304c7892b6767304a1c
+- Summary: Task 105 added archive-memory script and docs
+- Next Goal: run npm ci only once in autoTaskRunner loop

--- a/docs/SETUP_QUICKSTART.md
+++ b/docs/SETUP_QUICKSTART.md
@@ -6,5 +6,6 @@ Follow these steps to get the project running locally.
 2. Copy `.env.example` to `.env.local` and adjust settings as needed.
 3. Run `npm run lint && npm run test && npm run backtest` to verify the environment.
 4. Start the development server with `npm run dev`.
+5. Optionally run `npm run archive-memory` to back up memory logs.
 
 Refer to `AGENTS.md` for automation details and `README.md` for full documentation.

--- a/memory.log
+++ b/memory.log
@@ -232,3 +232,4 @@ ef94da3 | chore(memory): record Task 103 completion | TASKS.md, context.snapshot
 b8d36c2 | chore(memory): log mem-057 hash | memory.log | 2025-06-10T13:24:45Z
 69806de | Task 104: add mem-update command and tests | TASKS.md, package.json, scripts/setup-hooks.sh, src/__tests__/update-memory.test.ts, task_queue.json | 2025-06-10T13:41:28Z
 d01d08f | chore(tasks): mark Task 104 done | TASKS.md, task_queue.json | 2025-06-10T13:42:14Z
+9f15b1a510e50d19983f9304c7892b6767304a1c | Task 105 | add archive-memory script and docs | README.md,docs/SETUP_QUICKSTART.md,package.json,scripts/archive-memory.ts,TASKS.md,task_queue.json | 2025-06-10T14:01:19+00:00

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "mem-check": "ts-node scripts/memory-check.ts",
     "mem-update": "node --loader ts-node/esm scripts/update-memory.ts",
     "memory": "ts-node scripts/memory-cli.ts",
+    "archive-memory": "ts-node scripts/archive-memory.ts",
     "memgrep": "ts-node scripts/memgrep.ts",
     "clean-locks": "ts-node scripts/clean-locks.ts",
     "codex": "bash ./scripts/codex_context.sh",

--- a/scripts/archive-memory.ts
+++ b/scripts/archive-memory.ts
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import path from 'path';
+import { repoRoot, memPath, snapshotPath, withFileLock } from './memory-utils';
+
+const archiveDir = path.join(repoRoot, 'logs', 'archive');
+fs.mkdirSync(archiveDir, { recursive: true });
+const ts = new Date().toISOString().replace(/[:]/g, '-');
+
+function move(src: string, name: string) {
+  if (!fs.existsSync(src)) {
+    console.log(`${name} not found`);
+    return;
+  }
+  const dest = path.join(archiveDir, `${name}.${ts}`);
+  withFileLock(src, () => {
+    fs.renameSync(src, dest);
+  });
+  console.log(`Archived ${name} to ${dest}`);
+}
+
+move(memPath, 'memory.log');
+move(snapshotPath, 'context.snapshot.md');

--- a/task_queue.json
+++ b/task_queue.json
@@ -438,5 +438,10 @@
     "id": 104,
     "description": "merge memory scripts into update-memory.ts with mem-update command and tests",
     "status": "done"
+  },
+  {
+    "id": 105,
+    "description": "add archive-memory script and docs",
+    "status": "done"
   }
 ]


### PR DESCRIPTION
## Summary
- document new `archive-memory` script for rotating memory files
- implement archive script that moves memory files into `logs/archive`
- reference the archival command in setup guide
- track Task 105 in TASKS and `task_queue.json`
- record `mem-060` entry

## Testing
- `npm run lint` *(fails: no-unused-vars, no-explicit-any, etc.)*
- `npm run test` *(fails: multiple unit test errors)*
- `npm run backtest` *(fails: ERR_REQUIRE_CYCLE_MODULE)*
- `npm run validate-tasks` *(fails: Unknown file extension .ts)*

------
https://chatgpt.com/codex/tasks/task_b_684839a2e9708323bee6d94a3d2414cf