### PR TITLE
Task 112: consolidate memory CLI

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -76,6 +76,7 @@ Each task below is prefixed with `Task <id>` and tracked directly in this file.
 - [x] Task 109: define single workflow entry; update README, AGENTS, CODEX_START
 - [ ] Task 110: investigate and fix broken post-commit hook
 - [ ] Task 111: remove obsolete docs from repo
+- [ ] Task 112: refactor memory-cli with native subcommands; port mem-rotate, memgrep, mem-diff, mem-status and update tests
 
 
 ### Bitcoin Dashboard

--- a/scripts/mem-diff.ts
+++ b/scripts/mem-diff.ts
@@ -1,22 +1,3 @@
-import { execSync } from 'child_process';
-import { readMemoryLines, repoRoot } from './memory-utils';
+import { memDiff } from './memory-cli';
 
-const memHashes = new Set(
-  readMemoryLines().map((line) => line.split('|')[0].trim())
-);
-
-const gitHashes = execSync('git log --pretty=%h --no-merges', {
-  cwd: repoRoot,
-})
-  .toString()
-  .trim()
-  .split('\n')
-  .filter(Boolean);
-
-const missing = gitHashes.filter((h) => !memHashes.has(h));
-
-if (missing.length) {
-  console.log(missing.join('\n'));
-} else {
-  console.log('All commits present in memory.log');
-}
+memDiff();

--- a/scripts/mem-status.ts
+++ b/scripts/mem-status.ts
@@ -1,27 +1,3 @@
-import fs from 'fs';
-import path from 'path';
-import {
-  readMemoryLines,
-  nextMemId,
-  memPath,
-  repoRoot,
-  parseMemoryLines,
-} from './memory-utils';
+import { memStatus } from './memory-cli';
 
-const tasksPath = path.join(repoRoot, 'TASKS.md');
-
-const lines = readMemoryLines();
-const entries = parseMemoryLines(lines);
-const last = entries.length ? entries[entries.length - 1].raw : 'none';
-
-let task = 'none';
-if (fs.existsSync(tasksPath)) {
-  const tLines = fs.readFileSync(tasksPath, 'utf8').split('\n');
-  const pending = tLines.find((l) => l.startsWith('- [ ] '));
-  if (pending) task = pending.replace(/^- \[ \] /, '').trim();
-}
-
-const id = nextMemId();
-
-console.log(`${last}\nmem-${id}\n${task}`);
-
+memStatus();

--- a/scripts/memgrep.ts
+++ b/scripts/memgrep.ts
@@ -1,68 +1,15 @@
-import fs from 'fs';
-import { memPath, snapshotPath } from './memory-utils';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { memgrep } from './memory-cli';
 
-const args = process.argv.slice(2);
-let pattern: string | undefined;
-let sinceArg: string | undefined;
-let untilArg: string | undefined;
+const argv = yargs(hideBin(process.argv))
+  .option('since', { type: 'string' })
+  .option('until', { type: 'string' })
+  .parseSync();
 
-for (let i = 0; i < args.length; i++) {
-  const a = args[i];
-  if (a === '--since') {
-    sinceArg = args[++i];
-  } else if (a === '--until') {
-    untilArg = args[++i];
-  } else if (!pattern) {
-    pattern = a;
-  }
-}
-
+const [pattern] = argv._ as string[];
 if (!pattern) {
-  console.error(
-    'Usage: ts-node scripts/memgrep.ts <pattern> [--since <iso>] [--until <iso>]'
-  );
+  console.error('Usage: ts-node scripts/memgrep.ts <pattern> [--since <iso>] [--until <iso>]');
   process.exit(1);
 }
-
-const since = sinceArg ? Date.parse(sinceArg) : NaN;
-const until = untilArg ? Date.parse(untilArg) : NaN;
-const regex = new RegExp(pattern, 'i');
-
-// Search memory.log
-if (fs.existsSync(memPath)) {
-  const lines = fs.readFileSync(memPath, 'utf8').split('\n');
-  for (const line of lines) {
-    if (!regex.test(line)) continue;
-    const parts = line.split('|');
-    const ts = Date.parse(parts[parts.length - 1].trim());
-    if ((!Number.isNaN(since) && ts < since) || (!Number.isNaN(until) && ts > until)) {
-      continue;
-    }
-    const hash = parts[0].trim();
-    console.log(`${hash}: ${line.trim()}`);
-  }
-}
-
-// Search context.snapshot.md
-if (fs.existsSync(snapshotPath)) {
-  const lines = fs.readFileSync(snapshotPath, 'utf8').split('\n');
-  let currentId = 'unknown';
-  let currentTs = NaN;
-  for (const raw of lines) {
-    const line = raw.trimEnd();
-    const header = line.match(/^###\s+([^|]+)\s*\|\s*(mem-\d+)/);
-    if (header) {
-      currentTs = Date.parse(header[1].trim());
-      currentId = header[2];
-      continue;
-    }
-    if (!regex.test(line)) continue;
-    if (
-      (!Number.isNaN(since) && currentTs < since) ||
-      (!Number.isNaN(until) && currentTs > until)
-    ) {
-      continue;
-    }
-    console.log(`${currentId}: ${line.trim()}`);
-  }
-}
+memgrep(pattern, argv.since as string | undefined, argv.until as string | undefined);

--- a/scripts/memory-cli.ts
+++ b/scripts/memory-cli.ts
@@ -1,66 +1,380 @@
-import { spawnSync } from 'child_process';
+import fs from 'fs';
 import path from 'path';
+import { execSync } from 'child_process';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import { repoRoot } from './memory-utils';
+import {
+  repoRoot,
+  memPath,
+  snapshotPath,
+  readMemoryLines,
+  atomicWrite,
+  withFileLock,
+  parseMemoryLines,
+  parseSnapshotEntries,
+  nextMemId,
+} from './memory-utils';
+import { cleanLocks } from './clean-locks';
 
-const cmdArgs = hideBin(process.argv);
-
-function run(script: string, args: string[]) {
-  const result = spawnSync('ts-node', [path.join(__dirname, script), ...args], {
-    stdio: 'inherit',
-    cwd: repoRoot,
-  });
-  process.exitCode = result.status ?? undefined;
+export function rotate(limit = parseInt(process.env.MEM_ROTATE_LIMIT || '200', 10), dryRun = false): void {
+  const lines = readMemoryLines();
+  if (lines.length > limit) {
+    const trimmed = lines.slice(-limit);
+    const backupDir = path.join(repoRoot, 'logs');
+    fs.mkdirSync(backupDir, { recursive: true });
+    const ts = new Date().toISOString();
+    const backupPath = path.join(backupDir, `memory.log.${ts}.bak`);
+    if (dryRun) {
+      console.log(`[dry-run] Would backup to ${backupPath} and trim memory.log to last ${limit} entries`);
+    } else {
+      withFileLock(memPath, () => {
+        atomicWrite(backupPath, lines.join('\n') + '\n');
+        atomicWrite(memPath, trimmed.join('\n') + '\n');
+      });
+      console.log(`memory.log trimmed to last ${limit} entries`);
+    }
+  } else {
+    console.log('memory.log already within limit');
+  }
+  if (!dryRun) {
+    try {
+      execSync('ts-node scripts/memory-check.ts', { cwd: repoRoot, stdio: 'inherit' });
+    } catch (err: any) {
+      process.exit(err.status || 1);
+    }
+  } else {
+    console.log('[dry-run] Skipping memory-check');
+  }
 }
 
-const commandMap: Record<string, string> = {
-  rotate: 'mem-rotate.ts',
-  'snapshot-rotate': 'snapshot-rotate.ts',
-  status: 'mem-status.ts',
-  grep: 'memgrep.ts',
-  locate: 'mem-locate.ts',
-  'update-log': 'update-memory-log.ts',
-  list: 'mem-list.ts',
-  diff: 'mem-diff.ts',
-  json: 'memory-json.ts',
-  'clean-locks': 'clean-locks.ts',
-  check: 'memory-check.ts',
-  restore: 'restore-memory.ts',
-  rebuild: 'rebuild-memory.ts',
-  sync: 'mem-sync.ts',
-  'snapshot-update': 'update-snapshot.ts',
-};
+export function snapshotRotate(limit = parseInt(process.env.SNAP_ROTATE_LIMIT || '100', 10), dryRun = false): void {
+  if (!fs.existsSync(snapshotPath)) {
+    console.log('context.snapshot.md not found');
+    return;
+  }
+  const raw = fs.readFileSync(snapshotPath, 'utf8');
+  const lines = raw.split('\n');
+  const headers: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith('### ')) headers.push(i);
+  }
+  if (headers.length > limit) {
+    const start = headers[headers.length - limit];
+    const trimmed = lines.slice(start);
+    const backupDir = path.join(repoRoot, 'logs');
+    fs.mkdirSync(backupDir, { recursive: true });
+    const ts = new Date().toISOString();
+    const backupPath = path.join(backupDir, `context.snapshot.${ts}.bak`);
+    if (dryRun) {
+      console.log(`[dry-run] Would backup to ${backupPath} and trim context.snapshot.md to last ${limit} entries`);
+    } else {
+      withFileLock(snapshotPath, () => {
+        atomicWrite(backupPath, raw);
+        atomicWrite(snapshotPath, trimmed.join('\n') + '\n');
+      });
+      console.log(`context.snapshot.md trimmed to last ${limit} entries`);
+    }
+  } else {
+    console.log('context.snapshot.md already within limit');
+  }
+}
 
-yargs(cmdArgs)
-  .scriptName('memory')
-  .usage('Usage: $0 <command> [args]')
-  .command('rotate [limit]', 'Trim memory.log')
-  .command('snapshot-rotate [limit]', 'Trim context.snapshot.md')
-  .command('status', 'Print last entry and next task')
-  .command('grep <pattern>', 'Search memory files')
-  .command('locate <hash|mem-id>', 'Show snapshot entry for a commit')
-  .command('update-log', 'Refresh memory.log from git history')
-  .command('list', 'Show the last N entries')
-  .command('diff', 'List commits missing from memory.log')
-  .command('json', 'Export memory.log to memory.json')
-  .command('clean-locks', 'Delete stale .lock files')
-  .command('restore <backup> <memory|snapshot>',
-    'Restore memory or snapshot file')
-  .command('check', 'Verify memory files')
-  .command('rebuild [path]', 'Rebuild memory files from git history')
-  .command('sync <branch>', 'Merge memory.log from another branch')
-  .command('snapshot-update', 'Append last commit summary to snapshot')
-  .demandCommand(1, 'Specify a command')
-  .help()
-  .strict()
-  .parseSync();
+export function memStatus(): void {
+  const lines = readMemoryLines();
+  const entries = parseMemoryLines(lines);
+  const last = entries.length ? entries[entries.length - 1].raw : 'none';
+  let task = 'none';
+  const tasksPath = path.join(repoRoot, 'TASKS.md');
+  if (fs.existsSync(tasksPath)) {
+    const tLines = fs.readFileSync(tasksPath, 'utf8').split('\n');
+    const pending = tLines.find((l) => l.startsWith('- [ ] '));
+    if (pending) task = pending.replace(/^- \[ \] /, '').trim();
+  }
+  const id = nextMemId();
+  console.log(`${last}\nmem-${id}\n${task}`);
+}
 
-const [cmd, ...rest] = cmdArgs;
-const script = commandMap[cmd];
-if (script) {
-  run(script, rest);
-} else {
-  console.error(`Unknown command: ${cmd}`);
-  process.exitCode = 1;
+export function memgrep(pattern: string, since?: string, until?: string): void {
+  const sinceTs = since ? Date.parse(since) : NaN;
+  const untilTs = until ? Date.parse(until) : NaN;
+  const regex = new RegExp(pattern, 'i');
+  if (fs.existsSync(memPath)) {
+    const lines = fs.readFileSync(memPath, 'utf8').split('\n');
+    for (const line of lines) {
+      if (!regex.test(line)) continue;
+      const parts = line.split('|');
+      const ts = Date.parse(parts[parts.length - 1].trim());
+      if ((!Number.isNaN(sinceTs) && ts < sinceTs) || (!Number.isNaN(untilTs) && ts > untilTs)) continue;
+      const hash = parts[0].trim();
+      console.log(`${hash}: ${line.trim()}`);
+    }
+  }
+  if (fs.existsSync(snapshotPath)) {
+    const lines = fs.readFileSync(snapshotPath, 'utf8').split('\n');
+    let currentId = 'unknown';
+    let currentTs = NaN;
+    for (const raw of lines) {
+      const line = raw.trimEnd();
+      const header = line.match(/^###\s+([^|]+)\s*\|\s*(mem-\d+)/);
+      if (header) {
+        currentTs = Date.parse(header[1].trim());
+        currentId = header[2];
+        continue;
+      }
+      if (!regex.test(line)) continue;
+      if ((!Number.isNaN(sinceTs) && currentTs < sinceTs) || (!Number.isNaN(untilTs) && currentTs > untilTs)) continue;
+      console.log(`${currentId}: ${line.trim()}`);
+    }
+  }
+}
+
+export function memDiff(): void {
+  const memHashes = new Set(readMemoryLines().map((l) => l.split('|')[0].trim()));
+  const gitHashes = execSync('git log --pretty=%h --no-merges', { cwd: repoRoot })
+    .toString()
+    .trim()
+    .split('\n')
+    .filter(Boolean);
+  const missing = gitHashes.filter((h) => !memHashes.has(h));
+  if (missing.length) {
+    console.log(missing.join('\n'));
+  } else {
+    console.log('All commits present in memory.log');
+  }
+}
+
+export function memList(limit = 10): void {
+  const lines = readMemoryLines();
+  const entries = parseMemoryLines(lines);
+  const slice = entries.slice(-limit);
+  for (const e of slice) console.log(e.raw);
+}
+
+export function memLocate(arg: string): void {
+  const memEntries = parseMemoryLines(readMemoryLines());
+  const snapLines = fs.existsSync(snapshotPath)
+    ? fs.readFileSync(snapshotPath, 'utf8').split('\n')
+    : [];
+  const snapEntries = parseSnapshotEntries(snapLines);
+  let entry;
+  if (arg.startsWith('mem-')) {
+    entry = snapEntries.find((e) => e.id === arg);
+  } else {
+    const mem = memEntries.find((e) => e.hash.startsWith(arg));
+    const hash = mem ? mem.hash : arg;
+    entry = snapEntries.find((e) => e.commit.startsWith(hash));
+  }
+  if (entry) console.log(entry.raw.trim());
+}
+
+export function memSync(branch: string): void {
+  let otherLog = '';
+  try {
+    otherLog = execSync(`git show ${branch}:memory.log`, {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+  } catch {
+    console.error(`Unable to read memory.log from ${branch}`);
+    process.exit(1);
+  }
+  const otherLines = otherLog.trim().split('\n').filter(Boolean);
+  const localLines = readMemoryLines();
+  const combined = parseMemoryLines([...localLines, ...otherLines]);
+  combined.sort((a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp));
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const entry of combined) {
+    if (seen.has(entry.hash)) continue;
+    seen.add(entry.hash);
+    result.push(entry.raw.trim());
+  }
+  withFileLock(memPath, () => {
+    atomicWrite(memPath, result.join('\n') + '\n');
+  });
+  console.log('memory.log synchronized');
+}
+
+export function updateLog(verify = false): void {
+  let entries = readMemoryLines();
+  let lastHash = '';
+  if (entries.length) {
+    const candidate = entries[entries.length - 1].split(' | ')[0];
+    try {
+      execSync(`git cat-file -e ${candidate}`, { cwd: repoRoot, stdio: 'ignore' });
+      lastHash = candidate;
+    } catch {
+      lastHash = '';
+    }
+  }
+  const logCmd = lastHash
+    ? `git log ${lastHash}..HEAD --reverse --pretty=format:%h|%s|%cI --name-only`
+    : 'git log --reverse --pretty=format:%h|%s|%cI --name-only';
+  const lines = execSync(logCmd, { cwd: repoRoot, encoding: 'utf8' })
+    .trim()
+    .split('\n');
+  let current: { h: string; s: string; d: string; f: string[] } | undefined;
+  for (const line of lines) {
+    if (!line) continue;
+    if (line.includes('|')) {
+      if (current) {
+        entries.push(`${current.h} | ${current.s} | ${current.f.join(', ')} | ${current.d}`);
+      }
+      const [h, s, d] = line.split('|');
+      current = { h, s: s.trim(), d: d.trim(), f: [] };
+    } else if (current) {
+      current.f.push(line.trim());
+    }
+  }
+  if (current) {
+    entries.push(`${current.h} | ${current.s} | ${current.f.join(', ')} | ${current.d}`);
+  }
+  const uniq: string[] = [];
+  const seen = new Set<string>();
+  for (const line of entries) {
+    const hash = line.split('|')[0].trim();
+    if (seen.has(hash)) continue;
+    seen.add(hash);
+    uniq.push(line);
+  }
+  entries = uniq;
+  withFileLock(memPath, () => {
+    atomicWrite(memPath, entries.join('\n') + '\n');
+  });
+  console.log('memory.log updated');
+  if (verify) {
+    try {
+      execSync('ts-node scripts/memory-check.ts', { cwd: repoRoot, stdio: 'inherit' });
+    } catch (err: any) {
+      process.exit(err.status || 1);
+    }
+  }
+}
+
+export function memoryJson(): void {
+  const lines = readMemoryLines();
+  const entries = lines.map((line) => {
+    const parts = line.split('|').map((p) => p.trim());
+    const hash = parts[0];
+    const summary = parts.length === 5 ? parts[2] : parts[1];
+    const filesPart = parts.length === 5 ? parts[3] : parts[2];
+    const timestamp = parts[parts.length - 1];
+    const files = filesPart.split(',').map((f) => f.trim()).filter(Boolean);
+    return { hash, summary, files, timestamp };
+  });
+  const outPath = path.join(repoRoot, 'memory.json');
+  withFileLock(outPath, () => {
+    atomicWrite(outPath, JSON.stringify(entries, null, 2) + '\n');
+  });
+  console.log(`memory.json written to ${outPath}`);
+}
+
+export function restoreMemory(backup: string, target: 'memory' | 'snapshot'): void {
+  if (!fs.existsSync(backup)) {
+    console.error(`Backup file not found: ${backup}`);
+    process.exit(1);
+  }
+  const dest = target === 'memory' ? memPath : snapshotPath;
+  const data = fs.readFileSync(backup, 'utf8');
+  withFileLock(dest, () => {
+    atomicWrite(dest, data);
+  });
+  console.log(`${dest} restored from ${backup}`);
+}
+
+export function rebuildMemory(pathArg?: string): void {
+  const repo = pathArg ? path.resolve(pathArg) : repoRoot;
+  const memFile = path.join(repo, 'memory.log');
+  const snapFile = path.join(repo, 'context.snapshot.md');
+  if (fs.existsSync(memFile)) fs.unlinkSync(memFile);
+  if (fs.existsSync(snapFile)) fs.unlinkSync(snapFile);
+  const raw = execSync('git log --reverse --pretty=format:%h|%s|%cI --name-only', { cwd: repo, encoding: 'utf8' });
+  const lines = raw.trim().split('\n');
+  const entries: { h: string; s: string; d: string; f: string[] }[] = [];
+  let cur: { h: string; s: string; d: string; f: string[] } | undefined;
+  for (const line of lines) {
+    if (!line) continue;
+    if (line.includes('|')) {
+      if (cur) entries.push(cur);
+      const [h, s, d] = line.split('|');
+      cur = { h: h.trim(), s: s.trim(), d: d.trim(), f: [] };
+    } else if (cur) {
+      cur.f.push(line.trim());
+    }
+  }
+  if (cur) entries.push(cur);
+  const original = execSync('git rev-parse --abbrev-ref HEAD || git rev-parse HEAD', { cwd: repo, encoding: 'utf8', shell: '/bin/bash' }).trim();
+  const append = path.join(__dirname, 'append-memory.ts');
+  for (const e of entries) {
+    execSync(`git checkout ${e.h} --quiet`, { cwd: repo, stdio: 'ignore' });
+    execSync(`ts-node ${append} ${JSON.stringify(e.s)} ${JSON.stringify('rebuild')}`, { cwd: repo, stdio: 'ignore', shell: '/bin/bash' });
+  }
+  execSync(`git checkout ${original} --quiet`, { cwd: repo, stdio: 'ignore' });
+  const linesOut = entries.map((e) => `${e.h} | ${e.s} | ${e.f.join(', ')} | ${e.d}`);
+  withFileLock(memFile, () => {
+    atomicWrite(memFile, linesOut.join('\n') + '\n');
+  });
+  console.log('memory.log and context.snapshot.md rebuilt');
+}
+
+export function snapshotUpdate(): void {
+  function lastCommitSummary(): string {
+    const out = execSync('git log -1 --pretty=format:%s%n%n%b', { cwd: repoRoot, encoding: 'utf8' }).trim();
+    return out || 'No summary';
+  }
+  function nextOpenTask(): string {
+    try {
+      const cmd = "grep -m 1 '^- \[ \]' TASKS.md | sed -E 's/^- \[ \] //'";
+      const task = execSync(cmd, { cwd: repoRoot, shell: '/bin/bash', encoding: 'utf8' }).trim();
+      return task || 'none';
+    } catch {
+      return 'none';
+    }
+  }
+  const summary = lastCommitSummary();
+  const nextTask = nextOpenTask();
+  execSync(`ts-node scripts/append-memory.ts ${JSON.stringify(summary)} ${JSON.stringify(nextTask)}`, { cwd: repoRoot, stdio: 'inherit', shell: '/bin/bash' });
+}
+
+export function main(argv = hideBin(process.argv)): void {
+  yargs(argv)
+    .scriptName('memory')
+    .command('rotate [limit]', 'Trim memory.log', (y) =>
+      y.positional('limit', { type: 'number' }).option('dry-run', { type: 'boolean' }),
+      (args) => rotate(args.limit as number | undefined, args.dryRun as boolean)
+    )
+    .command('snapshot-rotate [limit]', 'Trim context.snapshot.md', (y) =>
+      y.positional('limit', { type: 'number' }).option('dry-run', { type: 'boolean' }),
+      (args) => snapshotRotate(args.limit as number | undefined, args.dryRun as boolean)
+    )
+    .command('status', 'Print last entry and next task', () => {}, () => memStatus())
+    .command('grep <pattern>', 'Search memory files', (y) =>
+      y.positional('pattern', { type: 'string' })
+        .option('since', { type: 'string' })
+        .option('until', { type: 'string' }),
+      (args) => memgrep(args.pattern as string, args.since as string | undefined, args.until as string | undefined)
+    )
+    .command('diff', 'List commits missing from memory.log', () => {}, () => memDiff())
+    .command('list [limit]', 'Show the last N entries', (y) => y.option('limit', { alias: 'n', type: 'number' }), (a) => memList(a.limit as number | undefined))
+    .command('locate <target>', 'Show snapshot entry for a commit', (y) => y.positional('target', { type: 'string' }), (a) => memLocate(a.target as string))
+    .command('update-log', 'Refresh memory.log from git history', (y) => y.option('verify', { type: 'boolean' }), (a) => updateLog(a.verify as boolean))
+    .command('json', 'Export memory.log to memory.json', () => {}, () => memoryJson())
+    .command('clean-locks', 'Delete stale .lock files', () => {}, () => cleanLocks())
+    .command('restore <backup> <dest>', 'Restore memory or snapshot file', (y) =>
+      y.positional('backup', { type: 'string' })
+        .positional('dest', { choices: ['memory', 'snapshot'] as const }),
+      (a) => restoreMemory(a.backup as string, a.dest as 'memory' | 'snapshot')
+    )
+    .command('check', 'Verify memory files', () => {}, () => require('./memory-check.ts'))
+    .command('rebuild [path]', 'Rebuild memory files from git history', (y) => y.positional('path', { type: 'string' }), (a) => rebuildMemory(a.path as string | undefined))
+    .command('sync <branch>', 'Merge memory.log from another branch', (y) => y.positional('branch', { type: 'string' }), (a) => memSync(a.branch as string))
+    .command('snapshot-update', 'Append last commit summary to snapshot', () => {}, () => snapshotUpdate())
+    .demandCommand(1)
+    .help()
+    .strict()
+    .parse();
+}
+
+if (require.main === module) {
+  main();
 }

--- a/src/__tests__/mem-diff.test.ts
+++ b/src/__tests__/mem-diff.test.ts
@@ -1,5 +1,6 @@
 import * as cp from 'child_process';
 import * as utils from '../../scripts/memory-utils';
+import { memDiff } from '../../scripts/memory-cli';
 
 describe('mem-diff', () => {
   it('prints hashes missing from memory.log', () => {
@@ -12,7 +13,7 @@ describe('mem-diff', () => {
     const logMock = jest.spyOn(console, 'log').mockImplementation(() => {});
 
     jest.isolateModules(() => {
-      require('../../scripts/mem-diff.ts');
+      memDiff();
     });
 
     expect(logMock).toHaveBeenCalledWith('def456');
@@ -35,7 +36,7 @@ describe('mem-diff', () => {
     const logMock = jest.spyOn(console, 'log').mockImplementation(() => {});
 
     jest.isolateModules(() => {
-      require('../../scripts/mem-diff.ts');
+      memDiff();
     });
 
     expect(logMock).toHaveBeenCalledWith('All commits present in memory.log');

--- a/src/__tests__/mem-rotate.test.ts
+++ b/src/__tests__/mem-rotate.test.ts
@@ -3,6 +3,7 @@ import os from "os";
 import path from "path";
 import * as cp from "child_process";
 import * as utils from "../../scripts/memory-utils";
+import { rotate } from "../../scripts/memory-cli";
 
 const { memPath, repoRoot } = utils;
 
@@ -100,9 +101,7 @@ describe("mem-rotate", () => {
     withFsMocks(map, () => {
       process.env.MEM_ROTATE_LIMIT = "3";
       jest.useFakeTimers().setSystemTime(new Date(iso));
-      jest.isolateModules(() => {
-        require("../../scripts/mem-rotate.ts");
-      });
+      rotate(3, false);
       jest.useRealTimers();
     });
     expect(execMock).toHaveBeenCalledWith(
@@ -134,12 +133,7 @@ describe("mem-rotate", () => {
     withFsMocks(map, () => {
       process.env.MEM_ROTATE_LIMIT = "2";
       jest.useFakeTimers().setSystemTime(new Date(iso));
-      jest.isolateModules(() => {
-        const orig = process.argv;
-        process.argv = ["node", "script", "--dry-run"];
-        require("../../scripts/mem-rotate.ts");
-        process.argv = orig;
-      });
+      rotate(2, true);
       jest.useRealTimers();
     });
 

--- a/src/__tests__/mem-status.test.ts
+++ b/src/__tests__/mem-status.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import * as utils from '../../scripts/memory-utils';
+import { memStatus } from '../../scripts/memory-cli';
 
 const { memPath, snapshotPath, repoRoot } = utils;
 
@@ -44,7 +45,7 @@ describe('mem-status', () => {
       },
       () => {
         jest.isolateModules(() => {
-          require('../../scripts/mem-status.ts');
+          memStatus();
         });
       }
     );

--- a/src/__tests__/memgrep.test.ts
+++ b/src/__tests__/memgrep.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { memPath, snapshotPath } from '../../scripts/memory-utils';
+import { memgrep } from '../../scripts/memory-cli';
 
 function withFsMocks(paths: Record<string, string>, fn: () => void) {
   const origExists = fs.existsSync;
@@ -46,8 +47,7 @@ describe('memgrep', () => {
 
     withFsMocks({ [memPath]: tmpMem, [snapshotPath]: tmpSnap }, () => {
       jest.isolateModules(() => {
-        process.argv = ['node', 'memgrep.ts', 'fix'];
-        require('../../scripts/memgrep.ts');
+        memgrep('fix');
       });
     });
 
@@ -72,8 +72,7 @@ describe('memgrep', () => {
 
     withFsMocks({ [memPath]: tmpMem, [snapshotPath]: tmpSnap }, () => {
       jest.isolateModules(() => {
-        process.argv = ['node', 'memgrep.ts', 'nomatch'];
-        require('../../scripts/memgrep.ts');
+        memgrep('nomatch');
       });
     });
 
@@ -104,16 +103,7 @@ describe('memgrep', () => {
 
     withFsMocks({ [memPath]: tmpMem, [snapshotPath]: tmpSnap }, () => {
       jest.isolateModules(() => {
-        process.argv = [
-          'node',
-          'memgrep.ts',
-          'fix',
-          '--since',
-          '2025-01-02T00:00:00Z',
-          '--until',
-          '2025-01-04T00:00:00Z',
-        ];
-        require('../../scripts/memgrep.ts');
+        memgrep('fix', '2025-01-02T00:00:00Z', '2025-01-04T00:00:00Z');
       });
     });
 

--- a/src/__tests__/memory-cli.test.ts
+++ b/src/__tests__/memory-cli.test.ts
@@ -1,87 +1,63 @@
-import path from 'path';
-import * as cp from 'child_process';
-import { repoRoot } from '../../scripts/memory-utils';
+const mockCheck = jest.fn();
+jest.mock('../../scripts/memory-check.ts', () => {
+  mockCheck();
+  return {};
+});
 
-const scriptDir = path.resolve(__dirname, '../../scripts');
+import * as cli from '../../scripts/memory-cli';
 
 function run(args: string[]) {
   const orig = process.argv;
   process.argv = ['node', 'memory-cli.ts', ...args];
   jest.isolateModules(() => {
-    require('../../scripts/memory-cli.ts');
+    cli.main();
   });
   process.argv = orig;
 }
 
 describe('memory-cli', () => {
-  let spy: jest.SpyInstance;
-
-  beforeEach(() => {
-    spy = jest.spyOn(cp, 'spawnSync').mockReturnValue({ status: 0 } as any);
-  });
-
   afterEach(() => jest.restoreAllMocks());
 
   it('runs mem-diff for diff command', () => {
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const diffSpy = jest.spyOn(cli, 'memDiff').mockImplementation(() => {});
     run(['diff']);
-    expect(spy).toHaveBeenCalledWith(
-      'ts-node',
-      [path.join(scriptDir, 'mem-diff.ts')],
-      { stdio: 'inherit', cwd: repoRoot }
-    );
+    expect(diffSpy).toHaveBeenCalled();
+    spy.mockRestore();
   });
 
   it('runs memory-json for json command', () => {
+    const jsonSpy = jest.spyOn(cli, 'memoryJson').mockImplementation(() => {});
     run(['json']);
-    expect(spy).toHaveBeenCalledWith(
-      'ts-node',
-      [path.join(scriptDir, 'memory-json.ts')],
-      { stdio: 'inherit', cwd: repoRoot }
-    );
+    expect(jsonSpy).toHaveBeenCalled();
   });
 
   it('runs clean-locks for clean-locks command', () => {
+    const clSpy = jest.spyOn(cli, 'cleanLocks').mockImplementation(() => {});
     run(['clean-locks']);
-    expect(spy).toHaveBeenCalledWith(
-      'ts-node',
-      [path.join(scriptDir, 'clean-locks.ts')],
-      { stdio: 'inherit', cwd: repoRoot }
-    );
+    expect(clSpy).toHaveBeenCalled();
   });
 
   it('runs memory-check for check command', () => {
     run(['check']);
-    expect(spy).toHaveBeenCalledWith(
-      'ts-node',
-      [path.join(scriptDir, 'memory-check.ts')],
-      { stdio: 'inherit', cwd: repoRoot }
-    );
+    expect(mockCheck).toHaveBeenCalled();
   });
 
   it('runs rebuild-memory for rebuild command', () => {
+    const rebuildSpy = jest.spyOn(cli, 'rebuildMemory').mockImplementation(() => {});
     run(['rebuild']);
-    expect(spy).toHaveBeenCalledWith(
-      'ts-node',
-      [path.join(scriptDir, 'rebuild-memory.ts')],
-      { stdio: 'inherit', cwd: repoRoot }
-    );
+    expect(rebuildSpy).toHaveBeenCalled();
   });
 
   it('runs update-snapshot for snapshot-update command', () => {
+    const snapSpy = jest.spyOn(cli, 'snapshotUpdate').mockImplementation(() => {});
     run(['snapshot-update']);
-    expect(spy).toHaveBeenCalledWith(
-      'ts-node',
-      [path.join(scriptDir, 'update-snapshot.ts')],
-      { stdio: 'inherit', cwd: repoRoot }
-    );
+    expect(snapSpy).toHaveBeenCalled();
   });
 
   it('runs mem-list for list command', () => {
+    const listSpy = jest.spyOn(cli, 'memList').mockImplementation(() => {});
     run(['list']);
-    expect(spy).toHaveBeenCalledWith(
-      'ts-node',
-      [path.join(scriptDir, 'mem-list.ts')],
-      { stdio: 'inherit', cwd: repoRoot }
-    );
+    expect(listSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add Task 112 for memory-cli refactor
- rewrite scripts/memory-cli.ts with yargs subcommands
- call new functions from mem-diff.ts, memgrep.ts, mem-rotate.ts and mem-status.ts
- update corresponding tests to use new exports

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm run test` *(fails: multiple jest suite errors)*
- `npm run backtest` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_b_6848982ed4ec83239e58dee79efa1bf6