### PR TITLE
Task 107: refactor update-memory to use memory-cli

### DIFF
--- a/src/__tests__/update-memory.test.ts
+++ b/src/__tests__/update-memory.test.ts
@@ -78,6 +78,10 @@ describe('update-memory', () => {
       if (cmd.startsWith('git rev-parse')) return Buffer.from('abc123');
       return Buffer.from('');
     });
+    const cli = require('../../scripts/memory-cli') as typeof import('../../scripts/memory-cli');
+    const uMock = jest.spyOn(cli, 'updateLog').mockImplementation(() => {});
+    const sMock = jest.spyOn(cli, 'snapshotUpdate').mockImplementation(() => {});
+    const rMock = jest.spyOn(cli, 'rotate').mockImplementation(() => {});
 
     withFsMocks(paths, () => {
       jest.isolateModules(() => {
@@ -86,11 +90,15 @@ describe('update-memory', () => {
     });
 
     execMock.mockRestore();
+    uMock.mockRestore();
+    sMock.mockRestore();
+    rMock.mockRestore();
     const outTasks = fs.readFileSync(tasks, 'utf8');
 
     expect(outTasks).toContain('- [x] Task 1: test');
-    expect(calls.some((c) => c.includes('update-memory-log.ts'))).toBe(true);
-    expect(calls.some((c) => c.includes('mem-rotate.ts'))).toBe(true);
+    expect(uMock).toHaveBeenCalled();
+    expect(sMock).toHaveBeenCalled();
+    expect(rMock).toHaveBeenCalled();
     expect(calls.some((c) => c.includes('memory-check.ts'))).toBe(true);
 
     fs.rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- switch `update-memory.ts` to call `memory-cli` functions
- update unit test expectations for memory-cli integration

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm run test` *(fails to run all Jest suites)*
- `npm run backtest` *(fails due to loader ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_b_68489dc49c5c83238bbbf13de8487538