### PR TITLE
Task 111: move npm ci outside task loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Task 95: create memory CLI with rotate, snapshot-rotate, status, grep, update-lo
 
 | Command | Purpose |
 | ------- | ------- |
-| `npm run auto` | Execute the AutoTaskRunner to process tasks in `TASKS.md`; each run validates memory after committing |
+| `npm run auto` | Execute the AutoTaskRunner to process tasks in `TASKS.md`; installs dependencies once then validates memory after each commit |
 | `npm run memory` | Manage memory files: rotate, snapshot-rotate, status, grep, update-log, list, diff, json, clean-locks, check, locate, rebuild, sync, snapshot-update |
 | `npm run mem-rotate` | Trim `memory.log` to a set number of entries |
 | `npm run mem-check` | Verify memory hashes and snapshot blocks (auto after `mem-rotate`) |

--- a/src/scripts/autoTaskRunner.ts
+++ b/src/scripts/autoTaskRunner.ts
@@ -16,6 +16,10 @@ function tryExec(cmd: string) {
   }
 }
 
+function ensureDeps() {
+  tryExec('npm ci');
+}
+
 export function runTasks() {
   const tasksPath = path.join(repoRoot, 'TASKS.md');
   const signalsPath = path.join(repoRoot, 'signals.json');
@@ -24,7 +28,8 @@ export function runTasks() {
   const memoryPath = memPath;
   process.chdir(repoRoot);
 
-  tryExec('npm ci');
+  // install dependencies before entering the main loop
+  ensureDeps();
 
   while (true) {
     const lines = fs.readFileSync(tasksPath, 'utf8').split('\n');


### PR DESCRIPTION
## Summary
- ensure dependencies install only once before AutoTaskRunner loop
- note automatic install in README

## Testing
- `npm run lint` *(fails: unexpected any and other lint errors)*
- `npm run test` *(fails: multiple test suites fail)*
- `npm run backtest` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_b_684876adbfdc8323a29cfce7c9ce64c4