### PR TITLE
Task 110: allow AutoTaskRunner to continue on task failure

### DIFF
--- a/src/scripts/autoTaskRunner.ts
+++ b/src/scripts/autoTaskRunner.ts
@@ -72,7 +72,8 @@ export function runTasks() {
       });
       fs.writeFileSync(path.join(logDir, `block-${taskNum}.txt`), 'Task failed.');
       console.error('Task failed. See logs for details.');
-      process.exit(1);
+      // halt current task but continue loop so other tasks run
+      return;
     }
 
     execSync('git add TASKS.md logs signals.json');
@@ -113,7 +114,8 @@ export function runTasks() {
         atomicWrite(signalsPath, JSON.stringify(signals, null, 2) + '\n');
       });
       console.error('Memory validation failed. See logs for details.');
-      process.exit(1);
+      // stop this task but keep runner alive for subsequent tasks
+      return;
     }
 
     tryExec('git pull --rebase origin main');


### PR DESCRIPTION
## Summary
- keep AutoTaskRunner loop running after lint/test/backtest failures
- do the same for memory validation failures

## Testing
- `npm run lint` *(fails: eslint errors)*
- `npm run test` *(fails: 21 failed test suites)*

------
https://chatgpt.com/codex/tasks/task_b_68486f2ebd208323ba3abcaa3dc93b74