### PR TITLE
Task 106: finalize task removal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Refer to [docs/SETUP_QUICKSTART.md](docs/SETUP_QUICKSTART.md) for a rapid local 
 
 
 This charter is optimized around **Git-based memory**. Every commit and
-summary becomes part of the agent's long-term knowledge. Keep the task queue,
+summary becomes part of the agent's long-term knowledge. Keep `TASKS.md`,
 memory files and commit history aligned so Codex can resume work even after a
 context reset.
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -70,7 +70,7 @@ Each task below is prefixed with `Task <id>` and tracked directly in this file.
 - [x] Task 104: merge memory scripts into update-memory.ts with mem-update command and tests
 - [x] Task 105: add archive-memory script and docs
 
-- [ ] Task 106: remove task_queue.json; autoTaskRunner reads TASKS.md; update docs
+- [x] Task 106: remove task_queue.json; autoTaskRunner reads TASKS.md; update docs
 - [ ] Task 107: rotate memory.log in update-memory.ts; drop pre-commit rotation
 - [x] Task 108: delete obsolete memory scripts from scripts/ and package.json
 - [x] Task 109: define single workflow entry; update README, AGENTS, CODEX_START


### PR DESCRIPTION
## Summary
- update AGENTS to mention TASKS.md instead of the old task queue
- mark Task 106 as complete in TASKS.md

## Testing
- `npm run lint` *(fails: 69 errors)*
- `npm run test` *(fails: 21 suites, 46 tests)*


------
https://chatgpt.com/codex/tasks/task_b_68487ff9e8ec83238c4ce463c6e8fcb1