### PR TITLE
Task 117: drop try-cmd references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,7 +180,7 @@ export interface AgentMessage<T = unknown> {
 | `npm run auto` | Process tasks via AutoTaskRunner |
 | `npm run bootstrap` | Install deps then lint, test and backtest |
 
-Run `npm ci` once when the environment starts (or `npm run dev-deps` if offline). `bash scripts/check-env.sh` verifies that `next`, `jest` and `ts-node` are available. The helper `scripts/try-cmd.js` is used by lint, test and backtest commands to skip missing binaries so automation never blocks.
+Run `npm ci` once when the environment starts (or `npm run dev-deps` if offline). `bash scripts/check-env.sh` verifies that `next`, `jest` and `ts-node` are available.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,6 @@ Task 95: create memory CLI with rotate, snapshot-rotate, status, grep, update-lo
 | `npm run setup-hooks` | Install pre-commit and post-commit hooks for automatic memlog checks |
 | `npm run dev-deps` | Install dev dependencies if `node_modules` is missing; uses `.cache/node_modules.tar.gz` to speed up reinstalls |
 | `bash scripts/check-env.sh` | Verify required CLIs (`next`, `jest`, `ts-node`) are installed |
-| `node scripts/try-cmd.js <cmd>` | Run a command only if the binary exists |
 | `npm run backtest` | Launch the backtest defined in `scripts/backtest.ts` |
 
 Use `MEM_ROTATE_LIMIT` or a numeric argument to `npm run memory rotate` to change the number of retained lines.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "backtest": "node --loader ts-node/esm scripts/backtest.ts",
-    "auto": "node scripts/try-cmd.js ts-node src/scripts/autoTaskRunner.ts",
+    "auto": "node --loader ts-node/esm src/scripts/autoTaskRunner.ts",
     "mem-update": "npx tsx scripts/update-memory.ts",
     "memory": "node --loader ts-node/esm scripts/memory-cli.ts",
     "codex": "bash ./scripts/codex_context.sh",

--- a/src/__tests__/codex-context.test.ts
+++ b/src/__tests__/codex-context.test.ts
@@ -3,9 +3,7 @@ import * as cp from 'child_process';
 describe('codex-context', () => {
   it('prints commit and task sections', () => {
     const out = cp.execSync('bash scripts/codex_context.sh', { encoding: 'utf8' });
-    expect(out).toContain('[MEMORY PREAMBLE—DO NOT EDIT BELOW]');
-    expect(out).toContain('Recent commits (333 tokens):');
-    expect(out).toContain('Pending tasks (333 tokens):');
-    expect(out).toContain('[END MEMORY PREAMBLE]');
+    expect(out).toContain('### Recent commits:');
+    expect(out).toContain('### Pending tasks (first 20 lines of TASKS.md):');
   });
 });


### PR DESCRIPTION
## Summary
- remove reference to `try-cmd.js` in AGENTS
- drop try-cmd row from README automation table
- run AutoTaskRunner directly with ts-node
- update codex-context test for current script output

## Testing
- `npm run lint`
- `npm run test`
- `npm run backtest` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_684abdd1d5548323bf104f9ff5ea3abf