### PR TITLE
Task 99: cache dev dependencies

### DIFF
--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -14,6 +14,13 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
+      - name: Cache dev dependencies
+        uses: actions/cache@v4
+        with:
+          path: .cache/node_modules.tar.gz
+          key: ${{ runner.os }}-devdeps-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-devdeps-
       - run: npm ci
       - run: npm run auto
       - name: Push changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,13 @@ jobs:
         with:
           node-version: '18'
           cache: 'npm'
+      - name: Cache dev dependencies
+        uses: actions/cache@v4
+        with:
+          path: .cache/node_modules.tar.gz
+          key: ${{ runner.os }}-devdeps-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-devdeps-
       - run: npm run dev-deps
       - run: npm run lint
       - run: npm run test

--- a/.github/workflows/mem-maintenance.yml
+++ b/.github/workflows/mem-maintenance.yml
@@ -13,6 +13,13 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
+      - name: Cache dev dependencies
+        uses: actions/cache@v4
+        with:
+          path: .cache/node_modules.tar.gz
+          key: ${{ runner.os }}-devdeps-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-devdeps-
       - run: npm run dev-deps
       - run: npm run mem-rotate
       - run: ts-node scripts/memory-check.ts

--- a/.github/workflows/memory-pages.yml
+++ b/.github/workflows/memory-pages.yml
@@ -22,6 +22,13 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
+      - name: Cache dev dependencies
+        uses: actions/cache@v4
+        with:
+          path: .cache/node_modules.tar.gz
+          key: ${{ runner.os }}-devdeps-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-devdeps-
       - run: npm ci
       - run: ts-node scripts/memory-json.ts
       - run: ts-node scripts/snapshot-json.ts

--- a/.github/workflows/pr-memory-status.yml
+++ b/.github/workflows/pr-memory-status.yml
@@ -12,6 +12,13 @@ jobs:
         with:
           node-version: '18'
           cache: 'npm'
+      - name: Cache dev dependencies
+        uses: actions/cache@v4
+        with:
+          path: .cache/node_modules.tar.gz
+          key: ${{ runner.os }}-devdeps-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-devdeps-
       - run: npm run dev-deps
       - id: status
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ next-env.d.ts
 # firebase
 firebase-debug.log
 firestore-debug.loglogs/commit.log
+memory.json
+snapshot.json

--- a/CODEX_START.md
+++ b/CODEX_START.md
@@ -25,7 +25,7 @@ Limit commit summaries in both the commit body and context snapshot to about **3
 ## Recap
 
 1. Run `npm run codex` and paste the output block into ChatGPT.
-2. Run `npm run dev-deps` if `node_modules` is missing before starting.
+2. Run `npm run dev-deps` if `node_modules` is missing before starting. This restores cached dev dependencies when available.
 3. Execute the next task from `TASKS.md`, committing with a clear message (`Task <id>:`).
 4. The `post-commit` hook will handle all memory updates automatically.
 5. End the session after the commit is complete unless instructed to continue.

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Task 95: create memory CLI with rotate, snapshot-rotate, status, grep, update-lo
 | `ts-node scripts/memory-json.ts` | Export `memory.log` lines to `memory.json` |
 | `ts-node scripts/snapshot-json.ts` | Export `context.snapshot.md` to `snapshot.json` |
 | `npm run setup-hooks` | Install pre-commit and post-commit hooks for automatic memlog checks |
-| `npm run dev-deps` | Install dev dependencies if `node_modules` is missing |
+| `npm run dev-deps` | Install dev dependencies if `node_modules` is missing; uses `.cache/node_modules.tar.gz` to speed up reinstalls |
 | `bash scripts/check-env.sh` | Verify required CLIs (`next`, `jest`, `ts-node`) are installed |
 | `node scripts/try-cmd.js <cmd>` | Run a command only if the binary exists |
 | `npm run backtest` | Launch the backtest defined in `scripts/backtest.ts` |

--- a/docs/SETUP_QUICKSTART.md
+++ b/docs/SETUP_QUICKSTART.md
@@ -2,7 +2,7 @@
 
 Follow these steps to get the project running locally.
 
-1. Clone the repository and run `npm run dev-deps` to install dependencies if `node_modules` is missing.
+1. Clone the repository and run `npm run dev-deps` to install dependencies if `node_modules` is missing. The script restores `.cache/node_modules.tar.gz` when available for faster setup.
 2. Copy `.env.example` to `.env.local` and adjust settings as needed.
 3. Run `npm run lint && npm run test && npm run backtest` to verify the environment.
 4. Start the development server with `npm run dev`.

--- a/logs/block-99.txt
+++ b/logs/block-99.txt
@@ -1,0 +1,1809 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> bitdash-firestudio@1.0.0 lint
+> ESLINT_USE_FLAT_CONFIG=false eslint -c .eslintrc.json "src/**/*.{ts,tsx,js,jsx}"
+
+
+/workspace/bitdashfirestudio/src/__tests__/autoTaskRunner.state.test.ts
+   80:11  error  'spawnMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+   81:11  error  'execMock' is assigned a value but never used    @typescript-eslint/no-unused-vars
+  111:11  error  'atomicMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  112:11  error  'lockMock' is assigned a value but never used    @typescript-eslint/no-unused-vars
+  114:11  error  'spawnMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  120:11  error  'execMock' is assigned a value but never used    @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/__tests__/memory-check.test.ts
+   46:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+   81:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  115:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  121:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  122:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  155:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  161:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  162:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  188:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  194:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  195:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  221:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  227:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  228:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  258:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  264:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  265:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  296:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  302:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  303:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  334:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  340:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  341:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/app/api/economic-events/route.ts
+  5:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/funding-schedule/route.ts
+  5:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/higher-candles/route.ts
+  9:19  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  9:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/open-interest/route.ts
+  5:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/prev-day/route.ts
+  19:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/page.tsx
+   45:15  error  'ComputedIndicators' is defined but never used  @typescript-eslint/no-unused-vars
+   46:15  error  'TradeSignal' is defined but never used         @typescript-eslint/no-unused-vars
+   73:25  error  '_t' is assigned a value but never used         @typescript-eslint/no-unused-vars
+   73:40  error  '_f' is assigned a value but never used         @typescript-eslint/no-unused-vars
+   73:49  error  '_s1' is assigned a value but never used        @typescript-eslint/no-unused-vars
+   73:59  error  '_s2' is assigned a value but never used        @typescript-eslint/no-unused-vars
+   73:69  error  '_d' is assigned a value but never used         @typescript-eslint/no-unused-vars
+   73:80  error  '_u' is assigned a value but never used         @typescript-eslint/no-unused-vars
+  279:41  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
+  280:41  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
+  652:11  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/agents/IndicatorEngine.ts
+  3:29  error  'IndicatorSet' is defined but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/lib/agents/TestingAgent.ts
+  16:10  error  '_msg' is defined but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/lib/agents/UIRenderer.ts
+  4:10  error  '_msg' is defined but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/lib/data/binanceCandles.ts
+  20:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/bybitOpenInterest.ts
+  11:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  13:37  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/coingecko.ts
+  20:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  36:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/economicEvents.ts
+   1:23  error  'FetchImportance' is defined but never used  @typescript-eslint/no-unused-vars
+  16:34  error  Unexpected any. Specify a different type     @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/fmp.ts
+  18:12  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  34:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  47:14  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  65:14  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/fundingSchedule.ts
+  11:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  13:37  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/fetchCache.ts
+  10:9  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/signals.ts
+  38:9  error  'now' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/scripts/autoTaskRunner.ts
+  29:10  error  Unexpected constant condition                    no-constant-condition
+  39:88  error  Unexpected any. Specify a different type         @typescript-eslint/no-explicit-any
+  58:5   error  Move function declaration to function body root  no-inner-declarations
+  80:5   error  Move function declaration to function body root  no-inner-declarations
+
+/workspace/bitdashfirestudio/src/types/agent.ts
+  1:35  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+✖ 69 problems (69 errors, 0 warnings)
+
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> bitdash-firestudio@1.0.0 test
+> jest
+
+FAIL src/__tests__/file-lock.test.ts (9.046 s)
+  ● withFileLock › serializes concurrent writes
+
+    ENOENT: no such file or directory, open '/tmp/locktest-xyXOT2/mem.txt'
+
+      39 |     ]);
+      40 |
+    > 41 |     const out = fs.readFileSync(file, 'utf8');
+         |                    ^
+      42 |     const sorted = out.split('').sort().join('');
+      43 |     expect(sorted).toBe('AB');
+      44 |     fs.rmSync(dir, { recursive: true, force: true });
+
+      at Object.<anonymous> (src/__tests__/file-lock.test.ts:41:20)
+
+  ● withFileLock › handles many concurrent writers
+
+    thrown: "Exceeded timeout of 5000 ms for a test.
+    Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."
+
+      87 |   });
+      88 |
+    > 89 |   it('handles many concurrent writers', async () => {
+         |   ^
+      90 |     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'locktest-'));
+      91 |     const file = path.join(dir, 'mem.txt');
+      92 |     const p1 = run(file, 'A', '200');
+
+      at src/__tests__/file-lock.test.ts:89:3
+      at Object.<anonymous> (src/__tests__/file-lock.test.ts:29:1)
+
+FAIL src/__tests__/append-memory.concurrent.test.ts
+  ● append-memory concurrency › serializes concurrent snapshot writes
+
+    ENOENT: no such file or directory, open '/tmp/append-31nlMb/context.snapshot.md'
+
+      31 |     ]);
+      32 |
+    > 33 |     const out = fs.readFileSync(snap, 'utf8');
+         |                    ^
+      34 |     const sections = out.match(/mem-\d+/g) || [];
+      35 |     expect(sections.length).toBe(2);
+      36 |     const sorted = [...new Set(sections)].sort();
+
+      at Object.<anonymous> (src/__tests__/append-memory.concurrent.test.ts:33:20)
+
+FAIL src/__tests__/autoTaskRunner.test.ts
+  ● autoTaskRunner memory writes › serializes concurrent invocations
+
+    ENOENT: no such file or directory, open '/tmp/autorun-McecTG/mem.log'
+
+      39 |     ]);
+      40 |
+    > 41 |     const lines = fs.readFileSync(file, 'utf8').trim().split('\n');
+         |                      ^
+      42 |     const sorted = [...lines].sort().join('');
+      43 |     expect(lines.length).toBe(2);
+      44 |     expect(sorted).toBe('AB');
+
+      at Object.<anonymous> (src/__tests__/autoTaskRunner.test.ts:41:22)
+
+FAIL src/__tests__/memory-utils.test.ts
+  ● Console
+
+    console.error
+      Malformed memory line: abc123 just text
+
+      223 |       };
+      224 |     } else {
+    > 225 |       console.error(`Malformed memory line: ${raw}`);
+          |               ^
+      226 |       entry = {
+      227 |         entryType: 'commit',
+      228 |         hash,
+
+      at Object.parseMemoryLines (scripts/memory-utils.ts:225:15)
+      at Object.<anonymous> (src/__tests__/memory-utils.test.ts:339:27)
+
+    console.error
+      Malformed memory line: abcd123 | test
+
+      223 |       };
+      224 |     } else {
+    > 225 |       console.error(`Malformed memory line: ${raw}`);
+          |               ^
+      226 |       entry = {
+      227 |         entryType: 'commit',
+      228 |         hash,
+
+      at Object.parseMemoryLines (scripts/memory-utils.ts:225:15)
+      at Object.<anonymous> (src/__tests__/memory-utils.test.ts:355:27)
+
+  ● update-memory-log › appends new commit entries from git log
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      123 |
+      124 |     const execMock = jest
+    > 125 |       .spyOn(cp, "execSync")
+          |        ^
+      126 |       .mockImplementation((cmd: string) => {
+      127 |         if (cmd.startsWith("git cat-file -e")) return Buffer.from("");
+      128 |         if (cmd.startsWith("git log")) {
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-utils.test.ts:125:8)
+
+  ● update-memory-log › runs memory-check when --verify flag passed
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      157 |
+      158 |     const execMock = jest
+    > 159 |       .spyOn(cp, "execSync")
+          |        ^
+      160 |       .mockImplementation((cmd: string) => {
+      161 |         if (cmd.startsWith("git cat-file -e")) return Buffer.from("");
+      162 |         if (cmd.startsWith("git log")) {
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-utils.test.ts:159:8)
+
+  ● update-memory-log › deduplicates existing entries
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      194 |
+      195 |     const execMock = jest
+    > 196 |       .spyOn(cp, "execSync")
+          |        ^
+      197 |       .mockReturnValue(Buffer.from(""));
+      198 |
+      199 |     withFsMocks({ [memPath]: tmpMem }, () => {
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-utils.test.ts:196:8)
+
+hint: Using 'master' as the name for the initial branch. This default branch name
+hint: is subject to change. To configure the initial branch name to use in all
+hint: of your new repositories, which will suppress this warning, call:
+hint: 
+hint: 	git config --global init.defaultBranch <name>
+hint: 
+hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+hint: 'development'. The just-created branch can be renamed via this command:
+hint: 
+hint: 	git branch -m <name>
+hint: Using 'master' as the name for the initial branch. This default branch name
+hint: is subject to change. To configure the initial branch name to use in all
+hint: of your new repositories, which will suppress this warning, call:
+hint: 
+hint: 	git config --global init.defaultBranch <name>
+hint: 
+hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+hint: 'development'. The just-created branch can be renamed via this command:
+hint: 
+hint: 	git branch -m <name>
+FAIL src/__tests__/rebuild-memory.test.ts
+  ● rebuild-memory › writes commit history to memory.log
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      18 |
+      19 |     const origExec = cp.execSync;
+    > 20 |     const execMock = jest.spyOn(cp, 'execSync').mockImplementation((cmd: string, opts?: any) => {
+         |                           ^
+      21 |       if (cmd.startsWith('ts-node') && cmd.includes('append-memory.ts')) {
+      22 |         return Buffer.from('');
+      23 |       }
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/rebuild-memory.test.ts:20:27)
+
+  ● rebuild-memory › writes sequential mem-ids to snapshot
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      53 |     let count = 0;
+      54 |     const execMock = jest
+    > 55 |       .spyOn(cp, 'execSync')
+         |        ^
+      56 |       .mockImplementation((cmd: string, opts?: any) => {
+      57 |         if (cmd.startsWith('ts-node') && cmd.includes('append-memory.ts')) {
+      58 |           const sha = origExec('git rev-parse --short HEAD', {
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/rebuild-memory.test.ts:55:8)
+
+FAIL src/__tests__/snapshot-rotate.test.ts
+  ● Console
+
+    console.log
+      context.snapshot.md trimmed to last 2 entries
+
+      at Object.<anonymous> (scripts/snapshot-rotate.ts:43:13)
+
+    console.log
+      [dry-run] Would backup to /workspace/bitdashfirestudio/logs/context.snapshot.2025-01-01T00:00:00.000Z.bak and trim context.snapshot.md to last 1 entries
+
+      at Object.<anonymous> (scripts/snapshot-rotate.ts:35:13)
+
+  ● snapshot-rotate › truncates context.snapshot.md and creates backup
+
+    expect(received).toBe(expected) // Object.is equality
+
+    - Expected  - 0
+    + Received  + 1
+
+      ### 2025-01-01 | mem-002
+      b
+      ### 2025-01-02 | mem-003
+      c
+
+    +
+
+      114 |     const snapOut = fs.readFileSync(tmpSnap, 'utf8');
+      115 |     const backupOut = fs.readFileSync(tmpBackup, 'utf8');
+    > 116 |     expect(snapOut).toBe(
+          |                     ^
+      117 |       '### 2025-01-01 | mem-002\n' +
+      118 |         'b\n' +
+      119 |         '### 2025-01-02 | mem-003\n' +
+
+      at Object.<anonymous> (src/__tests__/snapshot-rotate.test.ts:116:21)
+
+FAIL src/__tests__/memory-api.test.ts
+  ● memory api route › returns parsed memory entries
+
+    Cannot find module '@/lib/constants' from 'src/app/api/memory/route.ts'
+
+       5 |   MemoryEntry,
+       6 | } from '../../../../scripts/memory-utils'
+    >  7 | import { CACHE_TTL } from '@/lib/constants'
+         | ^
+       8 |
+       9 | let cache: { ts: number; data: MemoryEntry[] } | null = null
+      10 | const TTL = parseInt(process.env.MEMORY_API_TTL || String(CACHE_TTL / 1000), 10) * 1000
+
+      at Resolver._throwModNotFoundError (node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (src/app/api/memory/route.ts:7:1)
+      at src/__tests__/memory-api.test.ts:18:13
+      at Object.<anonymous> (src/__tests__/memory-api.test.ts:17:10)
+
+  ● memory api route › returns empty array when file missing
+
+    Cannot find module '@/lib/constants' from 'src/app/api/memory/route.ts'
+
+       5 |   MemoryEntry,
+       6 | } from '../../../../scripts/memory-utils'
+    >  7 | import { CACHE_TTL } from '@/lib/constants'
+         | ^
+       8 |
+       9 | let cache: { ts: number; data: MemoryEntry[] } | null = null
+      10 | const TTL = parseInt(process.env.MEMORY_API_TTL || String(CACHE_TTL / 1000), 10) * 1000
+
+      at Resolver._throwModNotFoundError (node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (src/app/api/memory/route.ts:7:1)
+      at src/__tests__/memory-api.test.ts:33:13
+      at Object.<anonymous> (src/__tests__/memory-api.test.ts:32:10)
+
+  ● memory api route › caches results using TTL
+
+    Cannot find module '@/lib/constants' from 'src/app/api/memory/route.ts'
+
+       5 |   MemoryEntry,
+       6 | } from '../../../../scripts/memory-utils'
+    >  7 | import { CACHE_TTL } from '@/lib/constants'
+         | ^
+       8 |
+       9 | let cache: { ts: number; data: MemoryEntry[] } | null = null
+      10 | const TTL = parseInt(process.env.MEMORY_API_TTL || String(CACHE_TTL / 1000), 10) * 1000
+
+      at Resolver._throwModNotFoundError (node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (src/app/api/memory/route.ts:7:1)
+      at src/__tests__/memory-api.test.ts:54:13
+      at Object.<anonymous> (src/__tests__/memory-api.test.ts:53:10)
+
+FAIL src/__tests__/autoTaskRunner.state.test.ts
+  ● autoTaskRunner writes › uses locks and atomic writes for tasks and signals
+
+    TypeError: Cannot redefine property: spawnSync
+        at Function.defineProperty (<anonymous>)
+
+      78 |     const lockMock = jest.spyOn(utils, 'withFileLock').mockImplementation((_, fn) => { fn(); });
+      79 |
+    > 80 |     const spawnMock = jest.spyOn(cp, 'spawnSync').mockReturnValue({ stdout: '', stderr: '', status: 0 } as any);
+         |                            ^
+      81 |     const execMock = jest.spyOn(cp, 'execSync').mockReturnValue(Buffer.from(''));
+      82 |
+      83 |     withFsMocks(map, () => {
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/autoTaskRunner.state.test.ts:80:28)
+
+  ● autoTaskRunner writes › halts when memory check fails
+
+    TypeError: Cannot redefine property: spawnSync
+        at Function.defineProperty (<anonymous>)
+
+      112 |     const lockMock = jest.spyOn(utils, 'withFileLock').mockImplementation((_, fn) => { fn(); });
+      113 |
+    > 114 |     const spawnMock = jest.spyOn(cp, 'spawnSync').mockImplementation((cmd: string) => {
+          |                            ^
+      115 |       if (cmd === 'ts-node scripts/memory-check.ts') {
+      116 |         return { stdout: 'fail', stderr: '', status: 1 } as any;
+      117 |       }
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/autoTaskRunner.state.test.ts:114:28)
+
+FAIL src/__tests__/memory-json.test.ts
+  ● memory-json › writes memory.json using atomicWrite with lock
+
+    expect(jest.fn()).toHaveBeenCalledWith(...expected)
+
+    Expected: "/workspace/bitdashfirestudio/memory.json", Any<Function>
+
+    Number of calls: 0
+
+      48 |       ) + '\n';
+      49 |
+    > 50 |     expect(lockMock).toHaveBeenCalledWith(outPath, expect.any(Function));
+         |                      ^
+      51 |     expect(atomicMock).toHaveBeenCalledWith(outPath, expected);
+      52 |
+      53 |     readMock.mockRestore();
+
+      at Object.<anonymous> (src/__tests__/memory-json.test.ts:50:22)
+
+FAIL src/__tests__/mem-list.test.ts
+  ● mem-list › prints last n entries
+
+    RangeError: Maximum call stack size exceeded
+
+      11 |   const exists = jest.spyOn(fs, 'existsSync').mockImplementation((p: any) => {
+      12 |     if (pathMap[p as string]) p = pathMap[p as string]
+    > 13 |     return fs.existsSync(p)
+         |               ^
+      14 |   })
+      15 |   try {
+      16 |     fn()
+
+      at Object.<anonymous> (node_modules/jest-mock/build/index.js:336:51)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+
+FAIL src/__tests__/precommit.test.ts
+  ● pre-commit hook › invokes npm run mem-check
+
+    TypeError: Cannot redefine property: spawnSync
+        at Function.defineProperty (<anonymous>)
+
+      16 |   it('invokes npm run mem-check', () => {
+      17 |     const spy = jest
+    > 18 |       .spyOn(cp, 'spawnSync')
+         |        ^
+      19 |       .mockReturnValue({ status: 0 } as any);
+      20 |     runHook();
+      21 |     expect(spy).toHaveBeenCalled();
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/precommit.test.ts:18:8)
+
+FAIL src/__tests__/memory-check.test.ts
+  ● memory-check › passes for ordered log
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      45 |     );
+      46 |     const execMock = jest
+    > 47 |       .spyOn(cp, 'execSync')
+         |        ^
+      48 |       .mockImplementation((cmd: string) => {
+      49 |         if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('test');
+      50 |         return Buffer.from('');
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-check.test.ts:47:8)
+
+  ● memory-check › allows commit after task with earlier timestamp
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      80 |     );
+      81 |     const execMock = jest
+    > 82 |       .spyOn(cp, 'execSync')
+         |        ^
+      83 |       .mockImplementation((cmd: string) => {
+      84 |         if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('msg');
+      85 |         return Buffer.from('');
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-check.test.ts:82:8)
+
+  ● memory-check › fails for unordered log
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      114 |     );
+      115 |     const execMock = jest
+    > 116 |       .spyOn(cp, 'execSync')
+          |        ^
+      117 |       .mockImplementation((cmd: string) => {
+      118 |         if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('test');
+      119 |         return Buffer.from('');
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-check.test.ts:116:8)
+
+  ● memory-check › fails for missing mem-id
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      154 |     );
+      155 |     const execMock = jest
+    > 156 |       .spyOn(cp, 'execSync')
+          |        ^
+      157 |       .mockImplementation((cmd: string) => {
+      158 |         if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('test');
+      159 |         return Buffer.from('');
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-check.test.ts:156:8)
+
+  ● memory-check › fails for mismatched summary
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      187 |     );
+      188 |     const execMock = jest
+    > 189 |       .spyOn(cp, 'execSync')
+          |        ^
+      190 |       .mockImplementation((cmd: string) => {
+      191 |         if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('correct');
+      192 |         return Buffer.from('');
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-check.test.ts:189:8)
+
+  ● memory-check › fails for invalid entry format
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      220 |     );
+      221 |     const execMock = jest
+    > 222 |       .spyOn(cp, 'execSync')
+          |        ^
+      223 |       .mockImplementation((cmd: string) => {
+      224 |         if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('something');
+      225 |         return Buffer.from('');
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-check.test.ts:222:8)
+
+  ● memory-check › fails when commit hashes repeat
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      257 |     );
+      258 |     const execMock = jest
+    > 259 |       .spyOn(cp, 'execSync')
+          |        ^
+      260 |       .mockImplementation((cmd: string) => {
+      261 |         if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('c');
+      262 |         return Buffer.from('');
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-check.test.ts:259:8)
+
+  ● memory-check › fails when tasks timestamps decrease
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      295 |     );
+      296 |     const execMock = jest
+    > 297 |       .spyOn(cp, 'execSync')
+          |        ^
+      298 |       .mockImplementation((cmd: string) => {
+      299 |         if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('t');
+      300 |         return Buffer.from('');
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-check.test.ts:297:8)
+
+  ● memory-check › fails when commit timestamps decrease
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      333 |     );
+      334 |     const execMock = jest
+    > 335 |       .spyOn(cp, 'execSync')
+          |        ^
+      336 |       .mockImplementation((cmd: string) => {
+      337 |         if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('m');
+      338 |         return Buffer.from('');
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-check.test.ts:335:8)
+
+FAIL src/__tests__/mem-rotate.test.ts
+  ● mem-rotate › truncates memory.log and backs up previous log
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      92 |     fs.writeFileSync(tmpMem, "1\n2\n3\n4\n5\n6\n");
+      93 |
+    > 94 |     const execMock = jest.spyOn(cp, "execSync").mockReturnValue(Buffer.from(""));
+         |                           ^
+      95 |
+      96 |     const map = {
+      97 |       [memPath]: tmpMem,
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/mem-rotate.test.ts:94:27)
+
+  ● mem-rotate › does not modify files during dry run
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      126 |     fs.writeFileSync(tmpMem, "1\n2\n3\n");
+      127 |
+    > 128 |     const execMock = jest.spyOn(cp, "execSync");
+          |                           ^
+      129 |
+      130 |     const map = {
+      131 |       [memPath]: tmpMem,
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/mem-rotate.test.ts:128:27)
+
+FAIL src/__tests__/economic-events-api.test.ts
+  ● economic events api › returns high impact events
+
+    Cannot find module '@/lib/data/economicEvents' from 'src/app/api/economic-events/route.ts'
+
+      1 | import { NextResponse } from 'next/server'
+    > 2 | import { fetchHighImpactEvents } from '@/lib/data/economicEvents'
+        | ^
+      3 | import { CACHE_TTL } from '@/lib/constants'
+      4 |
+      5 | let cache: { ts: number; data: any } | null = null
+
+      at Resolver._throwModNotFoundError (node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (src/app/api/economic-events/route.ts:2:1)
+      at src/__tests__/economic-events-api.test.ts:13:13
+      at Object.<anonymous> (src/__tests__/economic-events-api.test.ts:12:10)
+
+FAIL src/__tests__/mem-diff.test.ts
+  ● mem-diff › prints hashes missing from memory.log
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+       8 |       .mockReturnValue(['abc123 | test | file | 2025-01-01']);
+       9 |     const execMock = jest
+    > 10 |       .spyOn(cp, 'execSync')
+         |        ^
+      11 |       .mockReturnValue(Buffer.from('def456\nabc123\n'));
+      12 |     const logMock = jest.spyOn(console, 'log').mockImplementation(() => {});
+      13 |
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/mem-diff.test.ts:10:8)
+
+  ● mem-diff › prints success message when all hashes present
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      31 |       ]);
+      32 |     const execMock = jest
+    > 33 |       .spyOn(cp, 'execSync')
+         |        ^
+      34 |       .mockReturnValue(Buffer.from('def456\nabc123\n'));
+      35 |     const logMock = jest.spyOn(console, 'log').mockImplementation(() => {});
+      36 |
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/mem-diff.test.ts:33:8)
+
+FAIL src/__tests__/memgrep.test.ts
+  ● memgrep › prints matching lines with ids or hashes
+
+    expect(received).toContain(expected) // indexOf
+
+    Expected value: StringContaining "abc123:"
+    Received array: ["abc123: abc123 | fix bug | file | 2025-01-01T00:00:00Z", "mem-001: minor fix details"]
+
+    Looks like you wanted to test for object/array equality with the stricter `toContain` matcher. You probably need to use `toContainEqual` instead.
+
+      53 |
+      54 |     const outputs = logMock.mock.calls.map((c) => c[0]);
+    > 55 |     expect(outputs).toContain(expect.stringContaining('abc123:'));
+         |                     ^
+      56 |     expect(outputs).toContain('mem-001: minor fix details');
+      57 |     expect(outputs.some((o) => /def456/.test(o))).toBe(false);
+      58 |     expect(outputs.some((o) => /mem-002/.test(o))).toBe(false);
+
+      at Object.<anonymous> (src/__tests__/memgrep.test.ts:55:21)
+
+  ● memgrep › prints nothing when no match found
+
+    expect(jest.fn()).not.toHaveBeenCalled()
+
+    Expected number of calls: 0
+    Received number of calls: 2
+
+    1: "abc123: abc123 | fix bug | file | 2025-01-01T00:00:00Z"
+    2: "mem-001: minor fix details"
+
+      78 |     });
+      79 |
+    > 80 |     expect(logMock).not.toHaveBeenCalled();
+         |                         ^
+      81 |
+      82 |     logMock.mockRestore();
+      83 |     fs.rmSync(dir, { recursive: true, force: true });
+
+      at Object.<anonymous> (src/__tests__/memgrep.test.ts:80:25)
+
+  ● memgrep › respects --since and --until range
+
+    expect(received).toContain(expected) // indexOf
+
+    Expected value: StringContaining "bbb222:"
+    Received array: ["abc123: abc123 | fix bug | file | 2025-01-01T00:00:00Z", "mem-001: minor fix details", "bbb222: bbb222 | fix late | file | 2025-01-03T00:00:00Z"]
+
+    Looks like you wanted to test for object/array equality with the stricter `toContain` matcher. You probably need to use `toContainEqual` instead.
+
+      119 |
+      120 |     const outputs = logMock.mock.calls.map((c) => c[0]);
+    > 121 |     expect(outputs).toContain(expect.stringContaining('bbb222:'));
+          |                     ^
+      122 |     expect(outputs).toContain('mem-011: late note');
+      123 |     expect(outputs.some((o) => /aaa111/.test(o))).toBe(false);
+      124 |     expect(outputs.some((o) => /mem-010/.test(o))).toBe(false);
+
+      at Object.<anonymous> (src/__tests__/memgrep.test.ts:121:21)
+
+FAIL src/__tests__/update-memory.test.ts
+  ● update-memory › updates memory log, snapshot and rotates
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      72 |
+      73 |     const calls: string[] = [];
+    > 74 |     const execMock = jest.spyOn(cp, 'execSync').mockImplementation((cmd: string) => {
+         |                           ^
+      75 |       calls.push(cmd);
+      76 |       if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('Task 1: summary');
+      77 |       if (cmd.startsWith('grep -m 1')) return Buffer.from('next');
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/update-memory.test.ts:74:27)
+
+FAIL src/__tests__/mem-sync.test.ts
+  ● mem-sync › merges logs from branch
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      13 |     const otherLines = 'a1 | A | y | 2025-01-01T00:00:00Z\n'
+      14 |     const exec = jest
+    > 15 |       .spyOn(cp, 'execSync')
+         |        ^
+      16 |       .mockReturnValue(otherLines as any)
+      17 |     const read = jest
+      18 |       .spyOn(utils, 'readMemoryLines')
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/mem-sync.test.ts:15:8)
+
+FAIL src/__tests__/memory-cli.test.ts
+  ● memory-cli › runs mem-diff for diff command
+
+    TypeError: Cannot redefine property: spawnSync
+        at Function.defineProperty (<anonymous>)
+
+      18 |
+      19 |   beforeEach(() => {
+    > 20 |     spy = jest.spyOn(cp, 'spawnSync').mockReturnValue({ status: 0 } as any);
+         |                ^
+      21 |   });
+      22 |
+      23 |   afterEach(() => jest.restoreAllMocks());
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-cli.test.ts:20:16)
+
+  ● memory-cli › runs memory-json for json command
+
+    TypeError: Cannot redefine property: spawnSync
+        at Function.defineProperty (<anonymous>)
+
+      18 |
+      19 |   beforeEach(() => {
+    > 20 |     spy = jest.spyOn(cp, 'spawnSync').mockReturnValue({ status: 0 } as any);
+         |                ^
+      21 |   });
+      22 |
+      23 |   afterEach(() => jest.restoreAllMocks());
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-cli.test.ts:20:16)
+
+  ● memory-cli › runs clean-locks for clean-locks command
+
+    TypeError: Cannot redefine property: spawnSync
+        at Function.defineProperty (<anonymous>)
+
+      18 |
+      19 |   beforeEach(() => {
+    > 20 |     spy = jest.spyOn(cp, 'spawnSync').mockReturnValue({ status: 0 } as any);
+         |                ^
+      21 |   });
+      22 |
+      23 |   afterEach(() => jest.restoreAllMocks());
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-cli.test.ts:20:16)
+
+  ● memory-cli › runs memory-check for check command
+
+    TypeError: Cannot redefine property: spawnSync
+        at Function.defineProperty (<anonymous>)
+
+      18 |
+      19 |   beforeEach(() => {
+    > 20 |     spy = jest.spyOn(cp, 'spawnSync').mockReturnValue({ status: 0 } as any);
+         |                ^
+      21 |   });
+      22 |
+      23 |   afterEach(() => jest.restoreAllMocks());
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-cli.test.ts:20:16)
+
+  ● memory-cli › runs rebuild-memory for rebuild command
+
+    TypeError: Cannot redefine property: spawnSync
+        at Function.defineProperty (<anonymous>)
+
+      18 |
+      19 |   beforeEach(() => {
+    > 20 |     spy = jest.spyOn(cp, 'spawnSync').mockReturnValue({ status: 0 } as any);
+         |                ^
+      21 |   });
+      22 |
+      23 |   afterEach(() => jest.restoreAllMocks());
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-cli.test.ts:20:16)
+
+  ● memory-cli › runs update-snapshot for snapshot-update command
+
+    TypeError: Cannot redefine property: spawnSync
+        at Function.defineProperty (<anonymous>)
+
+      18 |
+      19 |   beforeEach(() => {
+    > 20 |     spy = jest.spyOn(cp, 'spawnSync').mockReturnValue({ status: 0 } as any);
+         |                ^
+      21 |   });
+      22 |
+      23 |   afterEach(() => jest.restoreAllMocks());
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-cli.test.ts:20:16)
+
+  ● memory-cli › runs mem-list for list command
+
+    TypeError: Cannot redefine property: spawnSync
+        at Function.defineProperty (<anonymous>)
+
+      18 |
+      19 |   beforeEach(() => {
+    > 20 |     spy = jest.spyOn(cp, 'spawnSync').mockReturnValue({ status: 0 } as any);
+         |                ^
+      21 |   });
+      22 |
+      23 |   afterEach(() => jest.restoreAllMocks());
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-cli.test.ts:20:16)
+
+FAIL src/__tests__/update-snapshot.test.ts
+  ● update-snapshot › calls append-memory with locking and atomic write
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      106 |     withFsMocks(map, openCalls, renameCalls, unlinkCalls, () => {
+      107 |       const execMock = jest
+    > 108 |         .spyOn(cp, 'execSync')
+          |          ^
+      109 |         .mockImplementation((cmd: string) => {
+      110 |           if (cmd.startsWith('git log -1')) return Buffer.from(summary);
+      111 |           if (cmd.startsWith("grep -m 1")) return Buffer.from(nextTask);
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at src/__tests__/update-snapshot.test.ts:108:10
+      at withFsMocks (src/__tests__/update-snapshot.test.ts:80:5)
+      at Object.<anonymous> (src/__tests__/update-snapshot.test.ts:106:5)
+
+FAIL src/__tests__/correlation.test.ts
+  ● correlation › zero correlation when arrays differ
+
+    expect(received).toBeCloseTo(expected)
+
+    Expected: 0
+    Received: NaN
+
+    Expected precision:    2
+    Expected difference: < 0.005
+    Received difference:   NaN
+
+       9 |   it('zero correlation when arrays differ', () => {
+      10 |     const val = correlation([1, 1, 1], [2, 3, 4]);
+    > 11 |     expect(val).toBeCloseTo(0);
+         |                 ^
+      12 |   });
+      13 | });
+      14 |
+
+      at Object.<anonymous> (src/__tests__/correlation.test.ts:11:17)
+
+PASS src/__tests__/codex-context.test.ts
+PASS src/__tests__/sessions.test.ts
+PASS src/__tests__/mem-locate.test.ts
+PASS src/__tests__/clean-locks.test.ts
+PASS src/__tests__/cache.test.ts
+PASS src/__tests__/indicators.test.ts
+PASS src/__tests__/mem-status.test.ts
+
+Summary of all failing tests
+FAIL src/__tests__/file-lock.test.ts (9.046 s)
+  ● withFileLock › serializes concurrent writes
+
+    ENOENT: no such file or directory, open '/tmp/locktest-xyXOT2/mem.txt'
+
+      39 |     ]);
+      40 |
+    > 41 |     const out = fs.readFileSync(file, 'utf8');
+         |                    ^
+      42 |     const sorted = out.split('').sort().join('');
+      43 |     expect(sorted).toBe('AB');
+      44 |     fs.rmSync(dir, { recursive: true, force: true });
+
+      at Object.<anonymous> (src/__tests__/file-lock.test.ts:41:20)
+
+  ● withFileLock › handles many concurrent writers
+
+    thrown: "Exceeded timeout of 5000 ms for a test.
+    Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."
+
+      87 |   });
+      88 |
+    > 89 |   it('handles many concurrent writers', async () => {
+         |   ^
+      90 |     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'locktest-'));
+      91 |     const file = path.join(dir, 'mem.txt');
+      92 |     const p1 = run(file, 'A', '200');
+
+      at src/__tests__/file-lock.test.ts:89:3
+      at Object.<anonymous> (src/__tests__/file-lock.test.ts:29:1)
+
+FAIL src/__tests__/append-memory.concurrent.test.ts
+  ● append-memory concurrency › serializes concurrent snapshot writes
+
+    ENOENT: no such file or directory, open '/tmp/append-31nlMb/context.snapshot.md'
+
+      31 |     ]);
+      32 |
+    > 33 |     const out = fs.readFileSync(snap, 'utf8');
+         |                    ^
+      34 |     const sections = out.match(/mem-\d+/g) || [];
+      35 |     expect(sections.length).toBe(2);
+      36 |     const sorted = [...new Set(sections)].sort();
+
+      at Object.<anonymous> (src/__tests__/append-memory.concurrent.test.ts:33:20)
+
+FAIL src/__tests__/autoTaskRunner.test.ts
+  ● autoTaskRunner memory writes › serializes concurrent invocations
+
+    ENOENT: no such file or directory, open '/tmp/autorun-McecTG/mem.log'
+
+      39 |     ]);
+      40 |
+    > 41 |     const lines = fs.readFileSync(file, 'utf8').trim().split('\n');
+         |                      ^
+      42 |     const sorted = [...lines].sort().join('');
+      43 |     expect(lines.length).toBe(2);
+      44 |     expect(sorted).toBe('AB');
+
+      at Object.<anonymous> (src/__tests__/autoTaskRunner.test.ts:41:22)
+
+FAIL src/__tests__/memory-utils.test.ts
+  ● update-memory-log › appends new commit entries from git log
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      123 |
+      124 |     const execMock = jest
+    > 125 |       .spyOn(cp, "execSync")
+          |        ^
+      126 |       .mockImplementation((cmd: string) => {
+      127 |         if (cmd.startsWith("git cat-file -e")) return Buffer.from("");
+      128 |         if (cmd.startsWith("git log")) {
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-utils.test.ts:125:8)
+
+  ● update-memory-log › runs memory-check when --verify flag passed
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      157 |
+      158 |     const execMock = jest
+    > 159 |       .spyOn(cp, "execSync")
+          |        ^
+      160 |       .mockImplementation((cmd: string) => {
+      161 |         if (cmd.startsWith("git cat-file -e")) return Buffer.from("");
+      162 |         if (cmd.startsWith("git log")) {
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-utils.test.ts:159:8)
+
+  ● update-memory-log › deduplicates existing entries
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      194 |
+      195 |     const execMock = jest
+    > 196 |       .spyOn(cp, "execSync")
+          |        ^
+      197 |       .mockReturnValue(Buffer.from(""));
+      198 |
+      199 |     withFsMocks({ [memPath]: tmpMem }, () => {
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-utils.test.ts:196:8)
+
+FAIL src/__tests__/rebuild-memory.test.ts
+  ● rebuild-memory › writes commit history to memory.log
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      18 |
+      19 |     const origExec = cp.execSync;
+    > 20 |     const execMock = jest.spyOn(cp, 'execSync').mockImplementation((cmd: string, opts?: any) => {
+         |                           ^
+      21 |       if (cmd.startsWith('ts-node') && cmd.includes('append-memory.ts')) {
+      22 |         return Buffer.from('');
+      23 |       }
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/rebuild-memory.test.ts:20:27)
+
+  ● rebuild-memory › writes sequential mem-ids to snapshot
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      53 |     let count = 0;
+      54 |     const execMock = jest
+    > 55 |       .spyOn(cp, 'execSync')
+         |        ^
+      56 |       .mockImplementation((cmd: string, opts?: any) => {
+      57 |         if (cmd.startsWith('ts-node') && cmd.includes('append-memory.ts')) {
+      58 |           const sha = origExec('git rev-parse --short HEAD', {
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/rebuild-memory.test.ts:55:8)
+
+FAIL src/__tests__/snapshot-rotate.test.ts
+  ● snapshot-rotate › truncates context.snapshot.md and creates backup
+
+    expect(received).toBe(expected) // Object.is equality
+
+    - Expected  - 0
+    + Received  + 1
+
+      ### 2025-01-01 | mem-002
+      b
+      ### 2025-01-02 | mem-003
+      c
+
+    +
+
+      114 |     const snapOut = fs.readFileSync(tmpSnap, 'utf8');
+      115 |     const backupOut = fs.readFileSync(tmpBackup, 'utf8');
+    > 116 |     expect(snapOut).toBe(
+          |                     ^
+      117 |       '### 2025-01-01 | mem-002\n' +
+      118 |         'b\n' +
+      119 |         '### 2025-01-02 | mem-003\n' +
+
+      at Object.<anonymous> (src/__tests__/snapshot-rotate.test.ts:116:21)
+
+FAIL src/__tests__/memory-api.test.ts
+  ● memory api route › returns parsed memory entries
+
+    Cannot find module '@/lib/constants' from 'src/app/api/memory/route.ts'
+
+       5 |   MemoryEntry,
+       6 | } from '../../../../scripts/memory-utils'
+    >  7 | import { CACHE_TTL } from '@/lib/constants'
+         | ^
+       8 |
+       9 | let cache: { ts: number; data: MemoryEntry[] } | null = null
+      10 | const TTL = parseInt(process.env.MEMORY_API_TTL || String(CACHE_TTL / 1000), 10) * 1000
+
+      at Resolver._throwModNotFoundError (node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (src/app/api/memory/route.ts:7:1)
+      at src/__tests__/memory-api.test.ts:18:13
+      at Object.<anonymous> (src/__tests__/memory-api.test.ts:17:10)
+
+  ● memory api route › returns empty array when file missing
+
+    Cannot find module '@/lib/constants' from 'src/app/api/memory/route.ts'
+
+       5 |   MemoryEntry,
+       6 | } from '../../../../scripts/memory-utils'
+    >  7 | import { CACHE_TTL } from '@/lib/constants'
+         | ^
+       8 |
+       9 | let cache: { ts: number; data: MemoryEntry[] } | null = null
+      10 | const TTL = parseInt(process.env.MEMORY_API_TTL || String(CACHE_TTL / 1000), 10) * 1000
+
+      at Resolver._throwModNotFoundError (node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (src/app/api/memory/route.ts:7:1)
+      at src/__tests__/memory-api.test.ts:33:13
+      at Object.<anonymous> (src/__tests__/memory-api.test.ts:32:10)
+
+  ● memory api route › caches results using TTL
+
+    Cannot find module '@/lib/constants' from 'src/app/api/memory/route.ts'
+
+       5 |   MemoryEntry,
+       6 | } from '../../../../scripts/memory-utils'
+    >  7 | import { CACHE_TTL } from '@/lib/constants'
+         | ^
+       8 |
+       9 | let cache: { ts: number; data: MemoryEntry[] } | null = null
+      10 | const TTL = parseInt(process.env.MEMORY_API_TTL || String(CACHE_TTL / 1000), 10) * 1000
+
+      at Resolver._throwModNotFoundError (node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (src/app/api/memory/route.ts:7:1)
+      at src/__tests__/memory-api.test.ts:54:13
+      at Object.<anonymous> (src/__tests__/memory-api.test.ts:53:10)
+
+FAIL src/__tests__/autoTaskRunner.state.test.ts
+  ● autoTaskRunner writes › uses locks and atomic writes for tasks and signals
+
+    TypeError: Cannot redefine property: spawnSync
+        at Function.defineProperty (<anonymous>)
+
+      78 |     const lockMock = jest.spyOn(utils, 'withFileLock').mockImplementation((_, fn) => { fn(); });
+      79 |
+    > 80 |     const spawnMock = jest.spyOn(cp, 'spawnSync').mockReturnValue({ stdout: '', stderr: '', status: 0 } as any);
+         |                            ^
+      81 |     const execMock = jest.spyOn(cp, 'execSync').mockReturnValue(Buffer.from(''));
+      82 |
+      83 |     withFsMocks(map, () => {
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/autoTaskRunner.state.test.ts:80:28)
+
+  ● autoTaskRunner writes › halts when memory check fails
+
+    TypeError: Cannot redefine property: spawnSync
+        at Function.defineProperty (<anonymous>)
+
+      112 |     const lockMock = jest.spyOn(utils, 'withFileLock').mockImplementation((_, fn) => { fn(); });
+      113 |
+    > 114 |     const spawnMock = jest.spyOn(cp, 'spawnSync').mockImplementation((cmd: string) => {
+          |                            ^
+      115 |       if (cmd === 'ts-node scripts/memory-check.ts') {
+      116 |         return { stdout: 'fail', stderr: '', status: 1 } as any;
+      117 |       }
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/autoTaskRunner.state.test.ts:114:28)
+
+FAIL src/__tests__/memory-json.test.ts
+  ● memory-json › writes memory.json using atomicWrite with lock
+
+    expect(jest.fn()).toHaveBeenCalledWith(...expected)
+
+    Expected: "/workspace/bitdashfirestudio/memory.json", Any<Function>
+
+    Number of calls: 0
+
+      48 |       ) + '\n';
+      49 |
+    > 50 |     expect(lockMock).toHaveBeenCalledWith(outPath, expect.any(Function));
+         |                      ^
+      51 |     expect(atomicMock).toHaveBeenCalledWith(outPath, expected);
+      52 |
+      53 |     readMock.mockRestore();
+
+      at Object.<anonymous> (src/__tests__/memory-json.test.ts:50:22)
+
+FAIL src/__tests__/mem-list.test.ts
+  ● mem-list › prints last n entries
+
+    RangeError: Maximum call stack size exceeded
+
+      11 |   const exists = jest.spyOn(fs, 'existsSync').mockImplementation((p: any) => {
+      12 |     if (pathMap[p as string]) p = pathMap[p as string]
+    > 13 |     return fs.existsSync(p)
+         |               ^
+      14 |   })
+      15 |   try {
+      16 |     fn()
+
+      at Object.<anonymous> (node_modules/jest-mock/build/index.js:336:51)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+      at Object.<anonymous> (src/__tests__/mem-list.test.ts:13:15)
+
+FAIL src/__tests__/precommit.test.ts
+  ● pre-commit hook › invokes npm run mem-check
+
+    TypeError: Cannot redefine property: spawnSync
+        at Function.defineProperty (<anonymous>)
+
+      16 |   it('invokes npm run mem-check', () => {
+      17 |     const spy = jest
+    > 18 |       .spyOn(cp, 'spawnSync')
+         |        ^
+      19 |       .mockReturnValue({ status: 0 } as any);
+      20 |     runHook();
+      21 |     expect(spy).toHaveBeenCalled();
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/precommit.test.ts:18:8)
+
+FAIL src/__tests__/memory-check.test.ts
+  ● memory-check › passes for ordered log
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      45 |     );
+      46 |     const execMock = jest
+    > 47 |       .spyOn(cp, 'execSync')
+         |        ^
+      48 |       .mockImplementation((cmd: string) => {
+      49 |         if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('test');
+      50 |         return Buffer.from('');
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-check.test.ts:47:8)
+
+  ● memory-check › allows commit after task with earlier timestamp
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      80 |     );
+      81 |     const execMock = jest
+    > 82 |       .spyOn(cp, 'execSync')
+         |        ^
+      83 |       .mockImplementation((cmd: string) => {
+      84 |         if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('msg');
+      85 |         return Buffer.from('');
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-check.test.ts:82:8)
+
+  ● memory-check › fails for unordered log
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      114 |     );
+      115 |     const execMock = jest
+    > 116 |       .spyOn(cp, 'execSync')
+          |        ^
+      117 |       .mockImplementation((cmd: string) => {
+      118 |         if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('test');
+      119 |         return Buffer.from('');
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-check.test.ts:116:8)
+
+  ● memory-check › fails for missing mem-id
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      154 |     );
+      155 |     const execMock = jest
+    > 156 |       .spyOn(cp, 'execSync')
+          |        ^
+      157 |       .mockImplementation((cmd: string) => {
+      158 |         if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('test');
+      159 |         return Buffer.from('');
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-check.test.ts:156:8)
+
+  ● memory-check › fails for mismatched summary
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      187 |     );
+      188 |     const execMock = jest
+    > 189 |       .spyOn(cp, 'execSync')
+          |        ^
+      190 |       .mockImplementation((cmd: string) => {
+      191 |         if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('correct');
+      192 |         return Buffer.from('');
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-check.test.ts:189:8)
+
+  ● memory-check › fails for invalid entry format
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      220 |     );
+      221 |     const execMock = jest
+    > 222 |       .spyOn(cp, 'execSync')
+          |        ^
+      223 |       .mockImplementation((cmd: string) => {
+      224 |         if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('something');
+      225 |         return Buffer.from('');
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-check.test.ts:222:8)
+
+  ● memory-check › fails when commit hashes repeat
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      257 |     );
+      258 |     const execMock = jest
+    > 259 |       .spyOn(cp, 'execSync')
+          |        ^
+      260 |       .mockImplementation((cmd: string) => {
+      261 |         if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('c');
+      262 |         return Buffer.from('');
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-check.test.ts:259:8)
+
+  ● memory-check › fails when tasks timestamps decrease
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      295 |     );
+      296 |     const execMock = jest
+    > 297 |       .spyOn(cp, 'execSync')
+          |        ^
+      298 |       .mockImplementation((cmd: string) => {
+      299 |         if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('t');
+      300 |         return Buffer.from('');
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-check.test.ts:297:8)
+
+  ● memory-check › fails when commit timestamps decrease
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      333 |     );
+      334 |     const execMock = jest
+    > 335 |       .spyOn(cp, 'execSync')
+          |        ^
+      336 |       .mockImplementation((cmd: string) => {
+      337 |         if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('m');
+      338 |         return Buffer.from('');
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-check.test.ts:335:8)
+
+FAIL src/__tests__/mem-rotate.test.ts
+  ● mem-rotate › truncates memory.log and backs up previous log
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      92 |     fs.writeFileSync(tmpMem, "1\n2\n3\n4\n5\n6\n");
+      93 |
+    > 94 |     const execMock = jest.spyOn(cp, "execSync").mockReturnValue(Buffer.from(""));
+         |                           ^
+      95 |
+      96 |     const map = {
+      97 |       [memPath]: tmpMem,
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/mem-rotate.test.ts:94:27)
+
+  ● mem-rotate › does not modify files during dry run
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      126 |     fs.writeFileSync(tmpMem, "1\n2\n3\n");
+      127 |
+    > 128 |     const execMock = jest.spyOn(cp, "execSync");
+          |                           ^
+      129 |
+      130 |     const map = {
+      131 |       [memPath]: tmpMem,
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/mem-rotate.test.ts:128:27)
+
+FAIL src/__tests__/economic-events-api.test.ts
+  ● economic events api › returns high impact events
+
+    Cannot find module '@/lib/data/economicEvents' from 'src/app/api/economic-events/route.ts'
+
+      1 | import { NextResponse } from 'next/server'
+    > 2 | import { fetchHighImpactEvents } from '@/lib/data/economicEvents'
+        | ^
+      3 | import { CACHE_TTL } from '@/lib/constants'
+      4 |
+      5 | let cache: { ts: number; data: any } | null = null
+
+      at Resolver._throwModNotFoundError (node_modules/jest-resolve/build/resolver.js:427:11)
+      at Object.<anonymous> (src/app/api/economic-events/route.ts:2:1)
+      at src/__tests__/economic-events-api.test.ts:13:13
+      at Object.<anonymous> (src/__tests__/economic-events-api.test.ts:12:10)
+
+FAIL src/__tests__/mem-diff.test.ts
+  ● mem-diff › prints hashes missing from memory.log
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+       8 |       .mockReturnValue(['abc123 | test | file | 2025-01-01']);
+       9 |     const execMock = jest
+    > 10 |       .spyOn(cp, 'execSync')
+         |        ^
+      11 |       .mockReturnValue(Buffer.from('def456\nabc123\n'));
+      12 |     const logMock = jest.spyOn(console, 'log').mockImplementation(() => {});
+      13 |
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/mem-diff.test.ts:10:8)
+
+  ● mem-diff › prints success message when all hashes present
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      31 |       ]);
+      32 |     const execMock = jest
+    > 33 |       .spyOn(cp, 'execSync')
+         |        ^
+      34 |       .mockReturnValue(Buffer.from('def456\nabc123\n'));
+      35 |     const logMock = jest.spyOn(console, 'log').mockImplementation(() => {});
+      36 |
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/mem-diff.test.ts:33:8)
+
+FAIL src/__tests__/memgrep.test.ts
+  ● memgrep › prints matching lines with ids or hashes
+
+    expect(received).toContain(expected) // indexOf
+
+    Expected value: StringContaining "abc123:"
+    Received array: ["abc123: abc123 | fix bug | file | 2025-01-01T00:00:00Z", "mem-001: minor fix details"]
+
+    Looks like you wanted to test for object/array equality with the stricter `toContain` matcher. You probably need to use `toContainEqual` instead.
+
+      53 |
+      54 |     const outputs = logMock.mock.calls.map((c) => c[0]);
+    > 55 |     expect(outputs).toContain(expect.stringContaining('abc123:'));
+         |                     ^
+      56 |     expect(outputs).toContain('mem-001: minor fix details');
+      57 |     expect(outputs.some((o) => /def456/.test(o))).toBe(false);
+      58 |     expect(outputs.some((o) => /mem-002/.test(o))).toBe(false);
+
+      at Object.<anonymous> (src/__tests__/memgrep.test.ts:55:21)
+
+  ● memgrep › prints nothing when no match found
+
+    expect(jest.fn()).not.toHaveBeenCalled()
+
+    Expected number of calls: 0
+    Received number of calls: 2
+
+    1: "abc123: abc123 | fix bug | file | 2025-01-01T00:00:00Z"
+    2: "mem-001: minor fix details"
+
+      78 |     });
+      79 |
+    > 80 |     expect(logMock).not.toHaveBeenCalled();
+         |                         ^
+      81 |
+      82 |     logMock.mockRestore();
+      83 |     fs.rmSync(dir, { recursive: true, force: true });
+
+      at Object.<anonymous> (src/__tests__/memgrep.test.ts:80:25)
+
+  ● memgrep › respects --since and --until range
+
+    expect(received).toContain(expected) // indexOf
+
+    Expected value: StringContaining "bbb222:"
+    Received array: ["abc123: abc123 | fix bug | file | 2025-01-01T00:00:00Z", "mem-001: minor fix details", "bbb222: bbb222 | fix late | file | 2025-01-03T00:00:00Z"]
+
+    Looks like you wanted to test for object/array equality with the stricter `toContain` matcher. You probably need to use `toContainEqual` instead.
+
+      119 |
+      120 |     const outputs = logMock.mock.calls.map((c) => c[0]);
+    > 121 |     expect(outputs).toContain(expect.stringContaining('bbb222:'));
+          |                     ^
+      122 |     expect(outputs).toContain('mem-011: late note');
+      123 |     expect(outputs.some((o) => /aaa111/.test(o))).toBe(false);
+      124 |     expect(outputs.some((o) => /mem-010/.test(o))).toBe(false);
+
+      at Object.<anonymous> (src/__tests__/memgrep.test.ts:121:21)
+
+FAIL src/__tests__/update-memory.test.ts
+  ● update-memory › updates memory log, snapshot and rotates
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      72 |
+      73 |     const calls: string[] = [];
+    > 74 |     const execMock = jest.spyOn(cp, 'execSync').mockImplementation((cmd: string) => {
+         |                           ^
+      75 |       calls.push(cmd);
+      76 |       if (cmd.includes('git log -1 --pretty=%s')) return Buffer.from('Task 1: summary');
+      77 |       if (cmd.startsWith('grep -m 1')) return Buffer.from('next');
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/update-memory.test.ts:74:27)
+
+FAIL src/__tests__/mem-sync.test.ts
+  ● mem-sync › merges logs from branch
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      13 |     const otherLines = 'a1 | A | y | 2025-01-01T00:00:00Z\n'
+      14 |     const exec = jest
+    > 15 |       .spyOn(cp, 'execSync')
+         |        ^
+      16 |       .mockReturnValue(otherLines as any)
+      17 |     const read = jest
+      18 |       .spyOn(utils, 'readMemoryLines')
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/mem-sync.test.ts:15:8)
+
+FAIL src/__tests__/memory-cli.test.ts
+  ● memory-cli › runs mem-diff for diff command
+
+    TypeError: Cannot redefine property: spawnSync
+        at Function.defineProperty (<anonymous>)
+
+      18 |
+      19 |   beforeEach(() => {
+    > 20 |     spy = jest.spyOn(cp, 'spawnSync').mockReturnValue({ status: 0 } as any);
+         |                ^
+      21 |   });
+      22 |
+      23 |   afterEach(() => jest.restoreAllMocks());
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-cli.test.ts:20:16)
+
+  ● memory-cli › runs memory-json for json command
+
+    TypeError: Cannot redefine property: spawnSync
+        at Function.defineProperty (<anonymous>)
+
+      18 |
+      19 |   beforeEach(() => {
+    > 20 |     spy = jest.spyOn(cp, 'spawnSync').mockReturnValue({ status: 0 } as any);
+         |                ^
+      21 |   });
+      22 |
+      23 |   afterEach(() => jest.restoreAllMocks());
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-cli.test.ts:20:16)
+
+  ● memory-cli › runs clean-locks for clean-locks command
+
+    TypeError: Cannot redefine property: spawnSync
+        at Function.defineProperty (<anonymous>)
+
+      18 |
+      19 |   beforeEach(() => {
+    > 20 |     spy = jest.spyOn(cp, 'spawnSync').mockReturnValue({ status: 0 } as any);
+         |                ^
+      21 |   });
+      22 |
+      23 |   afterEach(() => jest.restoreAllMocks());
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-cli.test.ts:20:16)
+
+  ● memory-cli › runs memory-check for check command
+
+    TypeError: Cannot redefine property: spawnSync
+        at Function.defineProperty (<anonymous>)
+
+      18 |
+      19 |   beforeEach(() => {
+    > 20 |     spy = jest.spyOn(cp, 'spawnSync').mockReturnValue({ status: 0 } as any);
+         |                ^
+      21 |   });
+      22 |
+      23 |   afterEach(() => jest.restoreAllMocks());
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-cli.test.ts:20:16)
+
+  ● memory-cli › runs rebuild-memory for rebuild command
+
+    TypeError: Cannot redefine property: spawnSync
+        at Function.defineProperty (<anonymous>)
+
+      18 |
+      19 |   beforeEach(() => {
+    > 20 |     spy = jest.spyOn(cp, 'spawnSync').mockReturnValue({ status: 0 } as any);
+         |                ^
+      21 |   });
+      22 |
+      23 |   afterEach(() => jest.restoreAllMocks());
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-cli.test.ts:20:16)
+
+  ● memory-cli › runs update-snapshot for snapshot-update command
+
+    TypeError: Cannot redefine property: spawnSync
+        at Function.defineProperty (<anonymous>)
+
+      18 |
+      19 |   beforeEach(() => {
+    > 20 |     spy = jest.spyOn(cp, 'spawnSync').mockReturnValue({ status: 0 } as any);
+         |                ^
+      21 |   });
+      22 |
+      23 |   afterEach(() => jest.restoreAllMocks());
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-cli.test.ts:20:16)
+
+  ● memory-cli › runs mem-list for list command
+
+    TypeError: Cannot redefine property: spawnSync
+        at Function.defineProperty (<anonymous>)
+
+      18 |
+      19 |   beforeEach(() => {
+    > 20 |     spy = jest.spyOn(cp, 'spawnSync').mockReturnValue({ status: 0 } as any);
+         |                ^
+      21 |   });
+      22 |
+      23 |   afterEach(() => jest.restoreAllMocks());
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at Object.<anonymous> (src/__tests__/memory-cli.test.ts:20:16)
+
+FAIL src/__tests__/update-snapshot.test.ts
+  ● update-snapshot › calls append-memory with locking and atomic write
+
+    TypeError: Cannot redefine property: execSync
+        at Function.defineProperty (<anonymous>)
+
+      106 |     withFsMocks(map, openCalls, renameCalls, unlinkCalls, () => {
+      107 |       const execMock = jest
+    > 108 |         .spyOn(cp, 'execSync')
+          |          ^
+      109 |         .mockImplementation((cmd: string) => {
+      110 |           if (cmd.startsWith('git log -1')) return Buffer.from(summary);
+      111 |           if (cmd.startsWith("grep -m 1")) return Buffer.from(nextTask);
+
+      at ModuleMocker.spyOn (node_modules/jest-mock/build/index.js:776:16)
+      at src/__tests__/update-snapshot.test.ts:108:10
+      at withFsMocks (src/__tests__/update-snapshot.test.ts:80:5)
+      at Object.<anonymous> (src/__tests__/update-snapshot.test.ts:106:5)
+
+FAIL src/__tests__/correlation.test.ts
+  ● correlation › zero correlation when arrays differ
+
+    expect(received).toBeCloseTo(expected)
+
+    Expected: 0
+    Received: NaN
+
+    Expected precision:    2
+    Expected difference: < 0.005
+    Received difference:   NaN
+
+       9 |   it('zero correlation when arrays differ', () => {
+      10 |     const val = correlation([1, 1, 1], [2, 3, 4]);
+    > 11 |     expect(val).toBeCloseTo(0);
+         |                 ^
+      12 |   });
+      13 | });
+      14 |
+
+      at Object.<anonymous> (src/__tests__/correlation.test.ts:11:17)
+
+
+Test Suites: 21 failed, 7 passed, 28 total
+Tests:       46 failed, 42 passed, 88 total
+Snapshots:   0 total
+Time:        19.609 s, estimated 22 s
+Ran all test suites.

--- a/scripts/dev-deps.sh
+++ b/scripts/dev-deps.sh
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
+
+CACHE_DIR=".cache"
+CACHE_ARCHIVE="$CACHE_DIR/node_modules.tar.gz"
+
 if [ ! -d node_modules ]; then
+  if [ -f "$CACHE_ARCHIVE" ]; then
+    echo "Restoring node_modules from cache..."
+    tar -xzf "$CACHE_ARCHIVE"
+  fi
+
   echo "Installing dev dependencies..."
   npm ci || echo "npm ci failed – possibly offline"
+
+  if [ -d node_modules ]; then
+    echo "Packing node_modules cache..."
+    mkdir -p "$CACHE_DIR"
+    tar -czf "$CACHE_ARCHIVE" node_modules
+  fi
 fi


### PR DESCRIPTION
## Summary
- use `.cache/node_modules.tar.gz` in `dev-deps.sh`
- cache the archive in all workflows
- document dependency cache in README and quickstart
- mention cached install in CODEX_START
- ignore generated memory JSON files
- failing lint/test results logged to `logs/block-99.txt`

## Testing
- `npm run lint` *(fails: 69 errors)*
- `npm run test` *(fails: 46 failed, 42 passed)*

------
https://chatgpt.com/codex/tasks/task_b_68486116f9c88323b064aeb204c7ba88