### PR TITLE
Task 107: rotate memory via post-commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,13 @@ See `docs/CODEX_WORKFLOW.md` for tips on using the Codex agent effectively.
 4. Commit messages must start with `Task <number>:`. The `commit-msg` hook runs
    `commitlint` to verify this format.
 5. A pre-commit hook greps `.git/COMMIT_EDITMSG` for `^Task [0-9]+:` and aborts
-   if the pattern is missing before running lint, tests and memory checks.
-6. After each commit a single `post-commit` hook runs `node --loader ts-node/esm scripts/update-memory.ts`.
+   if the pattern is missing before running lint, tests and memory checks. This
+   hook **does not** modify or rotate memory files.
+6. After each commit a single `post-commit` hook runs
+   `node --loader ts-node/esm scripts/update-memory.ts`.
    This script appends the commit to `memory.log`, updates `context.snapshot.md`,
-   rotates the log to 300 lines and validates memory consistency.
+   rotates the log to 300 lines and validates memory consistency. Rotation only
+   happens here, never during pre-commit.
 7. When resuming after a break, tail the end of `memory.log` to review recent commits.
 8. Test and backtest outputs are logged in `logs/`.
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -61,7 +61,7 @@ Each task below is prefixed with `Task <id>` and tracked directly in this file.
 - [x] Task 95: consolidate memory scripts into memory-cli with yargs
 - [x] Task 96: delete commit.log and update docs, tests, workflows
 - [ ] Task 97: run npm ci only once in autoTaskRunner loop
-- [ ] Task 98: rotate memory.log to 300 lines via pre-commit
+- [x] Task 98: rotate memory.log to 300 lines via pre-commit (obsolete)
 - [ ] Task 99: cache dev dependencies with dev-deps script and CI caching
 - [ ] Task 100: create setup-quickstart guide linked in README and AGENTS
 - [x] Task 101: unify memory update hook with update-memory.ts script

--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -253,4 +253,7 @@
 ### 2025-06-10 14:27 UTC | mem-061
 - Commit SHA: d68850c
 - Summary: removed task_queue.json workflow, docs and validation; scripts updated.
-- Next Goal: rotate memory.log in update-memory.ts
+### 2025-06-10 14:35 UTC | mem-062
+- Commit SHA: 8aecb6e
+- Summary: rotate memory in post-commit; docs clarify pre-commit does not modify memory; Task 98 marked obsolete
+- Next Goal: run npm ci only once in autoTaskRunner loop

--- a/memory.log
+++ b/memory.log
@@ -234,3 +234,4 @@ b8d36c2 | chore(memory): log mem-057 hash | memory.log | 2025-06-10T13:24:45Z
 d01d08f | chore(tasks): mark Task 104 done | TASKS.md, task_queue.json | 2025-06-10T13:42:14Z
 9f15b1a510e50d19983f9304c7892b6767304a1c | Task 105 | add archive-memory script and docs | README.md,docs/SETUP_QUICKSTART.md,package.json,scripts/archive-memory.ts,TASKS.md,task_queue.json | 2025-06-10T14:01:19+00:00
 d68850c5adc36fa6d8991525ce6e676ed92c42e5 | Task 106 | remove task queue and docs | .github/workflows/ci.yml,.husky/pre-commit,AGENTS.md,CODEX_START.md,README.md,TASKS.md,docs/CODEX_WORKFLOW.md,package.json,scripts/update-memory.ts,src/__tests__/update-memory.test.ts | 2025-06-10T14:27:34Z
+8aecb6e | Task 107: rotate memory in post-commit | README.md,TASKS.md,scripts/update-memory.ts | 2025-06-10T14:35:26Z

--- a/scripts/update-memory.ts
+++ b/scripts/update-memory.ts
@@ -53,6 +53,7 @@ function main() {
   updateSnapshot();
   const id = currentTaskId();
   if (id !== null) markTaskDone(id);
+  // rotate memory.log on every commit
   run('scripts/mem-rotate.ts');
   run('scripts/memory-check.ts');
 }


### PR DESCRIPTION
## Summary
- mark Task 98 obsolete
- clarify README about memory rotation occurring only after commit
- note pre-commit does not modify memory files
- ensure update-memory.ts rotates memory.log
- record mem-062 entry

## Testing
- `npm run lint` *(fails: no-unused-vars & explicit-any)*
- `npm run test` *(fails: tests unable to redefine spawnSync/execSync; module errors)*
- `npm run backtest` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_b_6848411efa588323ac0b220c441fd77f