### PR TITLE
Task 116: add archive and restore commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Task 95: create memory CLI with rotate, snapshot-rotate, status, grep, update-lo
 | Command | Purpose |
 | ------- | ------- |
 | `npm run auto` | Execute the AutoTaskRunner to process tasks in `TASKS.md`; installs dependencies once then validates memory after each commit |
-| `npm run memory` | Consolidated memory CLI with subcommands like `rotate`, `check`, `diff`, `grep`, `status`, `list` and `clean-locks` |
+| `npm run memory` | Consolidated memory CLI with subcommands like `rotate`, `archive`, `restore`, `update-log` and `check` |
 | `node --loader ts-node/esm scripts/update-memory.ts` | Update `memory.log`, `context.snapshot.md`, rotate the log and validate memory |
 | `ts-node scripts/rebuild-memory.ts [path]` | Rebuild `memory.log` and `context.snapshot.md` from git history |
 | `ts-node scripts/memory-json.ts` | Export `memory.log` lines to `memory.json` |

--- a/docs/SETUP_QUICKSTART.md
+++ b/docs/SETUP_QUICKSTART.md
@@ -6,7 +6,7 @@ Follow these steps to get the project running locally.
 2. Copy `.env.example` to `.env.local` and adjust settings as needed.
 3. Run `npm run lint && npm run test && npm run backtest` to verify the environment.
 4. Start the development server with `npm run dev`.
-5. Optionally run `npm run memory archive` to back up memory logs.
+5. Optionally run `npm run memory archive` to back up memory logs. Use `npm run memory restore <file> <memory|snapshot>` to recover from an archive.
 6. Use `npm run memory <command>` for log maintenance. For example `npm run memory rotate` trims `memory.log` and `npm run memory check` verifies consistency.
 
 Refer to `AGENTS.md` for automation details and `README.md` for full documentation.

--- a/scripts/memory-cli.ts
+++ b/scripts/memory-cli.ts
@@ -8,20 +8,29 @@ import {
   rebuildMemory,
   rotate,
 } from './memory-logic.ts';
+import { archive } from './memory/archive.ts';
+import { restore } from './memory/restore.ts';
 
 // Re-export functions for direct use, if needed elsewhere.
 export * from './memory-logic';
 
-function main(argv = hideBin(process.argv)): void {
+export function main(argv = hideBin(process.argv)): void {
   yargs(argv)
     .scriptName('memory')
     .command('rotate [limit]', 'Trim memory.log', (y) =>
       y.positional('limit', { type: 'number' }).option('dry-run', { type: 'boolean' }),
       (args) => rotate(args.limit as number | undefined, args.dryRun as boolean)
     )
+    .command('archive', 'Move memory.log and snapshot to logs/archive', () => {}, () => archive())
     .command('update-log', 'Refresh memory.log from git history', (y) => y.option('verify', { type: 'boolean' }), (a) => updateLog(a.verify as boolean))
     .command('snapshot-update', 'Append last commit summary to snapshot', () => {}, () => snapshotUpdate())
     .command('rebuild [path]', 'Rebuild memory files from git history', (y) => y.positional('path', { type: 'string' }), (a) => rebuildMemory(a.path as string | undefined))
+    .command('restore <backup> <target>', 'Restore memory or snapshot file', (y) =>
+      y
+        .positional('backup', { type: 'string' })
+        .positional('target', { choices: ['memory', 'snapshot'] as const }),
+      (a) => restore(a.backup as string, a.target as 'memory' | 'snapshot')
+    )
     .command('check', 'Verify memory files', () => {}, () => {
         const errors = checkMemory();
         if (errors.length) {

--- a/scripts/memory/archive.ts
+++ b/scripts/memory/archive.ts
@@ -2,21 +2,27 @@ import fs from 'fs';
 import path from 'path';
 import { repoRoot, memPath, snapshotPath, withFileLock } from '../memory-utils';
 
-const archiveDir = path.join(repoRoot, 'logs', 'archive');
-fs.mkdirSync(archiveDir, { recursive: true });
-const ts = new Date().toISOString().replace(/[:]/g, '-');
+export function archive(): void {
+  const archiveDir = path.join(repoRoot, 'logs', 'archive');
+  fs.mkdirSync(archiveDir, { recursive: true });
+  const ts = new Date().toISOString().replace(/[:]/g, '-');
 
-function move(src: string, name: string) {
-  if (!fs.existsSync(src)) {
-    console.log(`${name} not found`);
-    return;
+  function move(src: string, name: string) {
+    if (!fs.existsSync(src)) {
+      console.log(`${name} not found`);
+      return;
+    }
+    const dest = path.join(archiveDir, `${name}.${ts}`);
+    withFileLock(src, () => {
+      fs.renameSync(src, dest);
+    });
+    console.log(`Archived ${name} to ${dest}`);
   }
-  const dest = path.join(archiveDir, `${name}.${ts}`);
-  withFileLock(src, () => {
-    fs.renameSync(src, dest);
-  });
-  console.log(`Archived ${name} to ${dest}`);
+
+  move(memPath, 'memory.log');
+  move(snapshotPath, 'context.snapshot.md');
 }
 
-move(memPath, 'memory.log');
-move(snapshotPath, 'context.snapshot.md');
+if (require.main === module) {
+  archive();
+}

--- a/scripts/memory/restore.ts
+++ b/scripts/memory/restore.ts
@@ -1,29 +1,33 @@
-import fs from "fs";
+import fs from 'fs';
 import {
   memPath,
   snapshotPath,
   atomicWrite,
   withFileLock,
-} from "../memory-utils";
+} from '../memory-utils';
 
-const [backup, target] = process.argv.slice(2);
+export function restore(backup: string, target: 'memory' | 'snapshot'): void {
+  if (!fs.existsSync(backup)) {
+    console.error(`Backup file not found: ${backup}`);
+    process.exit(1);
+  }
 
-if (!backup || !target || (target !== "memory" && target !== "snapshot")) {
-  console.error(
-    "Usage: ts-node scripts/memory/restore.ts <backup-file> <memory|snapshot>",
-  );
-  process.exit(1);
+  const dest = target === 'memory' ? memPath : snapshotPath;
+  const data = fs.readFileSync(backup, 'utf8');
+
+  withFileLock(dest, () => {
+    atomicWrite(dest, data);
+  });
+  console.log(`${dest} restored from ${backup}`);
 }
 
-if (!fs.existsSync(backup)) {
-  console.error(`Backup file not found: ${backup}`);
-  process.exit(1);
+if (require.main === module) {
+  const [b, t] = process.argv.slice(2);
+  if (!b || !t || (t !== 'memory' && t !== 'snapshot')) {
+    console.error(
+      'Usage: ts-node scripts/memory/restore.ts <backup-file> <memory|snapshot>',
+    );
+    process.exit(1);
+  }
+  restore(b, t as 'memory' | 'snapshot');
 }
-
-const dest = target === "memory" ? memPath : snapshotPath;
-const data = fs.readFileSync(backup, "utf8");
-
-withFileLock(dest, () => {
-  atomicWrite(dest, data);
-});
-console.log(`${dest} restored from ${backup}`);

--- a/src/__tests__/memory-cli.test.ts
+++ b/src/__tests__/memory-cli.test.ts
@@ -1,0 +1,17 @@
+import { main } from '../../scripts/memory-cli.ts'
+
+describe('memory-cli', () => {
+  it('lists archive and restore commands in help output', () => {
+    const logs: string[] = []
+    const origLog = console.log
+    const origExit = process.exit
+    ;(process.exit as any) = jest.fn()
+    console.log = (msg?: any) => { logs.push(String(msg)) }
+    main(['--help'])
+    ;(process.exit as any) = origExit
+    console.log = origLog
+    const out = logs.join('\n')
+    expect(out).toContain('archive')
+    expect(out).toContain('restore <backup> <target>')
+  })
+})


### PR DESCRIPTION
## Summary
- add `archive` and `restore` subcommands to `memory-cli`
- expose new helpers in `scripts/memory`
- document archive/restore usage in README and SETUP_QUICKSTART
- add unit test for memory-cli help output

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest` *(fails: Cannot find module '/workspace/bitdashfirestudio/src/scripts/backtest' imported from /workspace/bitdashfirestudio/scripts/backtest.ts)*

------
https://chatgpt.com/codex/tasks/task_b_684a06f1ae8883238915f6f5831dee17