### PR TITLE
Task 113: organize archive & restore scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,10 +203,13 @@ npm run memory snapshot-rotate # prune context.snapshot.md
 
 ### Manual Archival
 
-Use this command to stash the current memory files before resetting them:
+Use the `memory archive` subcommand to stash the current memory files before
+resetting them. Restore later with `memory restore`:
 
 ```bash
-npm run archive-memory  # moves memory.log and snapshot to ./logs/archive/
+npm run memory archive                # moves memory.log and snapshot to ./logs/archive/
+npm run memory restore <file> memory  # restore memory.log from a backup
+npm run memory restore <file> snapshot # restore context.snapshot.md
 ```
 
 A weekly GitHub workflow automatically runs `npm run memory rotate` and `npm run memory clean-locks` to push the

--- a/TASKS.md
+++ b/TASKS.md
@@ -77,6 +77,7 @@ Each task below is prefixed with `Task <id>` and tracked directly in this file.
 - [ ] Task 110: investigate and fix broken post-commit hook
 - [ ] Task 111: remove obsolete docs from repo
 - [ ] Task 112: refactor memory-cli with native subcommands; port mem-rotate, memgrep, mem-diff, mem-status and update tests
+- [ ] Task 113: move archive & restore utilities into scripts/memory and document usage
 
 
 ### Bitcoin Dashboard

--- a/docs/SETUP_QUICKSTART.md
+++ b/docs/SETUP_QUICKSTART.md
@@ -6,7 +6,7 @@ Follow these steps to get the project running locally.
 2. Copy `.env.example` to `.env.local` and adjust settings as needed.
 3. Run `npm run lint && npm run test && npm run backtest` to verify the environment.
 4. Start the development server with `npm run dev`.
-5. Optionally run `npm run archive-memory` to back up memory logs.
+5. Optionally run `npm run memory archive` to back up memory logs.
 6. Use `npm run memory <command>` for log maintenance. For example `npm run memory rotate` trims `memory.log` and `npm run memory check` verifies consistency.
 
 Refer to `AGENTS.md` for automation details and `README.md` for full documentation.

--- a/logs/block-113.txt
+++ b/logs/block-113.txt
@@ -1,0 +1,128 @@
+
+> bitdash-firestudio@1.0.0 lint
+> ESLINT_USE_FLAT_CONFIG=false eslint -c .eslintrc.json "src/**/*.{ts,tsx,js,jsx}"
+
+
+/workspace/bitdashfirestudio/src/__tests__/autoTaskRunner.state.test.ts
+   80:11  error  'spawnMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+   81:11  error  'execMock' is assigned a value but never used    @typescript-eslint/no-unused-vars
+  111:11  error  'atomicMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  112:11  error  'lockMock' is assigned a value but never used    @typescript-eslint/no-unused-vars
+  114:11  error  'spawnMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  120:11  error  'execMock' is assigned a value but never used    @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/__tests__/memory-check.test.ts
+   46:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+   81:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  115:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  121:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  122:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  155:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  161:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  162:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  188:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  194:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  195:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  221:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  227:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  228:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  258:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  264:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  265:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  296:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  302:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  303:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  334:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  340:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  341:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/app/api/economic-events/route.ts
+  5:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/funding-schedule/route.ts
+  5:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/higher-candles/route.ts
+  9:19  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  9:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/open-interest/route.ts
+  5:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/prev-day/route.ts
+  19:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/page.tsx
+   45:15  error  'ComputedIndicators' is defined but never used  @typescript-eslint/no-unused-vars
+   46:15  error  'TradeSignal' is defined but never used         @typescript-eslint/no-unused-vars
+   73:25  error  '_t' is assigned a value but never used         @typescript-eslint/no-unused-vars
+   73:40  error  '_f' is assigned a value but never used         @typescript-eslint/no-unused-vars
+   73:49  error  '_s1' is assigned a value but never used        @typescript-eslint/no-unused-vars
+   73:59  error  '_s2' is assigned a value but never used        @typescript-eslint/no-unused-vars
+   73:69  error  '_d' is assigned a value but never used         @typescript-eslint/no-unused-vars
+   73:80  error  '_u' is assigned a value but never used         @typescript-eslint/no-unused-vars
+  279:41  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
+  280:41  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
+  652:11  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/agents/IndicatorEngine.ts
+  3:29  error  'IndicatorSet' is defined but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/lib/agents/TestingAgent.ts
+  16:10  error  '_msg' is defined but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/lib/agents/UIRenderer.ts
+  4:10  error  '_msg' is defined but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/lib/data/binanceCandles.ts
+  20:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/bybitOpenInterest.ts
+  11:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  13:37  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/coingecko.ts
+  20:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  36:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/economicEvents.ts
+   1:23  error  'FetchImportance' is defined but never used  @typescript-eslint/no-unused-vars
+  16:34  error  Unexpected any. Specify a different type     @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/fmp.ts
+  18:12  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  34:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  47:14  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  65:14  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/fundingSchedule.ts
+  11:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  13:37  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/fetchCache.ts
+  10:9  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/signals.ts
+  38:9  error  'now' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/scripts/autoTaskRunner.ts
+  34:10  error  Unexpected constant condition                    no-constant-condition
+  44:88  error  Unexpected any. Specify a different type         @typescript-eslint/no-explicit-any
+  63:5   error  Move function declaration to function body root  no-inner-declarations
+  86:5   error  Move function declaration to function body root  no-inner-declarations
+
+/workspace/bitdashfirestudio/src/types/agent.ts
+  1:35  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+✖ 69 problems (69 errors, 0 warnings)
+
+\n----TEST----\n
+
+> bitdash-firestudio@1.0.0 test
+> jest
+
+\n----BACKTEST----\n
+
+> bitdash-firestudio@1.0.0 backtest
+> node --loader ts-node/esm scripts/backtest.ts
+

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
 
     "mem-update": "node --loader ts-node/esm scripts/update-memory.ts",
     "memory": "ts-node scripts/memory-cli.ts",
-    "archive-memory": "ts-node scripts/archive-memory.ts",
+    "archive-memory": "ts-node scripts/memory/archive.ts",
+    "restore-memory": "ts-node scripts/memory/restore.ts",
 
     "clean-locks": "ts-node scripts/clean-locks.ts",
     "codex": "bash ./scripts/codex_context.sh",

--- a/scripts/memory/archive.ts
+++ b/scripts/memory/archive.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { repoRoot, memPath, snapshotPath, withFileLock } from './memory-utils';
+import { repoRoot, memPath, snapshotPath, withFileLock } from '../memory-utils';
 
 const archiveDir = path.join(repoRoot, 'logs', 'archive');
 fs.mkdirSync(archiveDir, { recursive: true });

--- a/scripts/memory/restore.ts
+++ b/scripts/memory/restore.ts
@@ -4,13 +4,13 @@ import {
   snapshotPath,
   atomicWrite,
   withFileLock,
-} from "./memory-utils";
+} from "../memory-utils";
 
 const [backup, target] = process.argv.slice(2);
 
 if (!backup || !target || (target !== "memory" && target !== "snapshot")) {
   console.error(
-    "Usage: ts-node scripts/restore-memory.ts <backup-file> <memory|snapshot>",
+    "Usage: ts-node scripts/memory/restore.ts <backup-file> <memory|snapshot>",
   );
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- move archive-memory and restore-memory under `scripts/memory`
- expose `archive` subcommand via memory CLI
- document new archive & restore usage
- update quickstart guide
- update npm script aliases

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars and others)*
- `npm run test` *(fails to redefine spawn/exec properties in tests)*
- `npm run backtest` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_b_6848a29615048323ae27859e98a8373f