### PR TITLE
Task 110: log mem-update errors

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,2 +1,10 @@
 #!/usr/bin/env bash
-npm run mem-update >/dev/null 2>&1
+set -e
+log_dir="logs"
+mkdir -p "$log_dir"
+log_file="$log_dir/post-commit-$(date -u +%Y%m%d%H%M%S).log"
+if ! npm run mem-update >"$log_file" 2>&1; then
+  echo "mem-update failed; see $log_file" >&2
+else
+  rm -f "$log_file"
+fi

--- a/scripts/memory-cli.ts
+++ b/scripts/memory-cli.ts
@@ -227,9 +227,13 @@ export function updateLog(verify = false): void {
     }
   }
   const logCmd = lastHash
-    ? `git log ${lastHash}..HEAD --reverse --pretty=format:%h|%s|%cI --name-only`
-    : 'git log --reverse --pretty=format:%h|%s|%cI --name-only';
-  const lines = execSync(logCmd, { cwd: repoRoot, encoding: 'utf8' })
+    ? `git log ${lastHash}..HEAD --reverse --pretty=format:%h\\|%s\\|%cI --name-only`
+    : 'git log --reverse --pretty=format:%h\\|%s\\|%cI --name-only';
+  const lines = execSync(logCmd, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    shell: '/bin/bash',
+  })
     .trim()
     .split('\n');
   let current: { h: string; s: string; d: string; f: string[] } | undefined;


### PR DESCRIPTION
## Summary
- capture post-commit mem-update output to logs
- fix memory-cli update-log shell quoting

## Testing
- `npm run lint` *(fails: no-unused-vars, unexpected any, etc.)*
- `npm run test` *(fails to redefine spawnSync & other errors)*

------
https://chatgpt.com/codex/tasks/task_b_68496fc1da488323b05298d286a3969d