### PR TITLE
Task 116: add archive/restore CLI test

### DIFF
--- a/logs/block-116-backtest.txt
+++ b/logs/block-116-backtest.txt
@@ -1,4 +1,19 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
 
 > bitdash-firestudio@1.0.0 backtest
 > node --loader ts-node/esm scripts/backtest.ts
 
+(node:3521) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:
+--import 'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; register("ts-node/esm", pathToFileURL("./"));'
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:3521) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
+(Use `node --trace-deprecation ...` to show where the warning was created)
+
+node:internal/modules/run_main:123
+    triggerUncaughtException(
+    ^
+[Object: null prototype] {
+  [Symbol(nodejs.util.inspect.custom)]: [Function: [nodejs.util.inspect.custom]]
+}
+
+Node.js v22.16.0

--- a/logs/block-116-lint.txt
+++ b/logs/block-116-lint.txt
@@ -1,3 +1,4 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
 
 > bitdash-firestudio@1.0.0 lint
 > ESLINT_USE_FLAT_CONFIG=false eslint -c .eslintrc.json "src/**/*.{ts,tsx,js,jsx}"

--- a/logs/block-116-test.txt
+++ b/logs/block-116-test.txt
@@ -1,4 +1,39 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
 
 > bitdash-firestudio@1.0.0 test
 > jest
 
+PASS src/__tests__/indicators.test.ts
+PASS src/__tests__/memory-cli.test.ts
+  ● Console
+
+    console.log
+      Archived memory.log to /tmp/mem-test-iortJs/logs/archive/memory.log.2025-06-12T00-15-11.741Z
+
+      at move (scripts/memory/archive.ts:19:13)
+
+    console.log
+      Archived context.snapshot.md to /tmp/mem-test-iortJs/logs/archive/context.snapshot.md.2025-06-12T00-15-11.741Z
+
+      at move (scripts/memory/archive.ts:19:13)
+
+    console.log
+      /tmp/mem-test-iortJs/memory.log restored from /tmp/mem-test-iortJs/logs/archive/memory.log.2025-06-12T00-15-11.741Z
+
+      at restore (scripts/memory/restore.ts:21:11)
+
+    console.log
+      /tmp/mem-test-iortJs/context.snapshot.md restored from /tmp/mem-test-iortJs/logs/archive/context.snapshot.md.2025-06-12T00-15-11.741Z
+
+      at restore (scripts/memory/restore.ts:21:11)
+
+PASS src/__tests__/sessions.test.ts
+PASS src/__tests__/cache.test.ts
+PASS src/__tests__/codex-context.test.ts
+PASS src/__tests__/correlation.test.ts
+
+Test Suites: 6 passed, 6 total
+Tests:       20 passed, 20 total
+Snapshots:   0 total
+Time:        0.997 s, estimated 2 s
+Ran all test suites.

--- a/src/__tests__/memory-cli.test.ts
+++ b/src/__tests__/memory-cli.test.ts
@@ -1,3 +1,6 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
 import { main } from '../../scripts/memory-cli.ts'
 
 describe('memory-cli', () => {
@@ -13,5 +16,52 @@ describe('memory-cli', () => {
     const out = logs.join('\n')
     expect(out).toContain('archive')
     expect(out).toContain('restore <backup> <target>')
+  })
+
+  it('archives and restores memory files', () => {
+    const origCwd = process.cwd()
+    const origMem = process.env.MEM_PATH
+    const origSnap = process.env.SNAPSHOT_PATH
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'mem-test-'))
+    const mem = path.join(tmp, 'memory.log')
+    const snap = path.join(tmp, 'context.snapshot.md')
+    fs.writeFileSync(mem, 'm')
+    fs.writeFileSync(snap, 's')
+    process.chdir(tmp)
+    process.env.MEM_PATH = mem
+    process.env.SNAPSHOT_PATH = snap
+
+    jest.isolateModules(() => {
+      const { main } = require('../../scripts/memory-cli.ts')
+      main(['archive'])
+    })
+
+    const archiveDir = path.join(tmp, 'logs', 'archive')
+    const files = fs.readdirSync(archiveDir)
+    const memBak = files.find((f) => f.startsWith('memory.log.')) as string
+    const snapBak = files.find((f) => f.startsWith('context.snapshot.md.')) as string
+    expect(memBak).toBeDefined()
+    expect(snapBak).toBeDefined()
+    expect(fs.existsSync(mem)).toBe(false)
+    expect(fs.existsSync(snap)).toBe(false)
+
+    jest.isolateModules(() => {
+      const { main } = require('../../scripts/memory-cli.ts')
+      main(['restore', path.join(archiveDir, memBak), 'memory'])
+    })
+    jest.isolateModules(() => {
+      const { main } = require('../../scripts/memory-cli.ts')
+      main(['restore', path.join(archiveDir, snapBak), 'snapshot'])
+    })
+
+    expect(fs.readFileSync(mem, 'utf8')).toBe('m')
+    expect(fs.readFileSync(snap, 'utf8')).toBe('s')
+
+    process.chdir(origCwd)
+    if (origMem) process.env.MEM_PATH = origMem
+    else delete process.env.MEM_PATH
+    if (origSnap) process.env.SNAPSHOT_PATH = origSnap
+    else delete process.env.SNAPSHOT_PATH
+    fs.rmSync(tmp, { recursive: true, force: true })
   })
 })


### PR DESCRIPTION
## Summary
- cover new memory archive/restore commands via CLI
- save lint/test/backtest logs

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest` *(fails: Error [ERR_MODULE_NOT_FOUND])*

------
https://chatgpt.com/codex/tasks/task_b_684a015f3bd48323b987fd68a7f3d983