### PR TITLE
Task 116: add archive & restore tests

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -80,6 +80,7 @@ Each task below is prefixed with `Task <id>` and tracked directly in this file.
 - [x] Task 113: move archive & restore utilities into scripts/memory and document usage
 - [x] Task 114: remove update-memory-log.ts & update-snapshot.ts; ensure memory-cli handles update-log & snapshot-update and migrate tests
 - [ ] Task 115: align rotate default with docs by keeping 300 lines
+- [ ] Task 116: test `memory archive` moves logs to archive and `memory restore` restores them
 
 
 ### Bitcoin Dashboard

--- a/logs/block-116-backtest.txt
+++ b/logs/block-116-backtest.txt
@@ -1,0 +1,4 @@
+
+> bitdash-firestudio@1.0.0 backtest
+> node --loader ts-node/esm scripts/backtest.ts
+

--- a/logs/block-116-lint.txt
+++ b/logs/block-116-lint.txt
@@ -1,0 +1,118 @@
+
+> bitdash-firestudio@1.0.0 lint
+> ESLINT_USE_FLAT_CONFIG=false eslint -c .eslintrc.json "src/**/*.{ts,tsx,js,jsx}"
+
+
+/workspace/bitdashfirestudio/src/__tests__/autoTaskRunner.state.test.ts
+   80:11  error  'spawnMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+   81:11  error  'execMock' is assigned a value but never used    @typescript-eslint/no-unused-vars
+  111:11  error  'atomicMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  112:11  error  'lockMock' is assigned a value but never used    @typescript-eslint/no-unused-vars
+  114:11  error  'spawnMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  120:11  error  'execMock' is assigned a value but never used    @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/__tests__/memory-check.test.ts
+   46:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+   81:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  115:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  121:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  122:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  155:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  161:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  162:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  188:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  194:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  195:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  221:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  227:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  228:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  258:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  264:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  265:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  296:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  302:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  303:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  334:11  error  'execMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+  340:11  error  'errMock' is assigned a value but never used   @typescript-eslint/no-unused-vars
+  341:11  error  'exitMock' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/app/api/economic-events/route.ts
+  5:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/funding-schedule/route.ts
+  5:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/higher-candles/route.ts
+  9:19  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  9:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/open-interest/route.ts
+  5:32  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/api/prev-day/route.ts
+  19:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/app/page.tsx
+   45:15  error  'ComputedIndicators' is defined but never used  @typescript-eslint/no-unused-vars
+   46:15  error  'TradeSignal' is defined but never used         @typescript-eslint/no-unused-vars
+   73:25  error  '_t' is assigned a value but never used         @typescript-eslint/no-unused-vars
+   73:40  error  '_f' is assigned a value but never used         @typescript-eslint/no-unused-vars
+   73:49  error  '_s1' is assigned a value but never used        @typescript-eslint/no-unused-vars
+   73:59  error  '_s2' is assigned a value but never used        @typescript-eslint/no-unused-vars
+   73:69  error  '_d' is assigned a value but never used         @typescript-eslint/no-unused-vars
+   73:80  error  '_u' is assigned a value but never used         @typescript-eslint/no-unused-vars
+  279:41  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
+  280:41  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
+  652:11  error  Unexpected any. Specify a different type        @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/agents/IndicatorEngine.ts
+  3:29  error  'IndicatorSet' is defined but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/lib/agents/TestingAgent.ts
+  16:10  error  '_msg' is defined but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/lib/agents/UIRenderer.ts
+  4:10  error  '_msg' is defined but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/lib/data/binanceCandles.ts
+  20:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/bybitOpenInterest.ts
+  11:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  13:37  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/coingecko.ts
+  20:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  36:34  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/economicEvents.ts
+   1:23  error  'FetchImportance' is defined but never used  @typescript-eslint/no-unused-vars
+  16:34  error  Unexpected any. Specify a different type     @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/fmp.ts
+  18:12  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  34:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  47:14  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  65:14  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/data/fundingSchedule.ts
+  11:36  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  13:37  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/fetchCache.ts
+  10:9  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+/workspace/bitdashfirestudio/src/lib/signals.ts
+  38:9  error  'now' is assigned a value but never used  @typescript-eslint/no-unused-vars
+
+/workspace/bitdashfirestudio/src/scripts/autoTaskRunner.ts
+  34:10  error  Unexpected constant condition                    no-constant-condition
+  44:88  error  Unexpected any. Specify a different type         @typescript-eslint/no-explicit-any
+  63:5   error  Move function declaration to function body root  no-inner-declarations
+  86:5   error  Move function declaration to function body root  no-inner-declarations
+
+/workspace/bitdashfirestudio/src/types/agent.ts
+  1:35  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+
+✖ 69 problems (69 errors, 0 warnings)
+

--- a/logs/block-116-test.txt
+++ b/logs/block-116-test.txt
@@ -1,0 +1,4 @@
+
+> bitdash-firestudio@1.0.0 test
+> jest
+

--- a/src/__tests__/archive-restore.test.ts
+++ b/src/__tests__/archive-restore.test.ts
@@ -1,0 +1,160 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+function withFsMocks(paths: Record<string, string>, fn: () => void) {
+  const expanded: Record<string, string> = {};
+  for (const [k, v] of Object.entries(paths)) {
+    expanded[k] = v;
+    const tmpK = path.join(path.dirname(k), `.${path.basename(k)}.tmp`);
+    const tmpV = path.join(path.dirname(v), `.${path.basename(v)}.tmp`);
+    expanded[tmpK] = tmpV;
+    expanded[`${k}.lock`] = `${v}.lock`;
+  }
+
+  const origExists = fs.existsSync;
+  const origRead = fs.readFileSync;
+  const origWrite = fs.writeFileSync;
+  const origRename = fs.renameSync;
+  const origOpen = fs.openSync;
+  const origClose = fs.closeSync;
+  const origUnlink = fs.unlinkSync;
+  const existsMock = jest
+    .spyOn(fs, 'existsSync')
+    .mockImplementation((p: any) => {
+      if (expanded[p as string]) {
+        return origExists.call(fs, expanded[p as string]);
+      }
+      return origExists.call(fs, p);
+    });
+  const readMock = jest
+    .spyOn(fs, 'readFileSync')
+    .mockImplementation((p: any, opt?: any) => {
+      if (expanded[p as string]) {
+        p = expanded[p as string];
+      }
+      return origRead.call(fs, p, opt);
+    });
+  const writeMock = jest
+    .spyOn(fs, 'writeFileSync')
+    .mockImplementation((p: any, data: any, opt?: any) => {
+      if (expanded[p as string]) {
+        p = expanded[p as string];
+      }
+      return origWrite.call(fs, p, data, opt as any);
+    });
+  const renameMock = jest
+    .spyOn(fs, 'renameSync')
+    .mockImplementation((a: any, b: any) => {
+      if (expanded[a as string]) a = expanded[a as string];
+      if (expanded[b as string]) b = expanded[b as string];
+      return origRename.call(fs, a, b);
+    });
+  const openMock = jest
+    .spyOn(fs, 'openSync')
+    .mockImplementation((p: any, flag: any) => {
+      if (expanded[p as string]) p = expanded[p as string];
+      return origOpen.call(fs, p, flag);
+    });
+  const closeMock = jest
+    .spyOn(fs, 'closeSync')
+    .mockImplementation((fd: any) => origClose.call(fs, fd));
+  const unlinkMock = jest
+    .spyOn(fs, 'unlinkSync')
+    .mockImplementation((p: any) => {
+      if (expanded[p as string]) p = expanded[p as string];
+      return origUnlink.call(fs, p);
+    });
+  try {
+    fn();
+  } finally {
+    existsMock.mockRestore();
+    readMock.mockRestore();
+    writeMock.mockRestore();
+    renameMock.mockRestore();
+    openMock.mockRestore();
+    closeMock.mockRestore();
+    unlinkMock.mockRestore();
+  }
+}
+
+const iso = '2025-01-01T00:00:00.000Z';
+
+describe('memory archive and restore', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete process.env.MEM_PATH;
+    delete process.env.SNAPSHOT_PATH;
+  });
+
+  it('archives memory.log and snapshot to logs/archive', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'memarc-'));
+    const archiveDir = path.join(dir, 'archive');
+    fs.mkdirSync(archiveDir);
+    const mem = path.join(dir, 'memory.log');
+    const snap = path.join(dir, 'context.snapshot.md');
+    fs.writeFileSync(mem, 'mem');
+    fs.writeFileSync(snap, 'snap');
+
+    process.env.MEM_PATH = mem;
+    process.env.SNAPSHOT_PATH = snap;
+
+    jest.useFakeTimers().setSystemTime(new Date(iso));
+    jest.isolateModules(() => {
+      const utils = require('../../scripts/memory-utils');
+      const { archiveFiles } = require('../../scripts/memory-cli');
+      const ts = new Date().toISOString().replace(/[:]/g, '-');
+      const map = {
+        [utils.memPath]: mem,
+        [utils.snapshotPath]: snap,
+        [path.join(utils.repoRoot, 'logs', 'archive')]: archiveDir,
+        [path.join(utils.repoRoot, 'logs', 'archive', `memory.log.${ts}`)]:
+          path.join(archiveDir, `memory.log.${ts}`),
+        [path.join(utils.repoRoot, 'logs', 'archive', `context.snapshot.md.${ts}`)]:
+          path.join(archiveDir, `context.snapshot.md.${ts}`),
+      } as Record<string, string>;
+      withFsMocks(map, () => {
+        archiveFiles();
+      });
+    });
+    jest.useRealTimers();
+
+    const tsFile = iso.replace(/[:]/g, '-');
+    const memDest = path.join(archiveDir, `memory.log.${tsFile}`);
+    const snapDest = path.join(archiveDir, `context.snapshot.md.${tsFile}`);
+    expect(fs.existsSync(memDest)).toBe(true);
+    expect(fs.existsSync(snapDest)).toBe(true);
+    expect(fs.readFileSync(memDest, 'utf8')).toBe('mem');
+    expect(fs.readFileSync(snapDest, 'utf8')).toBe('snap');
+    expect(fs.existsSync(mem)).toBe(false);
+    expect(fs.existsSync(snap)).toBe(false);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('restores files from backup', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'memres-'));
+    const mem = path.join(dir, 'memory.log');
+    const snap = path.join(dir, 'context.snapshot.md');
+    const memBak = path.join(dir, 'm.log');
+    const snapBak = path.join(dir, 's.md');
+    fs.writeFileSync(memBak, 'mem');
+    fs.writeFileSync(snapBak, 'snap');
+
+    process.env.MEM_PATH = mem;
+    process.env.SNAPSHOT_PATH = snap;
+
+    jest.isolateModules(() => {
+      const utils = require('../../scripts/memory-utils');
+      const { restoreMemory } = require('../../scripts/memory-cli');
+      const map = { [utils.memPath]: mem, [utils.snapshotPath]: snap } as Record<string, string>;
+      withFsMocks(map, () => {
+        restoreMemory(memBak, 'memory');
+        restoreMemory(snapBak, 'snapshot');
+      });
+    });
+
+    expect(fs.readFileSync(mem, 'utf8')).toBe('mem');
+    expect(fs.readFileSync(snap, 'utf8')).toBe('snap');
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests covering `memory archive` and `memory restore`
- capture failing lint/test/backtest logs
- document new task for archive/restore tests

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars, Unexpected any, etc.)*
- `npm run test` *(fails to execute multiple suites)*
- `npm run backtest` *(fails due to ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_b_684982f0da6c8323969a72a27b064275