### PR TITLE
Add tasks 106-109 for workflow cleanup

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -71,6 +71,11 @@ All tasks live in `task_queue.json` as `{ "id": number, "description": string, "
 - [x] Task 104: merge memory scripts into update-memory.ts with mem-update command and tests
 - [x] Task 105: add archive-memory script and docs
 
+- [ ] Task 106: remove task_queue.json; autoTaskRunner reads TASKS.md; update docs
+- [ ] Task 107: rotate memory.log in update-memory.ts; drop pre-commit rotation
+- [ ] Task 108: delete obsolete memory scripts from scripts/ and package.json
+- [ ] Task 109: define single workflow entry; update README, AGENTS, CODEX_START
+
 
 ### Bitcoin Dashboard
 

--- a/task_queue.json
+++ b/task_queue.json
@@ -443,5 +443,25 @@
     "id": 105,
     "description": "add archive-memory script and docs",
     "status": "done"
+  },
+  {
+    "id": 106,
+    "description": "remove task_queue.json; autoTaskRunner reads TASKS.md; update docs",
+    "status": "pending"
+  },
+  {
+    "id": 107,
+    "description": "rotate memory.log in update-memory.ts; drop pre-commit rotation",
+    "status": "pending"
+  },
+  {
+    "id": 108,
+    "description": "delete obsolete memory scripts from scripts/ and package.json",
+    "status": "pending"
+  },
+  {
+    "id": 109,
+    "description": "define single workflow entry; update README, AGENTS, CODEX_START",
+    "status": "pending"
   }
 ]


### PR DESCRIPTION
## Summary
- add tasks 106-109 per analysis recommendations
- queue up corresponding entries in task_queue.json

## Testing
- `npm run dev-deps`
- `npm run validate-tasks` *(fails: Unknown file extension .ts)*

------
https://chatgpt.com/codex/tasks/task_b_68483c432bdc8323a1366ba9317e81da