### PR TITLE
Task 109: unify startup command

### DIFF
--- a/.codexrc
+++ b/.codexrc
@@ -3,4 +3,4 @@
 set -euo pipefail
 git pull --rebase
 bash ./scripts/setup_dev.sh || exit 1
-echo "🟢 Environment ready — /tasks run 1 to start."
+echo "🟢 Environment ready — run 'npm run codex && npm run auto' to begin."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,7 +203,7 @@ Run `npm ci` once when the environment starts (or `npm run dev-deps` if offline)
 
 ### Codex Workflow
 
-1. Run `npm run codex` at the start of each ChatGPT session.
+1. Run `npm run codex && npm run auto` at the start of each ChatGPT session.
 2. Paste the printed context block into your first message to Codex.
 3. Craft descriptive commit messages referencing `TASKS.md` and update memory files after committing.
 

--- a/CODEX_START.md
+++ b/CODEX_START.md
@@ -27,8 +27,8 @@ Limit commit summaries in both the commit body and context snapshot to about **3
 
 ## Recap
 
-1. Run `npm run codex` and paste the output block into ChatGPT.
-2. If you receive a new ad-hoc request, add it to `TASKS.md` then run `npm run codex` again to print the refreshed context.
+1. Run `npm run codex && npm run auto` and paste the output block into ChatGPT.
+2. If you receive a new ad-hoc request, add it to `TASKS.md` then run the same command again to print the refreshed context and continue.
 3. Run `npm run dev-deps` if `node_modules` is missing before starting.
 4. Confirm AGENTS.md, memory.log and context.snapshot.md are loaded.
 5. Execute the next task from TASKS.md, committing with a clear message.

--- a/README.md
+++ b/README.md
@@ -137,20 +137,21 @@ See `docs/CODEX_WORKFLOW.md` for tips on using the Codex agent effectively.
 ### Recommended Workflow
 
 1. Run `npm ci` once when you start a session.
-2. Review `memory.log` for the latest summary line.
-3. Open `TASKS.md` and complete the next task.
-4. Commit messages must start with `Task <number>:`. The `commit-msg` hook runs
+2. Run `npm run codex && npm run auto` to print the context block and process the next task.
+3. Review `memory.log` for the latest summary line.
+4. Open `TASKS.md` and complete the next task.
+5. Commit messages must start with `Task <number>:`. The `commit-msg` hook runs
    `commitlint` to verify this format.
-5. A pre-commit hook greps `.git/COMMIT_EDITMSG` for `^Task [0-9]+:` and aborts
+6. A pre-commit hook greps `.git/COMMIT_EDITMSG` for `^Task [0-9]+:` and aborts
    if the pattern is missing before running lint, tests and memory checks. This
    hook **does not** modify or rotate memory files.
-6. After each commit a single `post-commit` hook runs
+7. After each commit a single `post-commit` hook runs
    `node --loader ts-node/esm scripts/update-memory.ts`.
    This script appends the commit to `memory.log`, updates `context.snapshot.md`,
    rotates the log to 300 lines and validates memory consistency. Rotation only
    happens here, never during pre-commit.
-7. When resuming after a break, tail the end of `memory.log` to review recent commits.
-8. Test and backtest outputs are logged in `logs/`.
+8. When resuming after a break, tail the end of `memory.log` to review recent commits.
+9. Test and backtest outputs are logged in `logs/`.
 
 ### Generating Context
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -73,7 +73,7 @@ Each task below is prefixed with `Task <id>` and tracked directly in this file.
 - [ ] Task 106: remove task_queue.json; autoTaskRunner reads TASKS.md; update docs
 - [ ] Task 107: rotate memory.log in update-memory.ts; drop pre-commit rotation
 - [x] Task 108: delete obsolete memory scripts from scripts/ and package.json
-- [ ] Task 109: define single workflow entry; update README, AGENTS, CODEX_START
+- [x] Task 109: define single workflow entry; update README, AGENTS, CODEX_START
 
 
 ### Bitcoin Dashboard

--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -261,3 +261,8 @@
 - Commit SHA: 40f26cb
 - Summary: removed obsolete autoTaskRunner.js and append-memory.sh wrappers; docs updated to run TypeScript directly. Lint, test and backtest still failing; results in logs/block-108.txt.
 - Next Goal: run npm ci only once in autoTaskRunner loop
+
+### 2025-06-10 15:49 UTC | mem-064
+- Commit SHA: fb5d2ce
+- Summary: unified startup instructions across AGENTS, README, CODEX_START and .codexrc; standard command 'npm run codex && npm run auto'.
+- Next Goal: run npm ci only once in autoTaskRunner loop

--- a/memory.log
+++ b/memory.log
@@ -237,3 +237,4 @@ d68850c5adc36fa6d8991525ce6e676ed92c42e5 | Task 106 | remove task queue and docs
 8aecb6e | Task 107: rotate memory in post-commit | README.md,TASKS.md,scripts/update-memory.ts | 2025-06-10T14:35:26Z
 40f26cb | Task 108 | removed autoTaskRunner.js and append-memory.sh; docs now use ts scripts; failing lint/test/backtest logged | app.md scripts/append-memory.sh scripts/autoTaskRunner.js logs/block-108.txt | 2025-06-10T15:15:57Z
 3346629 | chore | record mem-063 entry | context.snapshot.md,TASKS.md,memory.log | 2025-06-10T15:16:32Z
+fb5d2ce | Task 109 | unify startup command across docs | .codexrc,AGENTS.md,CODEX_START.md,README.md | 2025-06-10T15:49:41Z


### PR DESCRIPTION
## Summary
- standardize repo boot command to `npm run codex && npm run auto`
- update `.codexrc` message with the new startup flow
- align AGENTS, CODEX_START and README docs
- mark Task 109 complete and record mem-064

## Testing
- `npm run lint` *(fails: ESLint errors)*
- `npm run test` *(fails: Jest tests)*
- `npm run backtest` *(fails: require cycle)*

------
https://chatgpt.com/codex/tasks/task_b_684852625ad083238d92b6a3ce796d7d