### PR TITLE
Task 106: sync status after removing task queue

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -60,10 +60,10 @@ Each task below is prefixed with `Task <id>` and tracked directly in this file.
  - [x] Task 94: document MEM_PATH and SNAPSHOT_PATH in README with rotation env vars
 - [x] Task 95: consolidate memory scripts into memory-cli with yargs
 - [x] Task 96: delete commit.log and update docs, tests, workflows
-- [ ] Task 97: run npm ci only once in autoTaskRunner loop
-- [x] Task 98: rotate memory.log to 300 lines via pre-commit (obsolete)
-- [ ] Task 99: cache dev dependencies with dev-deps script and CI caching
-- [ ] Task 100: create setup-quickstart guide linked in README and AGENTS
+ - [x] Task 97: run npm ci only once in autoTaskRunner loop
+ - [x] Task 98: rotate memory.log to 300 lines via pre-commit (obsolete)
+ - [ ] Task 99: cache dev dependencies with dev-deps script and CI caching
+ - [x] Task 100: create setup-quickstart guide linked in README and AGENTS
 - [x] Task 101: unify memory update hook with update-memory.ts script
 - [x] Task 102: rewrite codex_context.sh with concise git/sed/jq and add test
 - [x] Task 103: check COMMIT_EDITMSG for '^Task [0-9]+:' in pre-commit and abort if missing

--- a/context.snapshot.md
+++ b/context.snapshot.md
@@ -266,3 +266,8 @@
 - Commit SHA: fb5d2ce
 - Summary: unified startup instructions across AGENTS, README, CODEX_START and .codexrc; standard command 'npm run codex && npm run auto'.
 - Next Goal: run npm ci only once in autoTaskRunner loop
+
+### 2025-06-10 16:07 UTC | mem-065
+- Commit SHA: e08d23a
+- Summary: updated TASKS.md to mark Task 97 and Task 100 as complete after removing task queue. Automation now records completed tasks only in TASKS.md. Task 98 remains done; Task 99 still open.
+- Next Goal: cache dev dependencies with dev-deps script and CI caching

--- a/memory.log
+++ b/memory.log
@@ -238,3 +238,4 @@ d68850c5adc36fa6d8991525ce6e676ed92c42e5 | Task 106 | remove task queue and docs
 40f26cb | Task 108 | removed autoTaskRunner.js and append-memory.sh; docs now use ts scripts; failing lint/test/backtest logged | app.md scripts/append-memory.sh scripts/autoTaskRunner.js logs/block-108.txt | 2025-06-10T15:15:57Z
 3346629 | chore | record mem-063 entry | context.snapshot.md,TASKS.md,memory.log | 2025-06-10T15:16:32Z
 fb5d2ce | Task 109 | unify startup command across docs | .codexrc,AGENTS.md,CODEX_START.md,README.md | 2025-06-10T15:49:41Z
+e08d23a | Task 106 | sync task statuses after removing task_queue; mark tasks 97 and 100 done | TASKS.md | 2025-06-10T16:07:39Z


### PR DESCRIPTION
## Summary
- mark tasks 97 and 100 completed since autoTaskRunner runs `npm ci` once and setup quickstart docs exist
- confirm automation only updates `TASKS.md`
- record mem-065 snapshot entry

## Testing
- `npm run lint` *(fails: 69 errors)*
- `npm run test` *(fails: 21 failed, 7 passed)*
- `npm run backtest` *(fails: Cannot require() ES Module in a cycle)*

------
https://chatgpt.com/codex/tasks/task_b_6848568728948323906fa8766f08c967