### PR TITLE
Task 108: remove obsolete wrappers

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -72,7 +72,7 @@ Each task below is prefixed with `Task <id>` and tracked directly in this file.
 
 - [ ] Task 106: remove task_queue.json; autoTaskRunner reads TASKS.md; update docs
 - [ ] Task 107: rotate memory.log in update-memory.ts; drop pre-commit rotation
-- [ ] Task 108: delete obsolete memory scripts from scripts/ and package.json
+- [x] Task 108: delete obsolete memory scripts from scripts/ and package.json
 - [ ] Task 109: define single workflow entry; update README, AGENTS, CODEX_START
 
 

--- a/app.md
+++ b/app.md
@@ -52,7 +52,7 @@ The application uses a file-based persistent memory system. Key files and their 
 
 ### 2.2. Automation (`autoTaskRunner`)
 
-*   **Core Script:** `src/scripts/autoTaskRunner.ts` (executed via `scripts/autoTaskRunner.js`).
+*   **Core Script:** `src/scripts/autoTaskRunner.ts`.
 *   **Workflow:**
     1.  Reads `TASKS.md` to find the next pending task (line starting with `- [ ]`).
     2.  Marks the task as complete (`- [x]`) in `TASKS.md`.
@@ -105,7 +105,6 @@ The application uses a file-based persistent memory system. Key files and their 
     *   `memory-check.ts`: Validates memory files.
     *   `mem-rotate.ts`: Rotates `memory.log`.
     *   `commitlog.ts`: Creates `logs/commit.log`.
-    *   `autoTaskRunner.js`: Node.js wrapper to run the TypeScript auto-runner.
 *   **`src/scripts/`:** Contains more complex TypeScript logic, currently housing the main `autoTaskRunner.ts`.
 *   **`logs/`:** Directory for various log files generated during operation.
 *   **Other `src/` directories (e.g., `src/app/`, `src/components/`, `src/lib/`):** Appear to be related to a Next.js application, which may or may not be directly integrated with the memory/automation system described here. This document primarily focuses on the memory and automation aspects found in `scripts/` and `src/scripts/`.
@@ -144,7 +143,7 @@ The application uses a file-based persistent memory system. Key files and their 
 
 *   **Automated Task Runner:**
     ```bash
-    node scripts/autoTaskRunner.js
+    npm run auto
     ```
     This will start processing tasks from `TASKS.md`.
 

--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -257,3 +257,7 @@
 - Commit SHA: 8aecb6e
 - Summary: rotate memory in post-commit; docs clarify pre-commit does not modify memory; Task 98 marked obsolete
 - Next Goal: run npm ci only once in autoTaskRunner loop
+### 2025-06-10 15:16 UTC | mem-063
+- Commit SHA: 40f26cb
+- Summary: removed obsolete autoTaskRunner.js and append-memory.sh wrappers; docs updated to run TypeScript directly. Lint, test and backtest still failing; results in logs/block-108.txt.
+- Next Goal: run npm ci only once in autoTaskRunner loop

--- a/logs/block-108.txt
+++ b/logs/block-108.txt
@@ -1,0 +1,128 @@
+
+> bitdash-firestudio@1.0.0 lint
+> ESLINT_USE_FLAT_CONFIG=false eslint -c .eslintrc.json "src/**/*.{ts,tsx,js,jsx}"
+
+
+/workspace/bitdashfirestudio/src/__tests__/autoTaskRunner.state.test.ts
+   80:11  error  'spawnMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+   81:11  error  'execMock' is assigned a value but never used    @typescript-eslint/no-unused-vars
+  111:11  error  'atomicMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  112:11  error  'lockMock' is assigned a value but never used    @typescript-eslint/no-unused-vars
+  114:11  error  'spawnMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  120:11  error  'execMock' is assigned a value but never used    @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/__tests__/memory-check.test.ts
+   46:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+   81:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  115:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  121:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  122:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  155:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  161:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  162:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  188:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  194:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  195:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  221:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  227:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  228:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  258:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  264:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  265:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  296:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  302:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  303:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  334:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  340:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  341:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/app/api/economic-events/route.ts
+  5:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/funding-schedule/route.ts
+  5:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/higher-candles/route.ts
+  9:19  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  9:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/open-interest/route.ts
+  5:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/prev-day/route.ts
+  19:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/page.tsx
+   45:15  error  'ComputedIndicators' is defined but never used  @typescript-eslint/no-unused-vars
+   46:15  error  'TradeSignal' is defined but never used         @typescript-eslint/no-unused-vars
+   73:25  error  '_t' is assigned a value but never used         @typescript-eslint/no-unused-vars
+   73:40  error  '_f' is assigned a value but never used         @typescript-eslint/no-unused-vars
+   73:49  error  '_s1' is assigned a value but never used        @typescript-eslint/no-unused-vars
+   73:59  error  '_s2' is assigned a value but never used        @typescript-eslint/no-unused-vars
+   73:69  error  '_d' is assigned a value but never used         @typescript-eslint/no-unused-vars
+   73:80  error  '_u' is assigned a value but never used         @typescript-eslint/no-unused-vars
+  279:41  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
+  280:41  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
+  652:11  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/agents/IndicatorEngine.ts
+  3:29  error  'IndicatorSet' is defined but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/lib/agents/TestingAgent.ts
+  16:10  error  '_msg' is defined but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/lib/agents/UIRenderer.ts
+  4:10  error  '_msg' is defined but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/lib/data/binanceCandles.ts
+  20:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/bybitOpenInterest.ts
+  11:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  13:37  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/coingecko.ts
+  20:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  36:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/economicEvents.ts
+   1:23  error  'FetchImportance' is defined but never used  @typescript-eslint/no-unused-vars
+  16:34  error  Unexpected any. Specify a different type     @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/fmp.ts
+  18:12  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  34:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  47:14  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  65:14  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/fundingSchedule.ts
+  11:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  13:37  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/fetchCache.ts
+  10:9  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/signals.ts
+  38:9  error  'now' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/scripts/autoTaskRunner.ts
+  29:10  error  Unexpected constant condition                    no-constant-condition
+  39:88  error  Unexpected any. Specify a different type         @typescript-eslint/no-explicit-any
+  58:5   error  Move function declaration to function body root  no-inner-declarations
+  80:5   error  Move function declaration to function body root  no-inner-declarations
+
+/workspace/bitdashfirestudio/src/types/agent.ts
+  1:35  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+✖ 69 problems (69 errors, 0 warnings)
+
+\n===== TEST =====\n
+
+> bitdash-firestudio@1.0.0 test
+> jest
+
+\n===== BACKTEST =====\n
+
+> bitdash-firestudio@1.0.0 backtest
+> node --loader ts-node/esm scripts/backtest.ts
+

--- a/memory.log
+++ b/memory.log
@@ -235,3 +235,5 @@ d01d08f | chore(tasks): mark Task 104 done | TASKS.md, task_queue.json | 2025-06
 9f15b1a510e50d19983f9304c7892b6767304a1c | Task 105 | add archive-memory script and docs | README.md,docs/SETUP_QUICKSTART.md,package.json,scripts/archive-memory.ts,TASKS.md,task_queue.json | 2025-06-10T14:01:19+00:00
 d68850c5adc36fa6d8991525ce6e676ed92c42e5 | Task 106 | remove task queue and docs | .github/workflows/ci.yml,.husky/pre-commit,AGENTS.md,CODEX_START.md,README.md,TASKS.md,docs/CODEX_WORKFLOW.md,package.json,scripts/update-memory.ts,src/__tests__/update-memory.test.ts | 2025-06-10T14:27:34Z
 8aecb6e | Task 107: rotate memory in post-commit | README.md,TASKS.md,scripts/update-memory.ts | 2025-06-10T14:35:26Z
+40f26cb | Task 108 | removed autoTaskRunner.js and append-memory.sh; docs now use ts scripts; failing lint/test/backtest logged | app.md scripts/append-memory.sh scripts/autoTaskRunner.js logs/block-108.txt | 2025-06-10T15:15:57Z
+3346629 | chore | record mem-063 entry | context.snapshot.md,TASKS.md,memory.log | 2025-06-10T15:16:32Z

--- a/scripts/append-memory.sh
+++ b/scripts/append-memory.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-DIR="$(cd "$(dirname "$0")" && pwd)"
-ts-node "$DIR/append-memory.ts" "$@"
-

--- a/scripts/autoTaskRunner.js
+++ b/scripts/autoTaskRunner.js
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-require('ts-node').register();
-require('../src/scripts/autoTaskRunner').runTasks();


### PR DESCRIPTION
## Summary
- drop `scripts/autoTaskRunner.js` and `scripts/append-memory.sh`
- update app documentation to use `npm run auto`
- log failing lint, test and backtest
- record mem-063 snapshot

## Testing
- `npm run lint` *(fails: unexpected any in many files)*
- `npm run test` *(fails: multiple Jest errors)*
- `npm run backtest` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_b_68484a22a2e8832386b1a8913345c03b